### PR TITLE
Docs : Add Known Issues and Limitations in FAQ section 

### DIFF
--- a/website/docs/docs/faq.md
+++ b/website/docs/docs/faq.md
@@ -64,3 +64,78 @@ sidebar_position: 100
    This project is in active development and not yet intended for production
    use. The _ResourceGraphDefinition_ CRD and other APIs used in this project are not
    solidified and highly subject to change.
+
+
+6. **What are the current known issues and limitations?**
+
+   This section documents frequently encountered issues and limitations reported by the kro community.
+
+   ### Current Known Issues
+
+   **1. Kro does not detect deleted resources**
+
+   - **Impact**: Deleted resources from kro instances are not detected and recreated automatically
+   - **Status**: Open bug
+   - **Workaround**: Manual recreation of deleted resources required
+   - **GitHub Issue**: [#520](https://github.com/kro-run/kro/issues/520)
+
+   **2. RGD instances stuck in "IN_PROGRESS" status**
+
+   - **Impact**: ResourceGraphDefinition instances remain in IN_PROGRESS status indefinitely
+   - **Status**: Under investigation
+   - **Workaround**: Manual intervention may be required
+   - **GitHub Issue**: [#407](https://github.com/kro-run/kro/issues/407)
+
+   **3. Missing detection of CRD breaking changes**
+
+   - **Impact**: Kro does not detect breaking changes in ResourceGroup schemas when modified
+   - **Status**: Feature enhancement needed
+   - **Workaround**: Manual validation of schema changes required
+   - **GitHub Issue**: [#186](https://github.com/kro-run/kro/issues/186)
+
+   **4. SNS topic creation failures**
+
+   - **Impact**: Cannot create SNS topics through kro despite correct IAM permissions
+   - **Status**: Open bug
+   - **Workaround**: Create topics manually or use manifest files directly
+   - **GitHub Issue**: [#522](https://github.com/kro-run/kro/issues/522)
+
+ 
+
+   ## Current Limitations
+
+   **1. Production readiness**
+   - **Limitation**: Project is in active development and not intended for production use
+   - **Impact**: ResourceGraphDefinition CRD and APIs are not solidified and subject to change
+   - **Recommendation**: Use only for development and testing environments
+
+   **2. API stability**
+   - **Limitation**: No guarantee of backward compatibility between versions
+   - **Impact**: Upgrades may require manual migration of existing ResourceGraphDefinitions
+   - **Recommendation**: Plan for potential breaking changes during upgrades
+
+   **3. Resource dependency complexity**
+   - **Limitation**: Complex dependency chains may be difficult to troubleshoot
+   - **Impact**: Issues in deeply nested resource dependencies can be hard to diagnose
+   - **Recommendation**: Keep ResourceGraphDefinition designs as simple as possible
+
+
+
+   **How to Contribute**
+
+   This section is community-maintained:
+
+   - Found a recurring issue? Check if it's already tracked in our [GitHub Issues](https://github.com/kro-run/kro/issues)
+   - For widespread issues affecting multiple users, consider updating this page via pull request
+   - Issues discussed in community calls will be added here
+
+
+
+
+   **Stay Updated**
+
+   - **Community Calls**: Join our [bi-weekly community meetings](https://docs.google.com/document/d/1GqeHcBlOw6ozo-qS4TLdXSi5qUn88QU6dwdq0GvxRz4/edit)
+   - **Live Issues**: [GitHub Issues](https://github.com/kro-run/kro/issues)
+   - **Community Slack**: [#kro channel](https://kubernetes.slack.com/archives/C081TMY9D6Y) in Kubernetes Slack
+
+   *Last updated: August 16, 2025 | This section is updated during major releases*

--- a/website/docs/docs/faq.md
+++ b/website/docs/docs/faq.md
@@ -68,74 +68,50 @@ sidebar_position: 100
 
 6. **What are the current known issues and limitations?**
 
-   This section documents frequently encountered issues and limitations reported by the kro community.
+   This section documents the most frequently observed and problematic issues reported by the kro community.
 
-   ### Current Known Issues
+    **Current Known Issues**
 
-   **1. Kro does not detect deleted resources**
+   **1. Missing API upgrade support for RGD-based CRDs**
 
-   - **Impact**: Deleted resources from kro instances are not detected and recreated automatically
-   - **Status**: Open bug
-   - **Workaround**: Manual recreation of deleted resources required
-   - **GitHub Issue**: [#520](https://github.com/kro-run/kro/issues/520)
+   - **Impact**: When Platform teams modify ResourceGraphDefinition schemas, there's no migration path for existing instances created by Developer teams
+   - **Status**: Major architectural limitation blocking production adoption  
+   - **Workaround**: Manual recreation of all instances when RGD schemas change
+   - **Community Impact**: Most frequently reported limitation preventing enterprise use
 
-   **2. RGD instances stuck in "IN_PROGRESS" status**
+   **2. Resource creation failures in complex dependency chains**
 
-   - **Impact**: ResourceGraphDefinition instances remain in IN_PROGRESS status indefinitely
-   - **Status**: Under investigation
-   - **Workaround**: Manual intervention may be required
-   - **GitHub Issue**: [#407](https://github.com/kro-run/kro/issues/407)
+   - **Impact**: Some resources may not be created when ResourceGraphDefinitions have complex dependencies, particularly with topological sorting issues
+   - **Status**: Confirmed issue affecting multiple users
+   - **Workaround**: Simplify resource dependencies or manually verify all resources are created
+   - **GitHub Issue**: [#225](https://github.com/kro-run/kro/issues/225)
 
-   **3. Missing detection of CRD breaking changes**
+   **3. GitOps integration compatibility**
 
-   - **Impact**: Kro does not detect breaking changes in ResourceGroup schemas when modified
-   - **Status**: Feature enhancement needed
-   - **Workaround**: Manual validation of schema changes required
-   - **GitHub Issue**: [#186](https://github.com/kro-run/kro/issues/186)
+   - **Impact**: Wrong API endpoints used with Fleet and other GitOps tools causing integration failures
+   - **Status**: Confirmed integration problem affecting GitOps workflows
+   - **Workaround**: Manual intervention or alternative deployment strategies  
+   - **GitHub Issue**: [#524](https://github.com/kro-run/kro/issues/524)
 
-   **4. SNS topic creation failures**
 
-   - **Impact**: Cannot create SNS topics through kro despite correct IAM permissions
-   - **Status**: Open bug
-   - **Workaround**: Create topics manually or use manifest files directly
-   - **GitHub Issue**: [#522](https://github.com/kro-run/kro/issues/522)
-
- 
-
-   ## Current Limitations
+   **Current Limitations**
 
    **1. Production readiness**
-   - **Limitation**: Project is in active development and not intended for production use
-   - **Impact**: ResourceGraphDefinition CRD and APIs are not solidified and subject to change
+   - **Limitation**: Project is in active development with no guarantee of backward compatibility between versions
+   - **Impact**: ResourceGraphDefinition CRDs and APIs are subject to breaking changes, and upgrades may require manual migration of existing ResourceGraphDefinitions
    - **Recommendation**: Use only for development and testing environments
 
-   **2. API stability**
-   - **Limitation**: No guarantee of backward compatibility between versions
-   - **Impact**: Upgrades may require manual migration of existing ResourceGraphDefinitions
-   - **Recommendation**: Plan for potential breaking changes during upgrades
+   **2. CEL expression observability**
+   - **Limitation**: No visibility into CEL expression execution costs, evaluation performance, or debugging information
+   - **Impact**: Difficult to troubleshoot and optimize complex ResourceGraphDefinitions when CEL expressions are expensive or fail
+   - **Status**: Architectural gap in observability framework
+   - **GitHub Issue**: [#190](https://github.com/kro-run/kro/issues/190)
 
-   **3. Resource dependency complexity**
-   - **Limitation**: Complex dependency chains may be difficult to troubleshoot
-   - **Impact**: Issues in deeply nested resource dependencies can be hard to diagnose
-   - **Recommendation**: Keep ResourceGraphDefinition designs as simple as possible
+   **How to Report Issues**
 
+   For bug reports and feature requests, please follow our [contributing guidelines](https://github.com/kro-run/kro/blob/main/CONTRIBUTING.md#reporting-bugsfeature-requests).
 
+   Note - This section focuses on the most frequently observed problematic issues confirmed by the community. 
+   Updated during majro releases based on community feedback. 
 
-   **How to Contribute**
-
-   This section is community-maintained:
-
-   - Found a recurring issue? Check if it's already tracked in our [GitHub Issues](https://github.com/kro-run/kro/issues)
-   - For widespread issues affecting multiple users, consider updating this page via pull request
-   - Issues discussed in community calls will be added here
-
-
-
-
-   **Stay Updated**
-
-   - **Community Calls**: Join our [bi-weekly community meetings](https://docs.google.com/document/d/1GqeHcBlOw6ozo-qS4TLdXSi5qUn88QU6dwdq0GvxRz4/edit)
-   - **Live Issues**: [GitHub Issues](https://github.com/kro-run/kro/issues)
-   - **Community Slack**: [#kro channel](https://kubernetes.slack.com/archives/C081TMY9D6Y) in Kubernetes Slack
-
-   *Last updated: August 16, 2025 | This section is updated during major releases*
+ 


### PR DESCRIPTION
## Summary
Adds a new "Known Issues and Limitations" section to the FAQ page as requested in the community call decision.

## Changes
- Documented 4 current known issues from GitHub repository:
- Documented current limitations.
- Added community contribution guidelines.
- Included links to GitHub Issues, community calls, and Slack

## Addresses
- Provides well-maintained enumerated list as specifically requested
- Located in FAQ section as specified in issue

Fixes #621 