### PR TITLE
feat: eager service account `SelfSubjectAccessReview` support when evaluating `ResourceGraphDefinition`

### DIFF
--- a/pkg/client/fake/fake.go
+++ b/pkg/client/fake/fake.go
@@ -22,6 +22,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	authclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -30,6 +31,7 @@ type FakeSet struct {
 	DynamicClient       dynamic.Interface
 	KubernetesClient    kubernetes.Interface
 	ApiExtensionsClient apiextensionsv1.ApiextensionsV1Interface
+	AuthorizationClient authclient.AuthorizationV1Interface
 	Config              *rest.Config
 }
 
@@ -51,6 +53,10 @@ func (f *FakeSet) Kubernetes() kubernetes.Interface {
 // Dynamic returns the dynamic client
 func (f *FakeSet) Dynamic() dynamic.Interface {
 	return f.DynamicClient
+}
+
+func (f *FakeSet) Authorization() authclient.AuthorizationV1Interface {
+	return f.AuthorizationClient
 }
 
 // APIExtensionsV1 returns the API extensions client

--- a/pkg/client/set.go
+++ b/pkg/client/set.go
@@ -20,6 +20,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	authclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
 	ctrlrtconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/release-utils/version"
@@ -37,6 +38,8 @@ type SetInterface interface {
 	// APIExtensionsV1 returns the API extensions client
 	APIExtensionsV1() apiextensionsv1.ApiextensionsV1Interface
 
+	Authorization() authclient.AuthorizationV1Interface
+
 	// RESTConfig returns a copy of the underlying REST config
 	RESTConfig() *rest.Config
 
@@ -53,6 +56,7 @@ type Set struct {
 	kubernetes      *kubernetes.Clientset
 	dynamic         *dynamic.DynamicClient
 	apiExtensionsV1 *apiextensionsv1.ApiextensionsV1Client
+	authClient      *authclient.AuthorizationV1Client
 }
 
 var _ SetInterface = (*Set)(nil)
@@ -125,6 +129,11 @@ func (c *Set) init() error {
 		return err
 	}
 
+	c.authClient, err = authclient.NewForConfigAndClient(c.config, sharedHttpClient)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -141,6 +150,11 @@ func (c *Set) Dynamic() dynamic.Interface {
 // APIExtensionsV1 returns the API extensions client
 func (c *Set) APIExtensionsV1() apiextensionsv1.ApiextensionsV1Interface {
 	return c.apiExtensionsV1
+}
+
+// Authorization returns the authorization client
+func (c *Set) Authorization() authclient.AuthorizationV1Interface {
+	return c.authClient
 }
 
 // RESTConfig returns a copy of the underlying REST config

--- a/test/e2e/chainsaw/check-rgd-deletion/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/check-rgd-deletion/chainsaw-test.yaml
@@ -45,4 +45,8 @@ spec:
   - name: check-that-crd-is-deleted
     try:
     - error:
-        file: instancecrd-assert.yaml        
+        resource:
+          apiVersion: kro.run/v1alpha1
+          kind: ResourceGraphDefinition
+          name: simple-deployment-for-deletion-rgd
+          namespace: default

--- a/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: check-rgd-creation
+spec:
+  description: |
+    Tests if a ResourceGraphDefinition can reject wrong service account configurations based on
+    SubjectAccessReview for cluster-scoped resources.
+  steps:
+  - name: service-account-restricted-cluster-scoped
+    try:
+    #description: Install the RGD that creates an Instance CRD
+    - apply:
+        file: service-account-restricted.yaml
+      description: Apply Base Role
+    - apply:
+        file: rgd-restricted-catchall.yaml
+      description: Apply RGD
+    - assert:
+        file: rgd-assert.yaml
+      description: Verify RGD state
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system

--- a/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/rgd-assert.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/rgd-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: namespace-creator
+  finalizers:
+    - kro.run/finalizer
+  generation: 1
+status:
+  # filter conditions array to keep elements where `type == 'Ready'`
+  # and assert there's a single element matching the filter
+  # and that this element status is `True`
+  (conditions[?type == 'Ready']):
+    - status: 'False'
+      message: |-
+        specified service account system:serviceaccount:default:namespace-creator does not have permission to delete "namespaceInstance" (/v1, Resource=namespaces)
+        specified service account system:serviceaccount:default:namespace-creator does not have permission to patch "namespaceInstance" (/v1, Resource=namespaces)
+        specified service account system:serviceaccount:default:namespace-creator does not have permission to update "namespaceInstance" (/v1, Resource=namespaces)
+        specified service account system:serviceaccount:default:namespace-creator does not have permission to watch "namespaceInstance" (/v1, Resource=namespaces)
+      observedGeneration: 1
+  state: Inactive
+
+
+

--- a/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/rgd-restricted-catchall.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/rgd-restricted-catchall.yaml
@@ -1,0 +1,19 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: namespace-creator
+spec:
+  defaultServiceAccounts:
+    "*": namespace-creator
+  schema:
+    apiVersion: v1alpha1
+    kind: NamespaceService
+    spec:
+      name: string
+  resources:
+    - id: namespaceInstance
+      template:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: ${schema.spec.name}-namespace

--- a/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/service-account-restricted.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess-cluster-scoped/service-account-restricted.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: namespace-creator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: namespace-create-role
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: namespace-create-binding
+subjects:
+  - kind: ServiceAccount
+    name: namespace-creator
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: namespace-create-role
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/chainsaw/check-subjectaccess/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/chainsaw-test.yaml
@@ -1,0 +1,44 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: check-rgd-creation
+spec:
+  description: | 
+    Tests if a ResourceGraphDefinition can reject wrong service account configurations based on
+    SubjectAccessReview
+  steps:
+  - name: service-account-restricted-catch-all
+    try:
+    #description: Install the RGD that creates an Instance CRD
+    - apply:
+        file: service-account-restricted.yaml
+      description: Apply Base Role
+    - apply:
+        file: rgd-restricted-catchall.yaml
+      description: Apply RGD
+    - assert:
+        file: rgd-assert.yaml
+      description: Verify RGD state
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system
+  - name: service-account-restricted-namespace-specific
+    try:
+      #description: Install the RGD that creates an Instance CRD
+      - apply:
+          file: my-custom-namespace.yaml
+      - apply:
+          file: service-account-restricted-namespaced.yaml
+      - apply:
+          file: rgd-restricted-namespace.yaml
+        description: Apply RGD
+      - assert:
+          file: rgd-assert-namespaced.yaml
+        description: Verify RGD state
+    catch:
+      - description: kro controller pod logs collector
+        podLogs:
+          selector: app.kubernetes.io/instance=kro
+          namespace: kro-system

--- a/test/e2e/chainsaw/check-subjectaccess/my-custom-namespace.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/my-custom-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: my-custom-namespace

--- a/test/e2e/chainsaw/check-subjectaccess/rgd-assert-namespaced.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/rgd-assert-namespaced.yaml
@@ -1,0 +1,21 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: config-map-service
+  finalizers:
+    - kro.run/finalizer
+  generation: 2
+status:
+  # filter conditions array to keep elements where `type == 'Ready'`
+  # and assert there's a single element matching the filter
+  # and that this element status is `True`
+  (conditions[?type == 'Ready']):
+    - status: 'False'
+      message: |-
+        specified service account system:serviceaccount:my-custom-namespace:configmap-creator-update does not have permission to create "configmap" (/v1, Resource=configmaps) in namespace my-custom-namespace
+        specified service account system:serviceaccount:my-custom-namespace:configmap-creator-update does not have permission to delete "configmap" (/v1, Resource=configmaps) in namespace my-custom-namespace
+        specified service account system:serviceaccount:my-custom-namespace:configmap-creator-update does not have permission to patch "configmap" (/v1, Resource=configmaps) in namespace my-custom-namespace
+        specified service account system:serviceaccount:my-custom-namespace:configmap-creator-update does not have permission to watch "configmap" (/v1, Resource=configmaps) in namespace my-custom-namespace
+      observedGeneration: 2
+  state: Inactive
+

--- a/test/e2e/chainsaw/check-subjectaccess/rgd-assert.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/rgd-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: config-map-service
+  finalizers:
+    - kro.run/finalizer
+  generation: 1
+status:
+  # filter conditions array to keep elements where `type == 'Ready'`
+  # and assert there's a single element matching the filter
+  # and that this element status is `True`
+  (conditions[?type == 'Ready']):
+    - status: 'False'
+      message: |-
+        specified service account system:serviceaccount:default:configmap-creator does not have permission to delete "configmap" (/v1, Resource=configmaps) in namespace default
+        specified service account system:serviceaccount:default:configmap-creator does not have permission to patch "configmap" (/v1, Resource=configmaps) in namespace default
+        specified service account system:serviceaccount:default:configmap-creator does not have permission to update "configmap" (/v1, Resource=configmaps) in namespace default
+        specified service account system:serviceaccount:default:configmap-creator does not have permission to watch "configmap" (/v1, Resource=configmaps) in namespace default
+      observedGeneration: 1
+  state: Inactive
+

--- a/test/e2e/chainsaw/check-subjectaccess/rgd-restricted-catchall.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/rgd-restricted-catchall.yaml
@@ -1,0 +1,21 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: config-map-service
+spec:
+  defaultServiceAccounts:
+    "*": configmap-creator
+  schema:
+    apiVersion: v1alpha1
+    kind: ConfigMapService
+    spec:
+      name: string
+  resources:
+    - id: configmap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.spec.name}-configmap
+        data:
+          key: value

--- a/test/e2e/chainsaw/check-subjectaccess/rgd-restricted-namespace.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/rgd-restricted-namespace.yaml
@@ -1,0 +1,22 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: config-map-service
+spec:
+  defaultServiceAccounts:
+    my-custom-namespace: configmap-creator-update
+  schema:
+    apiVersion: v1alpha1
+    kind: ConfigMapService
+    spec:
+      name: string
+  resources:
+    - id: configmap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.spec.name}-configmap
+          namespace: my-custom-namespace
+        data:
+          key: value

--- a/test/e2e/chainsaw/check-subjectaccess/service-account-restricted-namespaced.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/service-account-restricted-namespaced.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: configmap-creator-update
+  namespace: my-custom-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: configmap-update-role
+  namespace: my-custom-namespace
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]  # specify the resource type
+    verbs: ["update"]   # only allow create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: configmap-update-binding
+  namespace: my-custom-namespace
+subjects:
+  - kind: ServiceAccount
+    name: configmap-creator-update
+    namespace: my-custom-namespace
+roleRef:
+  kind: Role
+  name: configmap-update-role
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/chainsaw/check-subjectaccess/service-account-restricted.yaml
+++ b/test/e2e/chainsaw/check-subjectaccess/service-account-restricted.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: configmap-creator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: configmap-create-role
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]  # specify the resource type
+    verbs: ["create"]   # only allow create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: configmap-create-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: configmap-creator
+    namespace: default
+roleRef:
+  kind: Role
+  name: configmap-create-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  # ...
spec:
  defaultServiceAccounts:
    '*': configmap-creator
  resources:
  - id: configmap
    template:
      apiVersion: v1
      data:
        key: value
      kind: ConfigMap
      metadata:
        name: ${schema.spec.name}-configmap
  schema:
    apiVersion: v1alpha1
    group: kro.run
    kind: ConfigMapService
    spec:
      name: string
