### PR TITLE
#70 Support ArgoCD Resource tracking

### DIFF
--- a/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
+++ b/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
@@ -167,7 +167,7 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
+                      description: A human-readable message indicating details about
                         the transition.
                       type: string
                     observedGeneration:

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -167,7 +167,7 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
+                      description: A human-readable message indicating details about
                         the transition.
                       type: string
                     observedGeneration:

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -159,6 +159,12 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) error {
 		reconcileConfig:             c.reconcileConfig,
 		// Fresh instance state at each reconciliation loop.
 		state: newInstanceState(),
+		OwnerReference: metav1.OwnerReference{
+			APIVersion: instance.GetAPIVersion(),
+			Kind:       instance.GetKind(),
+			Name:       instance.GetName(),
+			UID:        instance.GetUID(),
+		},
 	}
 	return instanceGraphReconciler.reconcile(ctx)
 }

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -24,6 +24,7 @@ import (
 const (
 	// LabelKROPrefix is the label key prefix used to identify KRO owned resources.
 	LabelKROPrefix = v1alpha1.KRODomainName + "/"
+	K8sAppPrefix   = "app.kubernetes.io/"
 )
 
 const (
@@ -40,6 +41,8 @@ const (
 	ResourceGraphDefinitionNameLabel      = LabelKROPrefix + "resource-graph-definition-name"
 	ResourceGraphDefinitionNamespaceLabel = LabelKROPrefix + "resource-graph-definition-namespace"
 	ResourceGraphDefinitionVersionLabel   = LabelKROPrefix + "resource-graph-definition-version"
+
+	K8sAppInstanceLabel = K8sAppPrefix + "instance"
 )
 
 // IsKROOwned returns true if the resource is owned by KRO.
@@ -119,16 +122,25 @@ func NewResourceGraphDefinitionLabeler(rgMeta metav1.Object) GenericLabeler {
 	}
 }
 
-// NewInstanceLabeler returns a new labeler that sets the InstanceLabel and
+// NewInstanceLabeler returns a new labeler that sets the K8sComponentId, InstanceLabel and
 // InstanceIDLabel labels on a resource. The InstanceLabel is the namespace
 // and name of the instance that was reconciled to create the resource.
+// The K8s Component Id gets propagated from the given given and only set when
+// available on it.
 func NewInstanceLabeler(instanceMeta metav1.Object) GenericLabeler {
-	return map[string]string{
+	retVal := map[string]string{
 		InstanceIDLabel:        string(instanceMeta.GetUID()),
 		InstanceLabel:          instanceMeta.GetName(),
 		InstanceNamespaceLabel: instanceMeta.GetNamespace(),
 	}
+
+	appInstance, exists := instanceMeta.GetLabels()[K8sAppInstanceLabel]
+	if exists {
+		retVal[K8sAppInstanceLabel] = appInstance
+	}
+	return retVal
 }
+
 
 // NewKROMetaLabeler returns a new labeler that sets the OwnedLabel and
 // KROVersion labels on a resource.

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -88,7 +88,6 @@ func TestSetKROOwned(t *testing.T) {
 		})
 	}
 }
-
 func TestSetKROUnowned(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -177,6 +176,35 @@ func TestGenericLabeler(t *testing.T) {
 					assert.NoError(t, err)
 					assert.Equal(t, tc.expectedMerged, merged)
 				}
+			})
+		}
+	})
+
+	t.Run("FactoryFunction", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			given    metav1.ObjectMeta
+			expected map[string]string
+		}{
+			{
+				name:     "Create without K8s App Instance Label",
+				given:    metav1.ObjectMeta{UID: "123", Name: "Name", Namespace: "Namespace"},
+				expected: map[string]string{InstanceIDLabel: "123", InstanceLabel: "Name", InstanceNamespaceLabel: "Namespace"},
+			},
+			{
+				name:     "Create include K8s App Instance Label",
+				given:    metav1.ObjectMeta{UID: "123", Name: "Name", Namespace: "Namespace", Labels: map[string]string{K8sAppInstanceLabel: "someApp"}},
+				expected: map[string]string{InstanceIDLabel: "123", InstanceLabel: "Name", InstanceNamespaceLabel: "Namespace", K8sAppInstanceLabel: "someApp"},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+
+				obj := &mockObject{ObjectMeta: tc.given}
+				labeler := NewInstanceLabeler(obj)
+				labeler.ApplyLabels(obj)
+				assert.Equal(t, tc.expected, obj.Labels)
 			})
 		}
 	})

--- a/test/integration/suites/core/argocd_integration_test.go
+++ b/test/integration/suites/core/argocd_integration_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/kro-run/kro/pkg/metadata"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kro-run/kro/api/v1alpha1"
+	"github.com/kro-run/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("ArgoCD", func() {
+	var (
+		ctx       context.Context
+		namespace string
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		// Create namespace
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	It("should have correct label and ownership propagation", func() {
+		rgd := generator.NewResourceGraphDefinition("argo-label-test",
+			generator.WithSchema(
+				"TestStatus", "v1alpha1",
+				map[string]interface{}{
+					"field1": "string",
+				},
+				nil,
+			),
+			generator.WithResource("res1", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "${schema.spec.field1}",
+					"namespace": namespace,
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+		// Verify ResourceGraphDefinition status
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name: rgd.Name,
+			}, rgd)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Check conditions
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+
+		}, 10*time.Second, time.Second).Should(Succeed())
+
+		simpleInstance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"kind":       "TestStatus",
+				"metadata": map[string]interface{}{
+					"name":      "sample-instance",
+					"namespace": namespace,
+					"labels": map[string]interface{}{
+						metadata.K8sAppInstanceLabel: "ArgoTestApp",
+					},
+				},
+				"spec": map[string]interface{}{
+					"field1": "sample-instance-map",
+				},
+			},
+		}
+
+		Expect(env.Client.Create(ctx, simpleInstance)).To(Succeed())
+
+		// Verify ResourceGraphDefinition status
+		Eventually(func(g Gomega) {
+			err := env.Client.Get(ctx, types.NamespacedName{Namespace: namespace,
+				Name: simpleInstance.GetName(),
+			}, simpleInstance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+		}, 10*time.Second, time.Second).Should(Succeed())
+
+		// verify ConfigMap including OwnerReference
+		Eventually(func(g Gomega) {
+
+			configMap := corev1.ConfigMap{}
+
+			err := env.Client.Get(ctx, types.NamespacedName{Namespace: namespace,
+				Name: "sample-instance-map",
+			}, &configMap)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(configMap.Labels).To(HaveKeyWithValue(metadata.K8sAppInstanceLabel, "ArgoTestApp"))
+			g.Expect(configMap.OwnerReferences).To(HaveLen(1))
+
+			ownerRef := configMap.OwnerReferences[0]
+			g.Expect(ownerRef.Name).To(Equal("sample-instance"))
+			g.Expect(ownerRef.Kind).To(Equal("TestStatus"))
+
+		}, 10*time.Second, time.Second).Should(Succeed())
+
+	})
+})


### PR DESCRIPTION
This PR enables Tracking of child resources of a Kro created Resource (#70)

* Implemented propagation of app.kubernetes.io/appinstance label
* implemented propagation of OnwerReferences 

This PR supports the Resources Tracking of ArgoCD via Labels and Annoations 