### PR TITLE
Add support for explicit dependencies with `dependsOn` field

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -94,6 +94,9 @@ type Resource struct {
 	ReadyWhen []string `json:"readyWhen,omitempty"`
 	// +kubebuilder:validation:Optional
 	IncludeWhen []string `json:"includeWhen,omitempty"`
+	// +kubebuilder:validation:Optional
+	// DependsOn defines explicit dependencies on other resources
+	DependsOn []string `json:"dependsOn,omitempty"`
 }
 
 // ResourceGraphDefinitionState defines the state of the resource graph definition.

--- a/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
+++ b/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
@@ -73,6 +73,12 @@ spec:
                 description: The resources that are part of the resourcegraphdefinition.
                 items:
                   properties:
+                    dependsOn:
+                      description: DependsOn defines explicit dependencies on other
+                        resources
+                      items:
+                        type: string
+                      type: array
                     id:
                       type: string
                     includeWhen:
@@ -167,7 +173,7 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
+                      description: A human-readable message indicating details about
                         the transition.
                       type: string
                     observedGeneration:

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -73,6 +73,12 @@ spec:
                 description: The resources that are part of the resourcegraphdefinition.
                 items:
                   properties:
+                    dependsOn:
+                      description: DependsOn defines explicit dependencies on other
+                        resources
+                      items:
+                        type: string
+                      type: array
                     id:
                       type: string
                     includeWhen:
@@ -167,7 +173,7 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
+                      description: A human-readable message indicating details about
                         the transition.
                       type: string
                     observedGeneration:


### PR DESCRIPTION
Closes https://github.com/kro-run/kro/issues/110
Implements support for explicit dependencies between resources in a ResourceGraphDefinition using the dependsOn field. 

- Added support for the dependsOn field in the Resource struct
- Modified the dependency graph building logic to process explicit dependencies first
- Added validation to ensure referenced resources exist
- Ensured cycle detection works for both explicit and implicit dependencies
- Added unit tests