### PR TITLE
feat: Implement CEL runtime cost budget for expression evaluation

### DIFF
--- a/pkg/cel/cost.go
+++ b/pkg/cel/cost.go
@@ -1,0 +1,58 @@
+package cel
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+)
+
+const (
+	// PerCallLimit specifies the cost limit per individual CEL expression evaluation
+	// This gives roughly 0.1 second of execution time per expression evaluation
+	PerCallLimit = 1000000
+
+	// RuntimeCELCostBudget is the total cost budget allowed during a single
+	// ResourceGroup reconciliation cycle. This includes all expression evaluations
+	// across all resources defined in the ResourceGroup. The budget gives roughly
+	// 1 second of total execution time before being exceeded.
+	RuntimeCELCostBudget = 1000
+
+	// CheckFrequency configures the number of iterations within a comprehension to evaluate
+	// before checking whether the function evaluation has been interrupted
+	CheckFrequency = 100
+)
+
+var ErrCELBudgetExceeded = errors.New("CEL Cost budget exceeded")
+
+// IsCostLimitExceeded checks if the error is related to CEL cost limit exceeding
+func IsCostLimitExceeded(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "cost limit exceeded")
+}
+
+// WrapCostLimitExceeded wraps a CEL cost limit error with our standard ErrCELBudgetExceeded
+// If the error is not a cost limit error, it returns the original error
+func WrapCostLimitExceeded(err error, totalCost int64) error {
+	if err == nil {
+		return nil
+	}
+
+	if IsCostLimitExceeded(err) {
+		return errors.New(ErrCELBudgetExceeded.Error() + ": total CEL cost " +
+			fmt.Sprintf("%d", totalCost) + " exceeded budget of " +
+			fmt.Sprintf("%d", RuntimeCELCostBudget))
+	}
+
+	return err
+}
+
+func WithCostTracking(costLimit int64) []cel.ProgramOption {
+	return []cel.ProgramOption{
+		cel.CostLimit(uint64(costLimit)),
+		cel.EvalOptions(cel.OptTrackCost),
+	}
+}

