### PR TITLE
chore: Tidy up lack of parity on dynamic controller interface

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -56,7 +56,7 @@ func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx c
 // shutdownResourceGraphDefinitionMicroController stops the dynamic controller associated with the given GVR.
 // This ensures no new reconciliations occur for this resource type.
 func (r *ResourceGraphDefinitionReconciler) shutdownResourceGraphDefinitionMicroController(ctx context.Context, gvr *schema.GroupVersionResource) error {
-	if err := r.dynamicController.StopServiceGVK(ctx, *gvr); err != nil {
+	if err := r.dynamicController.Deregister(ctx, *gvr); err != nil {
 		return fmt.Errorf("error stopping service: %w", err)
 	}
 	return nil

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -166,7 +166,7 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinitionCRD(
 
 // reconcileResourceGraphDefinitionMicroController starts the microcontroller for handling the resources
 func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinitionMicroController(ctx context.Context, gvr *schema.GroupVersionResource, handler dynamiccontroller.Handler) error {
-	err := r.dynamicController.StartServingGVK(ctx, *gvr, handler)
+	err := r.dynamicController.Register(ctx, *gvr, handler)
 	if err != nil {
 		return newMicroControllerError(err)
 	}

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -440,8 +440,8 @@ func (dc *DynamicController) enqueueObject(obj interface{}, eventType string) {
 	dc.queue.Add(objectIdentifiers)
 }
 
-// StartServingGVK registers a new GVK to the informers map safely.
-func (dc *DynamicController) StartServingGVK(ctx context.Context, gvr schema.GroupVersionResource, handler Handler) error {
+// Register registers a new GVK to the informers map safely.
+func (dc *DynamicController) Register(ctx context.Context, gvr schema.GroupVersionResource, handler Handler) error {
 	dc.log.V(1).Info("Registering new GVK", "gvr", gvr)
 
 	_, exists := dc.informers.Load(gvr)
@@ -519,14 +519,14 @@ func (dc *DynamicController) StartServingGVK(ctx context.Context, gvr schema.Gro
 	return nil
 }
 
-// UnregisterGVK safely removes a GVK from the controller and cleans up associated resources.
-func (dc *DynamicController) StopServiceGVK(ctx context.Context, gvr schema.GroupVersionResource) error {
+// Deregister safely removes a GVK from the controller and cleans up associated resources.
+func (dc *DynamicController) Deregister(ctx context.Context, gvr schema.GroupVersionResource) error {
 	dc.log.Info("Unregistering GVK", "gvr", gvr)
 
 	// Retrieve the informer
 	informerObj, ok := dc.informers.Load(gvr)
 	if !ok {
-		dc.log.V(1).Info("GVK not registered, nothing to unregister", "gvr", gvr)
+		dc.log.V(1).Info("GVK not registered, nothing to deregister", "gvr", gvr)
 		return nil
 	}
 

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -117,20 +117,20 @@ func TestRegisterAndUnregisterGVK(t *testing.T) {
 	})
 
 	// Register GVK
-	err := dc.StartServingGVK(context.Background(), gvr, handlerFunc)
+	err := dc.Register(context.Background(), gvr, handlerFunc)
 	require.NoError(t, err)
 
 	_, exists := dc.informers.Load(gvr)
 	assert.True(t, exists)
 
 	// Try to register again (should not fail)
-	err = dc.StartServingGVK(context.Background(), gvr, handlerFunc)
+	err = dc.Register(context.Background(), gvr, handlerFunc)
 	assert.NoError(t, err)
 
 	// Unregister GVK
 	shutdownContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err = dc.StopServiceGVK(shutdownContext, gvr)
+	err = dc.Deregister(shutdownContext, gvr)
 	require.NoError(t, err)
 
 	_, exists = dc.informers.Load(gvr)
@@ -189,7 +189,7 @@ func TestInstanceUpdatePolicy(t *testing.T) {
 	})
 
 	// simulate initial creation of the resource graph
-	err := dc.StartServingGVK(context.Background(), gvr, handlerFunc)
+	err := dc.Register(context.Background(), gvr, handlerFunc)
 	assert.NoError(t, err)
 
 	// simulate reconciling the instances
@@ -200,7 +200,7 @@ func TestInstanceUpdatePolicy(t *testing.T) {
 	}
 
 	// simulate updating the resource graph
-	err = dc.StartServingGVK(context.Background(), gvr, handlerFunc)
+	err = dc.Register(context.Background(), gvr, handlerFunc)
 	assert.NoError(t, err)
 
 	// check if the expected objects are queued


### PR DESCRIPTION
While playing around with dynamic controller, I noticed that our names were askew:
* StopServiceGVK
* StartServingGVK

I also noticed that our comments referred to a "registration" concept that is commonly used in controller runtime. Feel free to reject if there are any consumers of this that I am not aware of.