### PR TITLE
fix: preserve owner references during resource updates

### DIFF
--- a/pkg/controller/instance/controller_reconcile.go
+++ b/pkg/controller/instance/controller_reconcile.go
@@ -273,6 +273,8 @@ func (igr *instanceGraphReconciler) updateResource(
 	// TODO: Handle annotations
 	desired.SetResourceVersion(observed.GetResourceVersion())
 	desired.SetFinalizers(observed.GetFinalizers())
+	desired.SetOwnerReferences(observed.GetOwnerReferences())
+
 	_, err = rc.Update(ctx, desired, metav1.UpdateOptions{})
 	if err != nil {
 		resourceState.State = "ERROR"


### PR DESCRIPTION
During resource updates, we now maintain owner references on resources managed by
the controller, similar to how we already preserve finalizers. This ensures that
existing ownership relationships are not disrupted during reconciliation. Added
integration tests to verify both finalizers and owner references are preserved
when resources are updated.