### PR TITLE
fix: Support referencing metadata fields in RGD. #377

### DIFF
--- a/examples/kubernetes/test-metadata.yaml
+++ b/examples/kubernetes/test-metadata.yaml
@@ -1,0 +1,26 @@
+// This file will be moved to examples/kubernetes/test-metadata.yaml
+
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: using-metadata
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: UsingMetadata
+    spec:
+      data:
+        foo: string
+        bar: integer
+    status:
+      created: ${configmap.metadata.creationTimestamp}
+  resources:
+    - id: configmap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${instance.metadata.name + "-cm"}
+        data:
+          foo: ${schema.spec.data.foo}
+          bar: ${string(schema.spec.data.bar)} 

--- a/examples/test-metadata.yaml
+++ b/examples/test-metadata.yaml
@@ -1,0 +1,24 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: using-metadata
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: UsingMetadata
+    spec:
+      data:
+        foo: string
+        bar: integer
+    status:
+      created: ${configmap.metadata.creationTimestamp}
+  resources:
+    - id: configmap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${instance.metadata.name + "-cm"}
+        data:
+          foo: ${schema.spec.data.foo}
+          bar: ${string(schema.spec.data.bar)} 

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -46,6 +46,16 @@ func WithCustomDeclarations(declarations []cel.EnvOption) EnvOption {
 	}
 }
 
+// WithMetadataSupport adds support for metadata field access in CEL expressions
+func WithMetadataSupport() EnvOption {
+	return func(opts *envOptions) {
+		// Add metadata type declarations
+		opts.customDeclarations = append(opts.customDeclarations,
+			cel.Variable("metadata", cel.AnyType),
+		)
+	}
+}
+
 // DefaultEnvironment returns the default CEL environment.
 func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 	opts := &envOptions{}
@@ -57,10 +67,14 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 		// default stdlibs
 		ext.Lists(),
 		ext.Strings(),
+		// Always enable metadata support by default
+		cel.Variable("metadata", cel.AnyType),
 	}
 
 	for _, name := range opts.resourceIDs {
 		declarations = append(declarations, cel.Variable(name, cel.AnyType))
 	}
+
+	declarations = append(declarations, opts.customDeclarations...)
 	return cel.NewEnv(declarations...)
 }

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -130,6 +130,15 @@ func (r *ResourceGraphDefinitionReconciler) setResourceGraphDefinitionStatus(
 		dc.Status.TopologicalOrder = topologicalOrder
 		dc.Status.Resources = resources
 
+		// Ensure metadata fields are included in the status update
+		metadata := resourcegraphdefinition.Object["metadata"].(map[string]interface{})
+		if metadata != nil {
+			dc.Status.Resources = append(dc.Status.Resources, v1alpha1.ResourceInformation{
+				ID: "metadata",
+				Dependencies: []v1alpha1.Dependency{},
+			})
+		}
+
 		log.V(1).Info("updating resource graph definition status",
 			"state", dc.Status.State,
 			"conditions", len(dc.Status.Conditions),

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -292,12 +292,22 @@ func (b *Builder) buildRGResource(rgResource *v1alpha1.Resource, namespacedResou
 			return nil, fmt.Errorf("failed, CEL expressions are not supported for CRDs, resource %s", rgResource.ID)
 		}
 	} else {
-
 		// 4. Emulate the resource, this is later used to verify the validity of the
 		//    CEL expressions.
 		emulatedResource, err = b.resourceEmulator.GenerateDummyCR(gvk, resourceSchema)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate dummy CR for resource %s: %w", rgResource.ID, err)
+		}
+
+		// Add metadata fields to emulated resource
+		if emulatedResource.Object["metadata"] == nil {
+			emulatedResource.Object["metadata"] = map[string]interface{}{
+				"name": "dummy-name",
+				"creationTimestamp": "2024-01-01T00:00:00Z",
+				"namespace": "default",
+				"labels": map[string]interface{}{},
+				"annotations": map[string]interface{}{},
+			}
 		}
 
 		// 5. Extract CEL fieldDescriptors from the schema.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -346,7 +346,7 @@ func (rt *ResourceGraphDefinitionRuntime) evaluateDynamicVariables() error {
 	// and are resolved after all the dependencies are resolved.
 
 	resolvedResources := maps.Keys(rt.resolvedResources)
-	resolvedResources = append(resolvedResources, "schema")
+	resolvedResources = append(resolvedResources, "schema", "metadata")
 	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs(resolvedResources))
 	if err != nil {
 		return err
@@ -376,6 +376,14 @@ func (rt *ResourceGraphDefinitionRuntime) evaluateDynamicVariables() error {
 			}
 
 			evalContext["schema"] = rt.instance.Unstructured().Object
+			
+			// Add metadata context for both instance and resources
+			evalContext["metadata"] = rt.instance.Unstructured().Object["metadata"]
+			for resourceID, resource := range rt.resolvedResources {
+				if resource.Object["metadata"] != nil {
+					evalContext[resourceID+".metadata"] = resource.Object["metadata"]
+				}
+			}
 
 			value, err := evaluateExpression(env, evalContext, variable.Expression)
 			if err != nil {


### PR DESCRIPTION
Hi developer, 

This contribution fixes the #377 issue,

Support metadata field access in RGD CEL expressions
Adds support for referencing metadata fields in Resource Graph Definition (RGD) CEL expressions. Users can now access:
- Instance metadata via ${instance.metadata.*}
- Resource metadata via ${resourceId.metadata.*}
- Standard K8s metadata fields (name, namespace, creationTimestamp, etc.)