### PR TITLE
feat: Add TTL based caching to schema resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,10 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/sync v0.12.0
 	golang.org/x/time v0.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.0
 	k8s.io/apimachinery v0.31.0
@@ -99,7 +101,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kro-run/kro/pkg/graph/emulator"
 	"github.com/kro-run/kro/pkg/graph/parser"
 	"github.com/kro-run/kro/pkg/graph/schema"
+	schemaresolver "github.com/kro-run/kro/pkg/graph/schema/resolver"
 	"github.com/kro-run/kro/pkg/graph/variable"
 	"github.com/kro-run/kro/pkg/metadata"
 	"github.com/kro-run/kro/pkg/simpleschema"
@@ -46,7 +47,7 @@ import (
 func NewBuilder(
 	clientConfig *rest.Config,
 ) (*Builder, error) {
-	schemaResolver, dc, err := schema.NewCombinedResolver(clientConfig)
+	schemaResolver, dc, err := schemaresolver.NewCombinedResolver(clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create schema resolver: %w", err)
 	}

--- a/pkg/graph/schema/resolver/metrics.go
+++ b/pkg/graph/schema/resolver/metrics.go
@@ -1,0 +1,69 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// Cache hit/miss metrics
+	cacheHitsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kro_schema_resolver_cache_hits_total",
+		Help: "Total number of schema resolver cache hits",
+	})
+	cacheMissesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kro_schema_resolver_cache_misses_total",
+		Help: "Total number of schema resolver cache misses",
+	})
+
+	// Cache size metric
+	cacheSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kro_schema_resolver_cache_size",
+		Help: "Current number of entries in the schema resolver cache",
+	})
+
+	// Cache evictions
+	cacheEvictionsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kro_schema_resolver_cache_evictions_total",
+		Help: "Total number of entries evicted from the schema resolver cache",
+	})
+
+	// API call duration
+	apiCallDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "kro_schema_resolver_api_call_duration_seconds",
+		Help:    "Duration of API calls to fetch schemas",
+		Buckets: prometheus.ExponentialBuckets(0.01, 2, 10), // 10ms to ~10s
+	})
+
+	// Singleflight deduplicated requests
+	singleflightDeduplicatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kro_schema_resolver_singleflight_deduplicated_total",
+		Help: "Total number of requests that were deduplicated by singleflight",
+	})
+)
+
+func init() {
+	// Register metrics with the controller-runtime metrics registry
+	metrics.Registry.MustRegister(
+		cacheHitsTotal,
+		cacheMissesTotal,
+		cacheSize,
+		cacheEvictionsTotal,
+		apiCallDuration,
+		singleflightDeduplicatedTotal,
+	)
+}

--- a/pkg/graph/schema/resolver/resolver.go
+++ b/pkg/graph/schema/resolver/resolver.go
@@ -12,29 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package resolver
 
 import (
+	"time"
+
 	"k8s.io/apiextensions-apiserver/pkg/generated/openapi"
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 )
 
 // NewCombinedResolver creates a new schema resolver that can resolve both core and client types.