status:
  conditions:
  # ...
  - lastTransitionTime: "2025-08-22T21:22:15Z"
    message: |-
      specified service account system:serviceaccount:default:configmap-creator does not have permission to delete "configmap" (/v1, Resource=configmaps) in namespace default
      specified service account system:serviceaccount:default:configmap-creator does not have permission to patch "configmap" (/v1, Resource=configmaps) in namespace default
      specified service account system:serviceaccount:default:configmap-creator does not have permission to update "configmap" (/v1, Resource=configmaps) in namespace default
      specified service account system:serviceaccount:default:configmap-creator does not have permission to watch "configmap" (/v1, Resource=configmaps) in namespace default
    observedGeneration: 1
    reason: InvalidResourceGraph
    status: "False"
    type: Ready
  state: Inactive
```

Added preflight RBAC validation for every resource in a ResourceGraphDefinition (RGD).

- Selects the service account per resource based on spec.defaultServiceAccounts (namespace-specific override first, then * catch-all).
- Performs SelfSubjectAccessReview calls (create, update, delete, patch, watch) using impersonation of the selected service account.
- Runs these SARs concurrently and aggregates denials into a single error.
- Treats permission failures as “invalid resource graph,” marking the RGD Ready=False and surfacing a precise, multi-line message listing missing verbs per resource.
- Wired the authorization client and impersonation into the shared client set (pkg/client/set.go) and extended the fake client to support it for tests.

Added E2E tests: Namespaced and cluster-scoped permission checks that assert Ready=False with exact denial messages. A deletion flow test that applies an RGD, verifies, deletes it, and confirms the object is gone.

## Why it’s useful

- Fast, explicit failure: Users get immediate, actionable feedback when service accounts lack required verbs, before any workloads are created.
- Least-privilege safety: Encourages narrowly scoped RBAC by showing exactly which verbs are needed for each resource.
- Better UX and debuggability: Aggregated, deterministic messages show all missing permissions in one place and propagate to the Ready condition.