### PR TITLE
feat(simpleschema): add support for pattern, minLength, maxLengt, uniqueItems, maxItems and minItems markers

### DIFF
--- a/pkg/simpleschema/markers.go
+++ b/pkg/simpleschema/markers.go
@@ -57,12 +57,26 @@ const (
 	MarkerTypeEnum MarkerType = "enum"
 	// MarkerTypeImmutable represents the `immutable` marker.
 	MarkerTypeImmutable MarkerType = "immutable"
+	// MarkerTypePattern represents the `pattern` marker.
+	MarkerTypePattern MarkerType = "pattern"
+	// MarkerTypeUniqueItems represents the `uniqueItems` marker.
+	MarkerTypeUniqueItems MarkerType = "uniqueItems"
+	// MarkerTypeMinLength represents the `minLength` marker.
+	MarkerTypeMinLength MarkerType = "minLength"
+	// MarkerTypeMaxLength represents the `maxLength` marker.
+	MarkerTypeMaxLength MarkerType = "maxLength"
+	// MarkerTypeMinItems represents the `minItems` marker.
+	MarkerTypeMinItems MarkerType = "minItems"
+	// MarkerTypeMaxItems represents the `maxItems` marker.
+	MarkerTypeMaxItems MarkerType = "maxItems"
 )
 
 func markerTypeFromString(s string) (MarkerType, error) {
 	switch MarkerType(s) {
 	case MarkerTypeRequired, MarkerTypeDefault, MarkerTypeDescription,
-		MarkerTypeMinimum, MarkerTypeMaximum, MarkerTypeValidation, MarkerTypeEnum, MarkerTypeImmutable:
+		MarkerTypeMinimum, MarkerTypeMaximum, MarkerTypeValidation, MarkerTypeEnum, MarkerTypeImmutable,
+		MarkerTypePattern, MarkerTypeUniqueItems, MarkerTypeMinLength, MarkerTypeMaxLength, MarkerTypeMinItems,
+		MarkerTypeMaxItems:
 		return MarkerType(s), nil
 	default:
 		return "", fmt.Errorf("unknown marker type: %s", s)

--- a/pkg/simpleschema/markers_test.go
+++ b/pkg/simpleschema/markers_test.go
@@ -134,6 +134,119 @@ func TestParseMarkers(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:  "pattern marker",
+			input: "pattern=\"^[a-zA-Z0-9]+$\"",
+			want: []*Marker{
+				{MarkerType: MarkerTypePattern, Key: "pattern", Value: "^[a-zA-Z0-9]+$"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "minLength and maxLength markers",
+			input: "minLength=5 maxLength=20",
+			want: []*Marker{
+				{MarkerType: MarkerTypeMinLength, Key: "minLength", Value: "5"},
+				{MarkerType: MarkerTypeMaxLength, Key: "maxLength", Value: "20"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "all string validation markers",
+			input: "pattern=\"[a-z]+\" minLength=3 maxLength=15 description=\"String field with validation\"",
+			want: []*Marker{
+				{MarkerType: MarkerTypePattern, Key: "pattern", Value: "[a-z]+"},
+				{MarkerType: MarkerTypeMinLength, Key: "minLength", Value: "3"},
+				{MarkerType: MarkerTypeMaxLength, Key: "maxLength", Value: "15"},
+				{MarkerType: MarkerTypeDescription, Key: "description", Value: "String field with validation"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "pattern with special regex characters",
+			input: "pattern=\"^(foo|bar)\\d{2,4}$\"",
+			want: []*Marker{
+				{MarkerType: MarkerTypePattern, Key: "pattern", Value: "^(foo|bar)\\d{2,4}$"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "zero minLength",
+			input: "minLength=0",
+			want: []*Marker{
+				{MarkerType: MarkerTypeMinLength, Key: "minLength", Value: "0"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "uniqueItems marker true",
+			input: "uniqueItems=true",
+			want: []*Marker{
+				{MarkerType: MarkerTypeUniqueItems, Key: "uniqueItems", Value: "true"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "uniqueItems marker false",
+			input: "uniqueItems=false",
+			want: []*Marker{
+				{MarkerType: MarkerTypeUniqueItems, Key: "uniqueItems", Value: "false"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "array field with uniqueItems and validation",
+			input: "uniqueItems=true description=\"Array with unique elements\"",
+			want: []*Marker{
+				{MarkerType: MarkerTypeUniqueItems, Key: "uniqueItems", Value: "true"},
+				{MarkerType: MarkerTypeDescription, Key: "description", Value: "Array with unique elements"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "minItems marker",
+			input: "minItems=2",
+			want: []*Marker{
+				{MarkerType: MarkerTypeMinItems, Key: "minItems", Value: "2"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "maxItems marker",
+			input: "maxItems=10",
+			want: []*Marker{
+				{MarkerType: MarkerTypeMaxItems, Key: "maxItems", Value: "10"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "minItems and maxItems markers",
+			input: "minItems=1 maxItems=5",
+			want: []*Marker{
+				{MarkerType: MarkerTypeMinItems, Key: "minItems", Value: "1"},
+				{MarkerType: MarkerTypeMaxItems, Key: "maxItems", Value: "5"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "array field with all validation markers",
+			input: "uniqueItems=true minItems=2 maxItems=8 description=\"Array with comprehensive validation\"",
+			want: []*Marker{
+				{MarkerType: MarkerTypeUniqueItems, Key: "uniqueItems", Value: "true"},
+				{MarkerType: MarkerTypeMinItems, Key: "minItems", Value: "2"},
+				{MarkerType: MarkerTypeMaxItems, Key: "maxItems", Value: "8"},
+				{MarkerType: MarkerTypeDescription, Key: "description", Value: "Array with comprehensive validation"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "zero minItems",
+			input: "minItems=0",
+			want: []*Marker{
+				{MarkerType: MarkerTypeMinItems, Key: "minItems", Value: "0"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -16,6 +16,7 @@ package simpleschema
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -30,6 +31,7 @@ const (
 	keyTypeBoolean = string(AtomicTypeBool)
 	keyTypeNumber  = "number"
 	keyTypeObject  = "object"
+	keyTypeArray   = "array"
 )
 
 // A predefinedType is a type that is predefined in the schema.
@@ -202,7 +204,7 @@ func (tf *transformer) handleSliceType(key, fieldType string) (*extv1.JSONSchema
 	}
 
 	fieldJSONSchemaProps := &extv1.JSONSchemaProps{
-		Type: "array",
+		Type: keyTypeArray,
 		Items: &extv1.JSONSchemaPropsOrArray{
 			Schema: &extv1.JSONSchemaProps{},
 		},
@@ -225,6 +227,7 @@ func (tf *transformer) handleSliceType(key, fieldType string) (*extv1.JSONSchema
 	return fieldJSONSchemaProps, nil
 }
 
+//nolint:gocyclo
 func (tf *transformer) applyMarkers(schema *extv1.JSONSchemaProps, markers []*Marker, key string, parentSchema *extv1.JSONSchemaProps) error {
 	for _, marker := range markers {
 		switch marker.MarkerType {
@@ -265,7 +268,7 @@ func (tf *transformer) applyMarkers(schema *extv1.JSONSchemaProps, markers []*Ma
 			}
 			schema.Maximum = &val
 		case MarkerTypeValidation:
-			if marker.Value == "" {
+			if strings.TrimSpace(marker.Value) == "" {
 				return fmt.Errorf("validation failed")
 			}
 			validation := []extv1.ValidationRule{
@@ -316,6 +319,75 @@ func (tf *transformer) applyMarkers(schema *extv1.JSONSchemaProps, markers []*Ma
 			if len(enumJSONValues) > 0 {
 				schema.Enum = enumJSONValues
 			}
+		case MarkerTypeMinLength:
+			// MinLength is only valid for string types
+			if schema.Type != keyTypeString {
+				return fmt.Errorf("minLength marker is only valid for string types, got type: %s", schema.Type)
+			}
+			val, err := strconv.ParseInt(marker.Value, 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse minLength value: %w", err)
+			}
+			schema.MinLength = &val
+
+		case MarkerTypeMaxLength:
+			// MaxLength is only valid for string types
+			if schema.Type != keyTypeString {
+				return fmt.Errorf("maxLength marker is only valid for string types, got type: %s", schema.Type)
+			}
+			val, err := strconv.ParseInt(marker.Value, 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse maxLength value: %w", err)
+			}
+			schema.MaxLength = &val
+		case MarkerTypePattern:
+			if marker.Value == "" {
+				return fmt.Errorf("pattern marker value cannot be empty")
+			}
+			// Pattern is only valid for string types
+			if schema.Type != keyTypeString {
+				return fmt.Errorf("pattern marker is only valid for string types, got type: %s", schema.Type)
+			}
+			// Validate regex
+			if _, err := regexp.Compile(marker.Value); err != nil {
+				return fmt.Errorf("invalid pattern regex: %w", err)
+			}
+			schema.Pattern = marker.Value
+		case MarkerTypeUniqueItems:
+			// UniqueItems is only valid for array types
+			switch isUnique, err := strconv.ParseBool(marker.Value); {
+			case err != nil:
+				return fmt.Errorf("failed to parse uniqueItems marker value: %w", err)
+			case schema.Type != keyTypeArray:
+				return fmt.Errorf("uniqueItems marker is only valid for array types, got type: %s", schema.Type)
+			case isUnique:
+				// Always set x-kubernetes-list-type to "set" when uniqueItems is true
+				// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions
+				// https://stackoverflow.com/questions/79399232/forbidden-uniqueitems-cannot-be-set-to-true-since-the-runtime-complexity-become
+				schema.XListType = ptr.To("set")
+			default:
+				// ignore
+			}
+		case MarkerTypeMinItems:
+			// MinItems is only valid for array types
+			if schema.Type != keyTypeArray {
+				return fmt.Errorf("minItems marker is only valid for array types, got type: %s", schema.Type)
+			}
+			val, err := strconv.ParseInt(marker.Value, 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse minItems value: %w", err)
+			}
+			schema.MinItems = &val
+		case MarkerTypeMaxItems:
+			// MaxItems is only valid for array types
+			if schema.Type != keyTypeArray {
+				return fmt.Errorf("maxItems marker is only valid for array types, got type: %s", schema.Type)
+			}
+			val, err := strconv.ParseInt(marker.Value, 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse maxItems value: %w", err)
+			}
+			schema.MaxItems = &val
 		}
 	}
 	return nil

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -594,6 +594,342 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "String field with pattern validation",
+			obj: map[string]interface{}{
+				"email": "string | pattern=\"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$\"",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"email": {
+						Type:    "string",
+						Pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "String field with minLength and maxLength",
+			obj: map[string]interface{}{
+				"username": "string | minLength=3 maxLength=20",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"username": {
+						Type:      "string",
+						MinLength: ptr.To(int64(3)),
+						MaxLength: ptr.To(int64(20)),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "String field with all validation markers",
+			obj: map[string]interface{}{
+				"code": "string | pattern=\"^[A-Z]{2}[0-9]{4}$\" minLength=6 maxLength=6 description=\"Country code format\"",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"code": {
+						Type:        "string",
+						Pattern:     "^[A-Z]{2}[0-9]{4}$",
+						MinLength:   ptr.To(int64(6)),
+						MaxLength:   ptr.To(int64(6)),
+						Description: "Country code format",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array field with uniqueItems true",
+			obj: map[string]interface{}{
+				"tags": "[]string | uniqueItems=true",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"tags": {
+						Type: "array",
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{Type: "string"},
+						},
+						XListType: ptr.To("set"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array field with uniqueItems false",
+			obj: map[string]interface{}{
+				"comments": "[]string | uniqueItems=false",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"comments": {
+						Type: "array",
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{Type: "string"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Complex object with multiple new validation markers",
+			obj: map[string]interface{}{
+				"user": map[string]interface{}{
+					"email":    "string | pattern=\"^[\\w\\.-]+@[\\w\\.-]+\\.\\w+$\"",
+					"username": "string | minLength=3 maxLength=15 pattern=\"^[a-zA-Z0-9_]+$\"",
+					"roles":    "[]string | uniqueItems=true",
+					"tags":     "[]string | uniqueItems=false",
+				},
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"user": {
+						Type: "object",
+						Properties: map[string]extv1.JSONSchemaProps{
+							"email": {
+								Type:    "string",
+								Pattern: "^[\\w\\.-]+@[\\w\\.-]+\\.\\w+$",
+							},
+							"username": {
+								Type:      "string",
+								Pattern:   "^[a-zA-Z0-9_]+$",
+								MinLength: ptr.To(int64(3)),
+								MaxLength: ptr.To(int64(15)),
+							},
+							"roles": {
+								Type: "array",
+								Items: &extv1.JSONSchemaPropsOrArray{
+									Schema: &extv1.JSONSchemaProps{Type: "string"},
+								},
+								XListType: ptr.To("set"),
+							},
+							"tags": {
+								Type: "array",
+								Items: &extv1.JSONSchemaPropsOrArray{
+									Schema: &extv1.JSONSchemaProps{Type: "string"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array field with minItems",
+			obj: map[string]interface{}{
+				"items": "[]string | minItems=2",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"items": {
+						Type:     "array",
+						MinItems: ptr.To(int64(2)),
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{Type: "string"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array field with maxItems",
+			obj: map[string]interface{}{
+				"tags": "[]string | maxItems=10",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"tags": {
+						Type:     "array",
+						MaxItems: ptr.To(int64(10)),
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{Type: "string"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array field with minItems and maxItems",
+			obj: map[string]interface{}{
+				"priorities": "[]integer | minItems=1 maxItems=5",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"priorities": {
+						Type:     "array",
+						MinItems: ptr.To(int64(1)),
+						MaxItems: ptr.To(int64(5)),
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{Type: "integer"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array field with all validation markers",
+			obj: map[string]interface{}{
+				"codes": "[]string | uniqueItems=true minItems=2 maxItems=8",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"codes": {
+						Type:     "array",
+						MinItems: ptr.To(int64(2)),
+						MaxItems: ptr.To(int64(8)),
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{Type: "string"},
+						},
+						XListType: ptr.To("set"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Array field with zero minItems",
+			obj: map[string]interface{}{
+				"optional": "[]string | minItems=0",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"optional": {
+						Type:     "array",
+						MinItems: ptr.To(int64(0)),
+						Items: &extv1.JSONSchemaPropsOrArray{
+							Schema: &extv1.JSONSchemaProps{Type: "string"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid pattern regex",
+			obj: map[string]interface{}{
+				"invalid": "string | pattern=\"[unclosed\"",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Pattern marker on non-string type",
+			obj: map[string]interface{}{
+				"invalid": "integer | pattern=\"[0-9]+\"",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "MinLength marker on non-string type",
+			obj: map[string]interface{}{
+				"invalid": "integer | minLength=5",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "MaxLength marker on non-string type",
+			obj: map[string]interface{}{
+				"invalid": "boolean | maxLength=10",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "UniqueItems marker on non-array type",
+			obj: map[string]interface{}{
+				"invalid": "string | uniqueItems=true",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid minLength value",
+			obj: map[string]interface{}{
+				"invalid": "string | minLength=abc",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid maxLength value",
+			obj: map[string]interface{}{
+				"invalid": "string | maxLength=xyz",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid uniqueItems value",
+			obj: map[string]interface{}{
+				"invalid": "[]string | uniqueItems=invalid",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "MinItems marker on non-array type",
+			obj: map[string]interface{}{
+				"invalid": "string | minItems=5",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "MaxItems marker on non-array type",
+			obj: map[string]interface{}{
+				"invalid": "integer | maxItems=10",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid minItems value",
+			obj: map[string]interface{}{
+				"invalid": "[]string | minItems=abc",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid maxItems value",
+			obj: map[string]interface{}{
+				"invalid": "[]string | maxItems=xyz",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Empty pattern value",
+			obj: map[string]interface{}{
+				"invalid": "string | pattern=\"\"",
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/chainsaw/check-validation-markers/README.md
+++ b/test/e2e/chainsaw/check-validation-markers/README.md
@@ -1,0 +1,49 @@
+# Validation Markers Chainsaw Test
+
+This test validates the new validation markers: `pattern`, `minLength`, `maxLength`, `uniqueItems`, `minItems`, and `maxItems`.
+
+## Test Structure
+
+1. **install-rgd**: Creates an RGD with validation markers and verifies:
+   - RGD is created and ready
+   - Instance CRD is generated with proper validation constraints
+
+2. **create-valid-instance**: Creates an instance with valid data and verifies:
+   - Instance is created successfully
+   - ConfigMap resource is created correctly
+
+## Validation Markers Tested
+
+### String Validation
+- **pattern**: Email regex validation `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+- **minLength/maxLength**: Username must be 3-15 characters
+- **maxLength**: Description limited to 100 characters
+
+### Array Validation
+- **uniqueItems**: Tags array must have unique elements
+- **minItems**: Tags array must have at least 1 element
+- **maxItems**: Tags array can have at most 5 elements
+- **minItems/maxItems**: Priorities array can have 0-3 elements
+
+### Numeric Validation (existing)
+
+- **minimum/maximum**: Replicas must be 1-10
+
+## Files
+
+- `rgd.yaml`: ResourceGraphDefinition with validation markers
+- `rgd-assert.yaml`: RGD readiness assertion
+- `instancecrd-assert.yaml`: CRD validation schema assertion  
+- `valid-instance.yaml`: Valid instance example
+- `valid-instance-assert.yaml`: Instance readiness assertion
+- `configmap-assert.yaml`: Generated ConfigMap assertion
+
+## Expected OpenAPI Schema Validation
+
+The generated CRD should include:
+
+- `pattern` constraints on string fields
+- `minLength`/`maxLength` constraints
+- `uniqueItems: true` on array fields  
+- `minItems`/`maxItems` constraints on array fields
+- Required field enforcement

--- a/test/e2e/chainsaw/check-validation-markers/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/chainsaw-test.yaml
@@ -1,0 +1,86 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: check-validation-markers
+spec:
+  description: |
+    Tests validation markers: pattern, minLength, maxLength, uniqueItems, minItems, and maxItems
+  steps:
+  - name: install-rgd
+    try:
+    #description: Install the RGD that creates an Instance CRD with validation markers
+    - apply:
+        file: rgd.yaml
+      description: Apply RGD with validation markers
+    - assert:
+        file: rgd-assert.yaml
+      description: Verify RGD state
+    - assert:
+        file: instancecrd-assert.yaml
+      description: Verify Instance CRD has validation constraints
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system
+    finally:
+    - description: sleep operation
+      sleep:
+        duration: 5s
+  - name: create-valid-instance
+    try:
+    #description: Create instance with valid data that meets validation constraints
+    - apply:
+        file: valid-instance.yaml
+      description: Create ValidationTest Instance with valid data
+    - assert:
+        file: valid-instance-assert.yaml
+      description: Verify valid Instance state
+    - assert:
+        file: configmap-assert.yaml
+      description: Verify ConfigMap was created
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system
+  - name: test-invalid-min-items
+    try:
+    - error:
+        file: invalid-instance-min-items.yaml
+      description: Expect validation error for minItems violation (empty tags array)
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system
+  - name: test-invalid-max-items
+    try:
+    - error:
+        file: invalid-instance-max-items.yaml
+      description: Expect validation error for maxItems violation (too many tags)
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system
+  - name: test-invalid-array-limits
+    try:
+    - error:
+        file: invalid-instance-array-limits.yaml
+      description: Expect validation error for maxItems violations (too many tags and priorities)
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system
+  - name: test-invalid-priorities-max
+    try:
+    - error:
+        file: invalid-instance-priorities-max.yaml
+      description: Expect validation error for maxItems violation (too many priorities)
+    catch:
+    - description: kro controller pod logs collector
+      podLogs:
+        selector: app.kubernetes.io/instance=kro
+        namespace: kro-system

--- a/test/e2e/chainsaw/check-validation-markers/configmap-assert.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/configmap-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valid-test-app-config
+data:
+  properties: |
+    email: user@example.com
+    username: testuser123
+    description: A test application
+    tags: [production frontend webapp]
+    replicas: 3

--- a/test/e2e/chainsaw/check-validation-markers/instancecrd-assert.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/instancecrd-assert.yaml
@@ -1,0 +1,118 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: validationtestapps.kro.run
+spec:
+  conversion:
+    strategy: None
+  group: kro.run
+  names:
+    kind: ValidationTestApp
+    listKind: ValidationTestAppList
+    plural: validationtestapps
+    singular: validationtestapp
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The state of a ResourceGraphDefinition instance
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: Whether a ResourceGraphDefinition instance have all it's subresources
+        ready
+      jsonPath: .status.conditions[?(@.type=="InstanceSynced")].status
+      name: Synced
+      type: string
+    - description: Age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              description: 
+                default: Test application
+                maxLength: 100
+                type: string
+              email:
+                description: Valid email address
+                pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+                type: string
+              replicas:
+                maximum: 10
+                minimum: 1
+                default: 1
+                type: integer
+              tags:
+                description: 1-3 unique tags
+                items:
+                  type: string
+                maxItems: 3
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: set
+              priorities:
+                description: Up to 3 priority levels
+                items:
+                  type: integer
+                maxItems: 3
+                minItems: 0
+                type: array
+              username:
+                description: Username must be 3-15 chars, alphanumeric and underscore only
+                maxLength: 15
+                minLength: 3
+                pattern: "^[a-zA-Z0-9_]+$"
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ValidationTestApp
+    listKind: ValidationTestAppList
+    plural: validationtestapps
+    singular: validationtestapp
+  conditions:
+  - message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established

--- a/test/e2e/chainsaw/check-validation-markers/invalid-instance-array-limits.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-instance-array-limits.yaml
@@ -1,0 +1,23 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-array-limits-app
+spec:
+  email: user@example.com
+  username: testuser123
+  tags:
+    # This violates maxItems=5 constraint
+    - tag1
+    - tag2
+    - tag3
+    - tag4
+    - tag5
+    - tag6
+  priorities:
+    # This violates maxItems=3 constraint
+    - 1
+    - 2
+    - 3
+    - 4
+  description: This app should fail validation
+  replicas: 3

--- a/test/e2e/chainsaw/check-validation-markers/invalid-instance-max-items.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-instance-max-items.yaml
@@ -1,0 +1,17 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-max-items-app
+spec:
+  email: user@example.com
+  username: testuser123
+  tags:
+    # This violates maxItems=3 constraint
+    - tag1
+    - tag2
+    - tag3
+    - tag4
+  priorities:
+    - 1
+  description: This app should fail validation due to too many tags
+  replicas: 3

--- a/test/e2e/chainsaw/check-validation-markers/invalid-instance-min-items.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-instance-min-items.yaml
@@ -1,0 +1,12 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-min-items-app
+spec:
+  email: user@example.com
+  username: testuser123
+  tags: []  # This violates minItems=1 constraint
+  priorities:
+    - 1
+  description: This app should fail validation due to empty tags
+  replicas: 3

--- a/test/e2e/chainsaw/check-validation-markers/invalid-instance-priorities-max.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-instance-priorities-max.yaml
@@ -1,0 +1,17 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-priorities-max-items-app
+spec:
+  email: user@example.com
+  username: testuser123
+  tags:
+    - tag1
+  priorities:
+    # This violates maxItems=3 constraint
+    - 1
+    - 2
+    - 3
+    - 4
+  description: This app should fail validation due to too many priorities
+  replicas: 3

--- a/test/e2e/chainsaw/check-validation-markers/invalid-length-error.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-length-error.yaml
@@ -1,0 +1,4 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-length-test

--- a/test/e2e/chainsaw/check-validation-markers/invalid-length-instance.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-length-instance.yaml
@@ -1,0 +1,10 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-length-test
+spec:
+  email: user@example.com
+  username: ab  # Too short - violates minLength=3
+  tags:
+    - test
+  replicas: 1

--- a/test/e2e/chainsaw/check-validation-markers/invalid-pattern-error.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-pattern-error.yaml
@@ -1,0 +1,4 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-pattern-test

--- a/test/e2e/chainsaw/check-validation-markers/invalid-pattern-instance.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-pattern-instance.yaml
@@ -1,0 +1,10 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-pattern-test
+spec:
+  email: invalid-email-format
+  username: testuser
+  tags:
+    - test
+  replicas: 1

--- a/test/e2e/chainsaw/check-validation-markers/invalid-unique-error.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-unique-error.yaml
@@ -1,0 +1,4 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-unique-test

--- a/test/e2e/chainsaw/check-validation-markers/invalid-unique-instance.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/invalid-unique-instance.yaml
@@ -1,0 +1,12 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: invalid-unique-test
+spec:
+  email: user@example.com
+  username: testuser
+  tags:
+    - production
+    - staging
+    - production  # Duplicate violates uniqueItems=true
+  replicas: 1

--- a/test/e2e/chainsaw/check-validation-markers/rgd-assert.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/rgd-assert.yaml
@@ -1,0 +1,33 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: check-validation-markers
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: ValidationTestApp
+    spec:
+      email: string | pattern="^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" description="Valid email address"
+      username: string | minLength=3 maxLength=15 pattern="^[a-zA-Z0-9_]+$" description="Username must be 3-15 chars, alphanumeric and underscore only"
+      tags: "[]string | uniqueItems=true minItems=1 maxItems=3 description=\"1-3 unique tags\""
+      priorities: "[]integer | minItems=0 maxItems=3 description=\"Up to 3 priority levels\""
+      description: string | default="Test application" maxLength=100
+      replicas: integer | default=1 minimum=1 maximum=10
+  resources:
+    - id: configmap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-config
+        data:
+          properties: |
+            email: ${schema.spec.email}
+            username: ${schema.spec.username}
+            description: ${schema.spec.description}
+            tags: ${schema.spec.tags}
+            replicas: ${schema.spec.replicas}
+status:
+  (conditions[?type == 'Ready']):
+    - status: 'True'
+  state: "Active"

--- a/test/e2e/chainsaw/check-validation-markers/rgd.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/rgd.yaml
@@ -1,0 +1,40 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: check-validation-markers
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: ValidationTestApp
+    spec:
+      # String validation with pattern
+      email: string | pattern="^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" description="Valid email address"
+      
+      # String validation with length constraints
+      username: string | minLength=3 maxLength=15 pattern="^[a-zA-Z0-9_]+$" description="Username must be 3-15 chars, alphanumeric and underscore only"
+      
+      # Array validation with unique items and size constraints
+      tags: "[]string | uniqueItems=true minItems=1 maxItems=3 description=\"1-3 unique tags\""
+      
+      # Array validation with size constraints only
+      priorities: "[]integer | minItems=0 maxItems=3 description=\"Up to 3 priority levels\""
+      
+      # Optional field for testing defaults
+      description: string | default="Test application" maxLength=100
+      
+      # Numeric validation (existing markers)
+      replicas: integer | default=1 minimum=1 maximum=10
+  resources:
+    - id: configmap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-config
+        data:
+          properties: |
+            email: ${schema.spec.email}
+            username: ${schema.spec.username}
+            description: ${schema.spec.description}
+            tags: ${schema.spec.tags}
+            replicas: ${schema.spec.replicas}

--- a/test/e2e/chainsaw/check-validation-markers/valid-instance-assert.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/valid-instance-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: valid-test-app
+spec:
+  email: user@example.com
+  username: testuser123
+  tags:
+    - production
+    - frontend
+    - webapp
+  description: A test application
+  replicas: 3
+status:
+  (conditions[?type == 'InstanceSynced']):
+    - status: 'True'
+  state: "ACTIVE"

--- a/test/e2e/chainsaw/check-validation-markers/valid-instance.yaml
+++ b/test/e2e/chainsaw/check-validation-markers/valid-instance.yaml
@@ -1,0 +1,16 @@
+apiVersion: kro.run/v1alpha1
+kind: ValidationTestApp
+metadata:
+  name: valid-test-app
+spec:
+  email: user@example.com
+  username: testuser123
+  tags:
+    - production
+    - frontend
+    - webapp
+  priorities:
+    - 1
+    - 3
+  description: A test application
+  replicas: 3

--- a/website/docs/docs/concepts/10-simple-schema.md
+++ b/website/docs/docs/concepts/10-simple-schema.md
@@ -194,8 +194,66 @@ mode: string | enum="debug,info,warn,error" default="info"
 - `minimum=value`: Minimum value for numbers
 - `maximum=value`: Maximum value for numbers
 - `immutable=true`: Field cannot be changed after creation
+- `pattern="regex"`: Regular expression pattern for string validation
+- `minLength=number`: Minimum length for strings
+- `maxLength=number`: Maximum length for strings
+- `uniqueItems=true`: Ensures array elements are unique
+- `minItems=number`: Minimum number of items in arrays
+- `maxItems=number`: Maximum number of items in arrays
 
 Multiple markers can be combined using the `|` separator.
+
+### String Validation Markers
+
+String fields support additional validation markers:
+
+- **`pattern="regex"`**: Validates the string against a regular expression pattern
+- **`minLength=number`**: Sets the minimum number of characters
+- **`maxLength=number`**: Sets the maximum number of characters
+
+Examples:
+
+```yaml
+# Email validation
+email: string | pattern="^[\\w\\.-]+@[\\w\\.-]+\\.\\w+$" required=true
+
+# Username with length constraints and pattern
+username: string | minLength=3 maxLength=15 pattern="^[a-zA-Z0-9_]+$"
+
+# Country code format
+countryCode: string | pattern="^[A-Z]{2}$" minLength=2 maxLength=2
+
+# Password with minimum length
+password: string | minLength=8 description="Password must be at least 8 characters"
+```
+
+### Array Validation Markers
+
+Array fields support validation markers to ensure data quality:
+
+- **`uniqueItems=true`**: Ensures all elements in the array are unique
+- **`uniqueItems=false`**: Allows duplicate elements (default behavior)
+- **`minItems=number`**: Sets the minimum number of elements required in the array
+- **`maxItems=number`**: Sets the maximum number of elements allowed in the array
+
+Examples:
+
+```yaml
+# Unique tags with size constraints
+tags: "[]string" | uniqueItems=true minItems=1 maxItems=10 description="1-10 unique tags"
+
+# Unique port numbers with minimum requirement
+ports: "[]integer" | uniqueItems=true minItems=1 description="At least one unique port"
+
+# Allow duplicate comments with size limits
+comments: "[]string" | uniqueItems=false maxItems=50 description="Up to 50 comments"
+
+# Complex validation with multiple markers
+roles: "[]string" | uniqueItems=true minItems=1 maxItems=5 required=true description="1-5 unique user roles"
+
+# Optional array with size constraints
+priorities: "[]integer" | minItems=0 maxItems=3 description="Up to 3 priority levels"
+```
 
 For example:
 
@@ -205,6 +263,9 @@ id: string | required=true immutable=true description="Unique identifier"
 replicas: integer | default=3 minimum=1 maximum=10
 price: float | minimum=0.01 maximum=999.99
 mode: string | enum="debug,info,warn,error" default="info"
+email: string | pattern="^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" description="Valid email address"
+username: string | minLength=3 maxLength=20 pattern="^[a-zA-Z0-9_]+$"
+tags: "[]string" | uniqueItems=true minItems=1 maxItems=10 description="1-10 unique tags"
 ```
 
 ## Status Fields


### PR DESCRIPTION
Hi

I noticed that simpleschema currently doesn’t support some common string-related JSON Schema markers such as pattern, minLength, and maxLength.
Since these are widely used in k8s, I was a bit surprised they weren’t already supported.

In this PR i added new marker types: pattern, minLength, maxLength and uniqueItems

Question for the maintainers:
Is there a specific reason why these markers were not supported so far (e.g., intentionally left out), or was it more a case of “not yet implemented”?

I opened this PR mainly to start the discussion. If these markers are welcome, I’d be happy to extend the PR with docs and tests.

Thanks for the feedback 🙏