-func NewCombinedResolver(clientConfig *rest.Config) (resolver.SchemaResolver, *discovery.DiscoveryClient, error) {
+func NewCombinedResolver(clientConfig *rest.Config) (resolver.SchemaResolver, discovery.DiscoveryInterface, error) {
+	// Create a regular discovery client first
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Wrap it with memory-only caching
+	// This caches discovery information in memory with a TTL
+	memCachedDiscoveryClient := memory.NewMemCacheClient(discoveryClient)
 
 	// ClientResolver is a resolver that uses the discovery client to resolve
 	// client types. It is used to resolve types that are not known at compile
 	// time a.k.a present in:
 	// https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/generated/openapi/zz_generated.openapi.go
 	clientResolver := &resolver.ClientDiscoveryResolver{
-		Discovery: discoveryClient,
+		Discovery: memCachedDiscoveryClient,
 	}
 
 	// CoreResolver is a resolver that uses the OpenAPI definitions to resolve
@@ -47,5 +55,10 @@ func NewCombinedResolver(clientConfig *rest.Config) (resolver.SchemaResolver, *d
 	// Combine the two resolvers to create a single resolver that can resolve
 	// both core and client types.
 	combinedResolver := coreResolver.Combine(clientResolver)
-	return combinedResolver, discoveryClient, nil
+
+	// Wrap with cache to avoid repeated schema resolutions
+	// Adjust maxSize based on your expected number of unique GVKs
+	cachedResolver := NewTTLCachedSchemaResolver(combinedResolver, 1000, 180*time.Minute)
+
+	return cachedResolver, memCachedDiscoveryClient, nil
 }

--- a/pkg/graph/schema/resolver/ttl_cached.go
+++ b/pkg/graph/schema/resolver/ttl_cached.go
@@ -1,0 +1,168 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"k8s.io/utils/clock"
+)
+
+// TTLCachedSchemaResolver caches schemas with time-based expiration and deduplicates concurrent requests
+type TTLCachedSchemaResolver struct {
+	mu sync.RWMutex
+
+	// maxSize is the maximum number of entries in the cache. 0 means no limit.
+	// When the cache exceeds this size, the oldest entry will be removed.
+	// This is a simple eviction policy and can be improved with more complex ones
+	// like LRU if needed.
+	maxSize int
+	// ttl is the time-to-live for cached schemas.
+	ttl time.Duration
+
+	// delegate is the underlying resolver to fetch schemas from when not in cache. a.k.a the actual
+	// culprit that does the API calls to fetch OpenAPI schemas.
+	delegate resolver.SchemaResolver
+
+	// cache is the in memory cache of resolved schemas.
+	cache map[schema.GroupVersionKind]*cacheEntry
+
+	// Deduplicate concurrent requests for the same GVK - if multiple RGD reconciliations are
+	// trying to resolve the same schema at the same time, only one will do the work
+	// and the others will wait for the result.
+	sf singleflight.Group
+
+	// clock for testing purposes
+	clock clock.Clock
+}
+
+// cacheEntry represents a cached schema entry with its registration timestamp.
+type cacheEntry struct {
+	schema    *spec.Schema
+	timestamp time.Time
+}
+
+// NewTTLCachedSchemaResolver creates a new TTLCachedSchemaResolver with the given delegate resolver,
+func NewTTLCachedSchemaResolver(
+	delegate resolver.SchemaResolver,
+	maxSize int,
+	ttl time.Duration,
+) *TTLCachedSchemaResolver {
+	return &TTLCachedSchemaResolver{
+		delegate: delegate,
+		cache:    make(map[schema.GroupVersionKind]*cacheEntry),
+		maxSize:  maxSize,
+		ttl:      ttl,
+		clock:    clock.RealClock{},
+	}
+}
+
+// ResolveSchema resolves the schema for the given GroupVersionKind, using the cache if possible.
+// If multiple concurrent requests for the same GVK are made, they will be deduplicated.
+func (c *TTLCachedSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	// Check cache first
+	c.mu.RLock()
+	if entry, ok := c.cache[gvk]; ok {
+		if c.clock.Since(entry.timestamp) < c.ttl {
+			c.mu.RUnlock()
+			cacheHitsTotal.Inc()
+			return entry.schema, nil
+		}
+		// Entry expired, will refetch
+	}
+	c.mu.RUnlock()
+
+	cacheMissesTotal.Inc()
+
+	// Use singleflight to ensure only one API call per GVK
+	key := gvk.String()
+	result, err, shared := c.sf.Do(key, func() (interface{}, error) {
+		// Double-check cache inside singleflight (another goroutine might have populated it)
+		c.mu.RLock()
+		if entry, ok := c.cache[gvk]; ok {
+			if c.clock.Since(entry.timestamp) < c.ttl {
+				c.mu.RUnlock()
+				return entry.schema, nil
+			}
+		}
+		c.mu.RUnlock()
+
+		// Actually fetch from delegate
+		start := c.clock.Now()
+		schemaResolver, err := c.delegate.ResolveSchema(gvk)
+		apiCallDuration.Observe(c.clock.Since(start).Seconds())
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Store in cache
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		// Evict expired entries first
+		evicted := 0
+		for k, v := range c.cache {
+			if c.clock.Since(v.timestamp) >= c.ttl {
+				delete(c.cache, k)
+				evicted++
+			}
+		}
+
+		// If still over limit, remove oldest
+		if len(c.cache) >= c.maxSize && c.maxSize > 0 {
+			var oldestKey schema.GroupVersionKind
+			var oldestTime time.Time
+			first := true
+			for k, v := range c.cache {
+				if first || v.timestamp.Before(oldestTime) {
+					oldestKey = k
+					oldestTime = v.timestamp
+					first = false
+				}
+			}
+			delete(c.cache, oldestKey)
+			evicted++
+		}
+
+		if evicted > 0 {
+			cacheEvictionsTotal.Add(float64(evicted))
+		}
+
+		c.cache[gvk] = &cacheEntry{
+			schema:    schemaResolver,
+			timestamp: c.clock.Now(),
+		}
+
+		cacheSize.Set(float64(len(c.cache)))
+
+		return schemaResolver, nil
+	})
+
+	if shared {
+		singleflightDeduplicatedTotal.Inc()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result.(*spec.Schema), nil
+}

--- a/pkg/graph/schema/resolver/ttl_cached_test.go
+++ b/pkg/graph/schema/resolver/ttl_cached_test.go
@@ -1,0 +1,137 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	fake "k8s.io/utils/clock/testing"
+)
+
+// mockResolver tracks call counts calls, mainly trying to catch redundant calls
+type mockResolver struct {
+	callCount int32
+	schemas   map[schema.GroupVersionKind]*spec.Schema
+}
+
+func newMockResolver() *mockResolver {
+	return &mockResolver{
+		schemas: make(map[schema.GroupVersionKind]*spec.Schema),
+	}
+}
+
+func (m *mockResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	atomic.AddInt32(&m.callCount, 1)
+
+	// Return a dummy schema
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+		},
+	}, nil
+}
+
+func (m *mockResolver) getCallCount() int {
+	return int(atomic.LoadInt32(&m.callCount))
+}
+
+func TestTTLCachedSchemaResolver_ConcurrentCallCounting(t *testing.T) {
+	mock := newMockResolver()
+	cachedResolver := NewTTLCachedSchemaResolver(mock, 100, 1*time.Hour)
+
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+	// launch 50 concurrent reads, only one should win, the rest should wait
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := cachedResolver.ResolveSchema(gvk)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// should have only called mock once due to singleflight
+	if calls := mock.getCallCount(); calls != 1 {
+		t.Errorf("expected 1 call with concurrent access, got %d", calls)
+	}
+}
+
+func TestTTLCachedSchemaResolver_DifferentGVKCallCounting(t *testing.T) {
+	mock := newMockResolver()
+	cachedResolver := NewTTLCachedSchemaResolver(mock, 100, 1*time.Hour)
+
+	gvks := []schema.GroupVersionKind{
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+		{Group: "batch", Version: "v1", Kind: "Job"},
+	}
+
+	// call each GVK twice
+	for _, gvk := range gvks {
+		for i := 0; i < 2; i++ {
+			_, err := cachedResolver.ResolveSchema(gvk)
+			if err != nil {
+				t.Fatalf("unexpected error for %v: %v", gvk, err)
+			}
+		}
+	}
+
+	// Should have called mock once per unique GVK
+	if calls := mock.getCallCount(); calls != len(gvks) {
+		t.Errorf("expected %d calls for %d unique GVKs, got %d", len(gvks), len(gvks), calls)
+	}
+}
+
+func TestTTLCachedSchemaResolver_ExpiryCallCounting(t *testing.T) {
+	mock := newMockResolver()
+	// Short TTL for testing
+
+	cachedResolver := NewTTLCachedSchemaResolver(mock, 100, 50*time.Millisecond)
+
+	// Use fake clock for time travel
+	fakeClock := fake.NewFakeClock(time.Now())
+	cachedResolver.clock = fakeClock
+
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+	// First call
+	_, _ = cachedResolver.ResolveSchema(gvk)
+
+	if calls := mock.getCallCount(); calls != 1 {
+		t.Errorf("expected 1 initial call, got %d", calls)
+	}
+
+	// Advance clock beyond TTL
+	fakeClock.Step(500 * time.Millisecond)
+
+	// Call again after expiry
+	_, _ = cachedResolver.ResolveSchema(gvk)
+
+	// Should have called mock twice now
+	if calls := mock.getCallCount(); calls != 2 {
+		t.Errorf("expected 2 calls after TTL expiry, got %d", calls)
+	}
+}


### PR DESCRIPTION
Performance testing with 100 RGDs and 100 concurrent reconcile workers revealed
the schema resolver was a major bottleneck. Memory profiling showed `ResolveSchema`
alone was consuming 78MB due to repeatedly fetching the same schemas (pods) from the
API server. The constant API calls were also triggering client side throttling,
with requests waiting over a second just due to rate limits.

This patch adds a caching layer that stores resolved schemas in memory with a 3 hour
TTL. To handle the concurrent access, using `x/singleflight` to ensure only one
worker fetches a schema while others wait for the result. The cache is capped
at 1000 entries to prevent unbounded growth.

After this change, ResolveSchema memory usage dropped to ~3MB and the
throttling warnings disappeared. Prometheus metrics were added to monitor cache
performance in production.

Tested with the same 100 RGDs and 100 concurrent workers - runs smoothly now
without the memory spikes or API server overloads.