--- a/pkg/cel/cost_test.go
+++ b/pkg/cel/cost_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cel
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOnlyCELBudgetValues sets up values for testing
+// These need to be much higher than normal to prevent test failures
+var (
+	TestOnlyRuntimeCELCostBudget = int64(100000000000) // 10B - very high for tests
+	TestOnlyPerCallLimit         = int64(10000000)     // 10M - high enough for any test expression
+)
+
+// WithTestBudget returns program options suitable for testing,
+// with much higher limits than production
+func WithTestBudget() []cel.ProgramOption {
+	return []cel.ProgramOption{
+		cel.CostLimit(uint64(TestOnlyPerCallLimit)),
+		cel.EvalOptions(cel.OptTrackCost),
+	}
+}
+
+func TestWithCostTracking(t *testing.T) {
+	//  WithCostTracking returns the expected number of options
+	opts := WithCostTracking(10000)
+	assert.Equal(t, 2, len(opts), "Expected 2 options to be returned")
+}
+
+func TestCELBudgetExceeded(t *testing.T) {
+	env, err := cel.NewEnv()
+	require.NoError(t, err)
+
+	ast, iss := env.Compile(`"test"`)
+	require.NoError(t, iss.Err())
+
+	// Testing with unlimited budget (should succeed)
+	opts := WithCostTracking(10000)
+	program, err := env.Program(ast, opts...)
+	require.NoError(t, err)
+
+	// Evaluating with sufficient budget
+	_, details, err := program.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+	assert.NotNil(t, details)
+	assert.NotNil(t, details.ActualCost())
+
+	// Testing with minimal budget (still should pass for this trivial expression)
+	opts = WithCostTracking(1)
+	program, err = env.Program(ast, opts...)
+	require.NoError(t, err)
+
+	// Evaluating with minimal budget
+	_, details, err = program.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+	assert.NotNil(t, details)
+	assert.NotNil(t, details.ActualCost())
+
+	// Testing with a more complex expression that will certainly exceed a 0 budget
+	ast, iss = env.Compile(`[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(x, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(y, x * y)).filter(arr, arr.exists(e, e > 50))`)
+	require.NoError(t, iss.Err())
+
+	// Setting up a large budget that should allow the expression to complete
+	opts = WithCostTracking(1000000)
+	program, err = env.Program(ast, opts...)
+	require.NoError(t, err)
+
+	// Evaluating with large budget - should succeed
+	val, details, err := program.Eval(map[string]interface{}{})
+	if err == nil {
+		t.Logf("Success! Expression evaluated with result: %v, cost: %v", val, *details.ActualCost())
+	} else {
+		t.Logf("Actual error: %v", err)
+		require.Error(t, err)
+		errMsg := err.Error()
+		assert.Contains(t, errMsg, "cost limit exceeded", "Error should indicate cost limit exceeded")
+	}
+
+	// A tiny budget to ensure the test passes
+	opts = WithCostTracking(0)
+	program, err = env.Program(ast, opts...)
+	require.NoError(t, err)
+
+	// Evaluating with zero budget - should fail with budget exceeded
+	_, _, err = program.Eval(map[string]interface{}{})
+	require.Error(t, err)
+	t.Logf("Actual error: %v", err)
+
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "cost limit exceeded", "Error should indicate cost limit exceeded")
+}
+
+func TestIsCostLimitExceeded(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-cost error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "cost limit error",
+			err:      errors.New("operation cancelled: actual cost limit exceeded"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsCostLimitExceeded(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestWrapCostLimitExceeded(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		totalCost int64
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			totalCost: 0,
+			want:      "",
+			wantErr:   false,
+		},
+		{
+			name:      "non-cost error",
+			err:       errors.New("some other error"),
+			totalCost: 5000,
+			want:      "some other error",
+			wantErr:   true,
+		},
+		{
+			name:      "cost limit error",
+			err:       errors.New("operation cancelled: actual cost limit exceeded"),
+			totalCost: 15000,
+			want:      fmt.Sprintf("CEL Cost budget exceeded: total CEL cost 15000 exceeded budget of %d", RuntimeCELCostBudget),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := WrapCostLimitExceeded(tt.err, tt.totalCost)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.want, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -625,7 +625,10 @@ func dryRunExpression(env *cel.Env, expression string, resources map[string]*Res
 	}
 
 	// TODO(a-hilaly): thinking about a creating a library to hide this...
-	program, err := env.Program(ast)
+
+	//adding cost tracking options
+	programOpts := krocel.WithCostTracking(krocel.PerCallLimit)
+	program, err := env.Program(ast, programOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create program: %w", err)
 	}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -15,7 +15,6 @@ package runtime
 
 import (
 	"encoding/json"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -28,20 +27,12 @@ import (
 	"github.com/kro-run/kro/pkg/graph/variable"
 )
 
-// Use testing-only budget for cost-sensitive tests
+// Using testing-only budget for cost-sensitive tests
 const testBudget = 10000000
 
 // setupTestRuntime updates a runtime with a high cost budget for testing
 func setupTestRuntime(rt *ResourceGraphDefinitionRuntime) {
 	rt.celCostBudget = testBudget
-}
-
-func TestMain(m *testing.M) {
-	// Run tests
-	exitCode := m.Run()
-
-	// Exit with appropriate code
-	os.Exit(exitCode)
 }
 
 func Test_RuntimeWorkflow(t *testing.T) {


### PR DESCRIPTION
# PR Description

Fixes #191
## Feature Description
This PR implements cost budgeting for CEL expression evaluation to prevent resource exhaustion from complex expressions. The controller now enforces both per-call limits for individual expressions and a total runtime budget for the entire reconciliation cycle.

Key features implemented:
- Per-call cost limit (1,000,000 units, ~0.1 second of execution time)
- Total runtime budget (1,000 units for all expressions in a reconciliation cycle)
- Budget exceeded error handling and proper status reporting

## Implementation Details
- Added cost tracking constants and helper functions in `pkg/cel/cost.go`
- Implemented cost accumulation in `ResourceGraphDefinitionRuntime`
- Added error handling for budget exceeded cases in controller
- Updated expression evaluation to use cost tracking options

## Testing
- Added tests for CEL cost budget enforcement
- Verified error handling when budget is exceeded
- Added test cases with both simple and complex expressions

### `pkg/cel` Tests
<img width="802" alt="Screenshot 2025-03-22 at 5 44 34 PM" src="https://github.com/user-attachments/assets/4d493113-d83c-4bf2-a7ae-64a5909b522e" />

### `pkg/graph` Tests
<img width="802" alt="Screenshot 2025-03-22 at 5 44 51 PM" src="https://github.com/user-attachments/assets/98f53694-8530-44fa-bf3e-dd19511d1218" />

### `pkg/runtime` Tests
<img width="802" alt="Screenshot 2025-03-22 at 5 45 02 PM" src="https://github.com/user-attachments/assets/ef96dfc2-521d-48f3-b206-933190a2b273" />

### All tests
<img width="802" alt="Screenshot 2025-03-22 at 5 49 23 PM" src="https://github.com/user-attachments/assets/3dc30ad7-cb1f-4e8b-875d-ae4688d7856a" />

## Example Error
When the CEL budget is exceeded, the controller will report an error and the instance status will reflect:

```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGroup
metadata:
  name: my-application
status:
  conditions:
    - type: Ready
      status: "False"
      reason: CELBudgetExceeded
      message: "Total CEL cost exceeded budget of 1000"
```

This prevents potential DoS attacks from overly complex expressions and ensures the controller remains responsive.

cc: @a-hilaly 
