### PR TITLE
chore: Hydrate goproxy after each push

### DIFF
--- a/.github/workflows/postsubmit.yaml
+++ b/.github/workflows/postsubmit.yaml
@@ -1,0 +1,16 @@
+name: postsubmit
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  postsubmit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: hydrate-goproxy
+      run: |
+        mkdir -p hydrate-goproxy
+        cd hydrate-goproxy
+        go mod init hydrate-goproxy
+        go get github.com/kubernetes-sigs/kro@${GITHUB_SHA}


### PR DESCRIPTION
Modules don't land in goproxy until they are depended on by another package and pulled through the proxy. Some corporate firewalls (...) synchronize from go proxy, and until packages are hydrated there, they cannot be reflected into internal build systems. This change automates that pull and makes sure the proxy always has the latest version.

See: https://github.com/awslabs/operatorpkg/blob/main/.github/workflows/postsubmit.yaml