### PR TITLE
KREP-011: RGD Variables

### DIFF
--- a/docs/design/proposals/variables.md
+++ b/docs/design/proposals/variables.md
@@ -1,0 +1,495 @@
+# KREP-011: RGD Variables
+
+## Problem statement
+
+kro does not support intermediate computed values in ResourceGraphDefinitions.
+This creates two problems:
+
+1. **No reusable expressions.** When a complex CEL expression like
+   `${schema.metadata.name + '-' + schema.spec.environment}` is needed across
+   multiple resources, users must copy-paste it into every resource that uses it.
+   Updating the expression requires changes in every location, creating
+   maintenance burden and risk of inconsistency.
+
+2. **No computed lists inside a resource.** If a user wants to define a list of
+   containers as a template and reference it inside a Pod spec, there is no way
+   to do so today. `forEach` creates multiple *resources*, but there is no
+   mechanism to produce a computed *value* (like an array) that can be embedded
+   within a single resource's template.
+
+Refs: 
+- https://github.com/kubernetes-sigs/kro/issues/1008
+- https://github.com/kubernetes-sigs/kro/issues/781
+
+## Proposal
+
+This proposal introduces **variable nodes** — a new resource node type in the RGD
+that computes values without creating Kubernetes resources. Variable nodes
+participate in the DAG alongside template and externalRef nodes, enabling
+reusable expressions and computed lists that other resources can reference.
+
+### Overview
+
+Extend the RGD `resources` field to support a new node type: **variable nodes**.
+Today, each entry in `resources` is either:
+
+- A **template** node — kro creates and manages a Kubernetes resource.
+- An **externalRef** node — kro reads an existing Kubernetes resource (read-only).
+
+This proposal adds:
+
+- A **variable** node — kro computes values without creating any Kubernetes resource.
+
+Variable nodes participate in the DAG like any other node. They can reference
+`schema.spec` fields and other resources, and downstream resources can reference
+them. They support `forEach`, `includeWhen`, and `readyWhen`.
+
+### Design details
+
+#### Variable node structure
+
+A variable node uses a `variable` field (mutually exclusive with `template` and
+`externalRef`). The `variable` field must be a map (key-value pairs). Values
+within the map can be constants, CEL expressions, arrays, or nested objects.
+
+Values within a variable node can be:
+
+- **Constants:** literal values the user wants to reuse throughout the RGD.
+- **Static variables:** CEL expressions referencing `schema.spec` — the type is
+  known at compile time (RGD reconciler) and the value is provided at runtime
+  (instance reconciler).
+- **Dynamic variables:** CEL expressions referencing other resources in the RGD,
+  creating dependencies in the DAG.
+
+```yaml
+- id: vars
+  variable:
+    prefix: constant-value
+    name: ${schema.spec.name}
+    podName: ${myPod.metadata.name}
+```
+
+#### Referencing variable nodes
+
+Variable nodes can be referenced by any resource or other variable nodes in the RGD,
+as long as it's not cyclic. References work in two ways:
+
+- **By path:** `${vars.prefix}`, `${vars.name}` — accesses a specific field
+  within the variable node's map.
+- **By id:** `${vars}` — receives the entire map structure.
+
+Standard kro type validation applies at compile time: the type of the field
+where the variable is used must match the type of the referenced value.
+
+A variable node's top-level keys must not match its own id. Since variable node fields
+are referenced as `${<id>.<key>}`, a key matching the id would create confusion
+about whether `${naming.naming}` refers to the node itself or a nested field.
+For example, the following is invalid:
+
+```yaml
+- id: naming
+  variable:
+    naming: ${schema.spec.name}  # error: top-level key "naming" matches node id
+    prefix: ${schema.spec.name + '-' + schema.spec.environment}
+```
+
+#### forEach with variable nodes
+
+Variable nodes support `forEach`, producing an array of computed values rather than
+multiple Kubernetes resources. This addresses problem #2 — computed lists that
+can be embedded within a single resource template.
+
+**Example: shared container list across Deployment and StatefulSet**
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: shared-pod-template
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: MyApp
+    spec:
+      appImage: string
+      workers: "[]string"
+  resources:
+    # Variable node: compute a list of containers using forEach
+    - id: containers
+      forEach:
+        - worker: ${schema.spec.workers}
+      variable:
+        name: ${worker}
+        image: ${schema.spec.appImage}
+        command: ["process", "${worker}"]
+
+    # Both Deployment and StatefulSet reference the same container list
+    - id: deployment
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${schema.metadata.name + '-deploy'}
+        spec:
+          template:
+            spec:
+              containers: ${containers}
+
+    - id: statefulset
+      template:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: ${schema.metadata.name + '-sts'}
+        spec:
+          template:
+            spec:
+              containers: ${containers}
+```
+
+Without variables, the user would have to duplicate the container definitions
+in both the Deployment and the StatefulSet, and any change to the container
+spec would need to be made in both places.
+
+**Example: DRY naming prefix**
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: my-app
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: MyApp
+    spec:
+      environment: string
+      module: string
+  resources:
+    - id: naming
+      variable:
+        prefix: ${schema.metadata.name + '-' + schema.spec.environment}
+        sanitizedModule: ${schema.spec.module.replace('.', '-').replace('_', '-').replace('/', '-')}
+
+    - id: configmap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${naming.prefix + '-config'}
+
+    - id: deployment
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${naming.prefix + '-' + naming.sanitizedModule}
+        spec: ...
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${naming.prefix + '-svc'}
+        spec: ...
+```
+
+**Example: dynamic variable referencing resource output**
+
+```yaml
+- id: vpc
+  template:
+    apiVersion: ec2.services.k8s.aws/v1alpha1
+    kind: VPC
+    metadata:
+      name: ${schema.metadata.name + '-vpc'}
+    spec: ...
+
+- id: vpcInfo
+  variable:
+    region: ${vpc.status.ackResourceMetadata.region}
+    vpcId: ${vpc.status.vpcID}
+    fullName: ${schema.metadata.name + '-' + schema.spec.environment + '-' + vpc.status.ackResourceMetadata.region}
+
+- id: subnet
+  template:
+    apiVersion: ec2.services.k8s.aws/v1alpha1
+    kind: Subnet
+    metadata:
+      name: ${vpcInfo.fullName + '-subnet'}
+    spec:
+      vpcID: ${vpcInfo.vpcId}
+```
+
+#### DAG representation
+
+Each variable node is a single node in the DAG. Dependencies are extracted from its
+CEL expressions the same way they are for template and externalRef nodes. If
+`vars.podName` references `${myPod.metadata.name}`, then `vars` depends on
+`myPod`.
+
+A downstream resource that references `${vars.prefix}` depends on the `vars`
+node, which means it waits for all of `vars`'s own dependencies to resolve
+before evaluating.
+
+#### Type inference
+
+Template nodes infer types from the Kubernetes resource schema (OpenAPI). Variable
+nodes need a different approach since there is no Kubernetes schema backing them.
+
+kro already handles this pattern for RGD instance status fields, which are also
+schemaless `runtime.RawExtension` content containing CEL expressions. The
+existing `parser.ParseSchemalessResource` function (in `pkg/graph/parser/`)
+recursively walks a `map[string]interface{}` structure, extracting CEL
+expressions as `FieldDescriptor`s and identifying plain (constant) field paths.
+Variable nodes can reuse this same parser to:
+
+- **Extract CEL expressions** from the data content and feed them into the CEL
+  compiler, which infers the return type from the expression and the known types
+  of referenced nodes.
+- **Identify constant fields** and infer their types from the parsed YAML values
+  (`5` is an integer, `"hello"` is a string, `true` is a boolean, `[1, 2, 3]`
+  is an integer array, nested maps preserve their structure).
+
+This reuse means variable node type inference requires no new parsing infrastructure
+— the same code path that handles instance status fields applies directly.
+
+## Other solutions considered
+
+### 1. ConfigMap as variable storage
+
+Users can store values in a ConfigMap resource within the RGD and reference its
+fields from other resources:
+
+```yaml
+resources:
+  - id: vars
+    template:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ${schema.metadata.name + '-vars'}
+      data:
+        prefix: ${schema.metadata.name + '-' + schema.spec.environment}
+        sanitizedModule: ${schema.spec.module.replace('.', '-').replace('_', '-')}
+
+  - id: deployment
+    template:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ${vars.data.prefix + '-deploy'}
+      spec: ...
+```
+
+Issues with this approach:
+
+- ConfigMap `data` only supports `map[string]string`, so it cannot hold complex
+  typed data (integers, booleans, arrays, nested objects).
+- It creates an actual Kubernetes resource in the cluster just to hold
+  intermediate values, which is wasteful.
+
+### 2. Separate "variable" RGD
+
+Users can create a dedicated RGD with no resources and a schema that serves as
+a variable container, then include an instance of it inside the RGD where they
+need the variables.
+
+```yaml
+# A dedicated "variable" RGD
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: variable-rgd
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Variable
+    spec:
+      complexStringVar: string
+      constantVar: integer | default=5
+---
+# The actual RGD that uses it
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+spec:
+  schema:
+    spec:
+      name: string
+  resources:
+    - id: variableResource
+      template:
+        apiVersion: kro.run/v1alpha1
+        kind: Variable
+        metadata:
+          name: variableInstance
+        spec:
+          complexStringVar: ${schema.spec.name.split('.')[0]}
+    - id: myPod
+      template:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: ${variableResource.spec.complexStringVar}-pod
+```
+
+Issues with this approach:
+
+- **RGD proliferation:** Users need a new RGD for every distinct variable
+  "shape" they want. Each variable RGD generates a CRD, a dynamic controller,
+  and an instance — significant overhead for storing a few computed values.
+- **Management burden:** kro must reconcile both the variable RGD and its
+  instances. Variable instances go through the full lifecycle (CRD creation,
+  instance reconciliation, status tracking) even though they manage no actual
+  Kubernetes resources.
+- **Hidden dependencies:** Creates implicit coupling between RGDs. Deleting or
+  modifying the variable RGD breaks all RGDs that reference its kind. These
+  cross-RGD dependencies are not visible in any single RGD's DAG.
+
+## Scoping
+
+### What is in scope for this proposal?
+
+- The `variable` field on resources as a new node type (mutually exclusive with
+  `template` and `externalRef`), must be a map of key-value pairs
+- Constants, static variables, and dynamic variables within variable nodes
+- DAG participation: variable nodes as dependencies and dependents
+- `forEach` support on variable nodes to produce computed arrays
+- `includeWhen` support on variable nodes for conditional computation
+- `readyWhen` support on variable nodes
+- Type inference for variable node fields via `parser.ParseSchemalessResource`
+- Referencing variable nodes by id (whole map) or by path (specific field)
+
+### What is not in scope?
+
+- **Schema-level locals:** A separate `locals` field on the schema (option 1
+  from the GitHub issue). The resource-level approach is more flexible since it
+  can reference resource outputs.
+- **Mutable variables:** Variable nodes are computed once per reconciliation cycle,
+  not reassigned.
+
+## Testing strategy
+
+### Requirements
+
+- envtest-based integration test environment (existing infrastructure)
+- Unit tests for the graph builder changes (CEL parsing, DAG construction, type
+  inference for variable nodes)
+
+### Test plan
+
+- **Unit tests:**
+  - Variable node parsing and validation (constants, static vars, dynamic vars)
+  - DAG dependency extraction from variable node CEL expressions
+  - Type inference for variable node fields
+  - Mutual exclusivity validation (variable vs template vs externalRef)
+  - `readyWhen` evaluation on variable nodes
+  - forEach expansion on variable nodes producing arrays
+- **Integration tests:**
+  - RGD with variable nodes reconciles successfully and generates correct CRD
+  - Instance reconciliation evaluates variable node expressions in correct order
+  - Variable nodes with `forEach` produce correct arrays
+  - Variable nodes with `includeWhen` conditionally compute values
+  - Downstream resources correctly receive variable node values
+  - Circular dependency detection involving variable nodes
+- **E2E tests:**
+  - Full lifecycle: RGD with variable nodes -> instance creation -> resource
+    creation with correct computed values -> update -> deletion
+
+## Community discussions
+
+### `spec.variables` as an alternative placement
+
+An alternative to placing variable nodes in the `resources` array is a dedicated
+`spec.variables` field. Variables would have the same capabilities as variable
+nodes — DAG participation, resource output references, forEach, includeWhen —
+but live in their own section:
+
+```yaml
+spec:
+  schema: ...
+  variables:
+    - id: naming
+      data:
+        prefix: ${schema.spec.name + '-' + schema.spec.environment}
+    - id: vpcInfo
+      data:
+        vpcId: ${vpc.status.vpcID}
+  resources:
+    - id: vpc
+      template: ...
+    - id: subnet
+      template:
+        spec:
+          vpcID: ${vpcInfo.vpcId}
+```
+
+**Advantages:**
+
+- Clear visual separation between "compute values" and "kubernetes resources".
+- The `Resource` type stays focused on template vs externalRef.
+
+**Tradeoffs:**
+
+- Variable IDs and resource IDs must be unique across both arrays, but the
+  uniqueness constraint isn't obvious from the YAML structure since the entries
+  live in separate fields.
+
+Both approaches are nearly equivalent in implementation cost and user
+complexity. The `variable`-in-resources approach keeps all DAG participants in one
+place; `spec.variables` gives cleaner type separation.
+
+### Virtual resources as variable nodes
+
+Instead of introducing a new `variable` field, variable nodes could be modeled
+as **virtual resources** — resources that use the existing `template` field with
+a reserved apiVersion (`virtual.kro.run/v1alpha1`) and kind (`Variable`). kro
+would recognize this apiVersion/kind combination and treat the resource as a
+variable node: it participates in the DAG but no Kubernetes resource is created.
+
+```yaml
+resources:
+  - id: naming
+    template:
+      apiVersion: virtual.kro.run/v1alpha1
+      kind: Variable
+      data:
+        prefix: ${schema.spec.name + '-' + schema.spec.environment}
+        sanitizedModule: ${schema.spec.module.replace('.', '-')}
+
+  - id: deployment
+    template:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ${naming.prefix + '-deploy'}
+      spec: ...
+```
+
+**Advantages:**
+
+- No new field — reuses the familiar `template` syntax users already know.
+- **Explicit intent.** The `apiVersion` and `kind` make it unambiguous that this
+  is a variable node. Unlike the "template without apiVersion" approach, a
+  forgotten `apiVersion` on a real resource would still produce a validation
+  error rather than silently becoming a variable.
+- **Familiar structure.** Virtual resources follow the same shape as Kubernetes
+  resources (apiVersion, kind, data/spec), reducing cognitive overhead for users
+  already familiar with the Kubernetes resource model.
+- **Clear validation.** Since kro unmarshals the template into a `Variable`
+  struct, unknown fields produce natural error messages (e.g., "unknown field
+  `metadata` in Variable node"). No special validation logic is needed beyond
+  struct unmarshalling.
+- **Extensible.** The `virtual.kro.run` API group can host other virtual resource
+  kinds in the future without requiring new fields on the `Resource` type.
+
+**Tradeoffs:**
+
+- **Overloaded `template` semantics.** The `template` field would now mean two
+  different things depending on the apiVersion: "create this Kubernetes resource"
+  vs "compute these values internally." This dual meaning is subtler than a
+  dedicated `variable` field.
+- **Boilerplate.** Every variable node requires the `apiVersion` and `kind`
+  lines, adding two lines of YAML per variable node compared to the dedicated
+  `variable` field approach.

--- a/test/integration/suites/core/variable_node_test.go
+++ b/test/integration/suites/core/variable_node_test.go
@@ -1,0 +1,414 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Variable Nodes", func() {
+	var (
+		namespace string
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	Context("RGD Reconciliation", func() {
+		It("should reconcile RGD with variable nodes and generate correct CRD", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-data-node-rgd",
+				generator.WithSchema(
+					"TestDataNodeRGD", "v1alpha1",
+					map[string]interface{}{
+						"name":        "string",
+						"environment": "string",
+					},
+					nil,
+				),
+				generator.WithVariable("naming", map[string]interface{}{
+					"prefix": "${schema.spec.name + '-' + schema.spec.environment}",
+				}, nil, nil, nil),
+				generator.WithResource("configmap", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "${naming.prefix}-config",
+					},
+					"data": map[string]interface{}{
+						"env": "${schema.spec.environment}",
+					},
+				}, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+			})
+
+			// Wait for RGD to become active
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+				// Variable nodes should appear in topological order
+				g.Expect(rgd.Status.TopologicalOrder).To(ContainElement("naming"))
+				g.Expect(rgd.Status.TopologicalOrder).To(ContainElement("configmap"))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should reject RGD with stuttered variable key", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-data-stutter",
+				generator.WithSchema(
+					"TestDataStutter", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithVariable("naming", map[string]interface{}{
+					"naming": "stutter",
+				}, nil, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+			})
+
+			expectRGDInactiveWithError(ctx, rgd, "top-level key")
+		})
+	})
+
+	Context("Instance Reconciliation", func() {
+		It("should evaluate variable node expressions and pass values to downstream resources", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-data-instance",
+				generator.WithSchema(
+					"TestDataInstance", "v1alpha1",
+					map[string]interface{}{
+						"appName":     "string",
+						"environment": "string",
+					},
+					nil,
+				),
+				generator.WithVariable("fullName", "${schema.spec.appName + '-' + schema.spec.environment}", nil, nil, nil),
+				generator.WithResource("configmap", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "${fullName}",
+					},
+					"data": map[string]interface{}{
+						"name": "${fullName}",
+					},
+				}, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+			})
+
+			// Wait for RGD to become active
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Create instance
+			instance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+					"kind":       "TestDataInstance",
+					"metadata": map[string]interface{}{
+						"name":      "test-data",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"appName":     "myapp",
+						"environment": "prod",
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, instance)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				_ = env.Client.Delete(ctx, instance)
+			})
+
+			// Verify ConfigMap is created with the correct computed name
+			cm := &corev1.ConfigMap{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "myapp-prod",
+					Namespace: namespace,
+				}, cm)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cm.Data["name"]).To(Equal("myapp-prod"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Verify instance becomes ACTIVE
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "test-data",
+					Namespace: namespace,
+				}, instance)
+				g.Expect(err).ToNot(HaveOccurred())
+				state, found, _ := unstructured.NestedString(instance.Object, "status", "state")
+				g.Expect(found).To(BeTrue())
+				g.Expect(state).To(Equal("ACTIVE"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Cleanup: delete instance and verify ConfigMap is cleaned up
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "myapp-prod",
+					Namespace: namespace,
+				}, cm)
+				g.Expect(err).To(MatchError(errors.IsNotFound, "configmap should be deleted"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should support variable-to-variable references with correct evaluation order", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-data-chain",
+				generator.WithSchema(
+					"TestDataChain", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+						"env":  "string",
+					},
+					nil,
+				),
+				// First variable node: compute prefix
+				generator.WithVariable("naming", map[string]interface{}{
+					"prefix": "${schema.spec.name + '-' + schema.spec.env}",
+				}, nil, nil, nil),
+				// Second variable node: references first variable node
+				generator.WithVariable("labels", map[string]interface{}{
+					"app": "${naming.prefix + '-app'}",
+				}, nil, nil, nil),
+				// Template resource: uses second variable node
+				generator.WithResource("configmap", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "${naming.prefix}-cm",
+					},
+					"data": map[string]interface{}{
+						"appLabel": "${labels.app}",
+					},
+				}, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+			})
+
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			instance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+					"kind":       "TestDataChain",
+					"metadata": map[string]interface{}{
+						"name":      "test-chain",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"name": "svc",
+						"env":  "staging",
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, instance)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				_ = env.Client.Delete(ctx, instance)
+			})
+
+			// Verify ConfigMap has the chained variable node values
+			cm := &corev1.ConfigMap{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "svc-staging-cm",
+					Namespace: namespace,
+				}, cm)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cm.Data["appLabel"]).To(Equal("svc-staging-app"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should expand forEach variable nodes and pass expanded values to downstream resources", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-data-foreach-var",
+				generator.WithSchema(
+					"TestDataForEachVar", "v1alpha1",
+					map[string]interface{}{
+						"appName": "string",
+						"regions": "[]string",
+					},
+					nil,
+				),
+				// Variable node with forEach: computes a label per region
+				generator.WithVariable("labels",
+					map[string]interface{}{
+						"fullName": "${schema.spec.appName + '-' + region}",
+					},
+					nil, nil,
+					[]krov1alpha1.ForEachDimension{
+						{"region": "${schema.spec.regions}"},
+					},
+				),
+				// One ConfigMap per forEach iteration, consuming the variable
+				generator.WithResourceCollection("configmaps",
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name": "${label.fullName + '-cm'}",
+						},
+						"data": map[string]interface{}{
+							"label": "${label.fullName}",
+						},
+					},
+					[]krov1alpha1.ForEachDimension{
+						{"label": "${labels}"},
+					},
+					nil, nil,
+				),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+			})
+
+			// Wait for RGD to become active
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Create instance with two regions
+			instance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+					"kind":       "TestDataForEachVar",
+					"metadata": map[string]interface{}{
+						"name":      "test-foreach-var",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"appName": "myapp",
+						"regions": []interface{}{"east", "west"},
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, instance)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				_ = env.Client.Delete(ctx, instance)
+			})
+
+			// Verify two ConfigMaps are created with correct computed names
+			cm1 := &corev1.ConfigMap{}
+			cm2 := &corev1.ConfigMap{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "myapp-east-cm",
+					Namespace: namespace,
+				}, cm1)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cm1.Data["label"]).To(Equal("myapp-east"))
+
+				err = env.Client.Get(ctx, types.NamespacedName{
+					Name:      "myapp-west-cm",
+					Namespace: namespace,
+				}, cm2)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cm2.Data["label"]).To(Equal("myapp-west"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Verify instance becomes ACTIVE
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{
+					Name:      "test-foreach-var",
+					Namespace: namespace,
+				}, instance)
+				g.Expect(err).ToNot(HaveOccurred())
+				state, found, _ := unstructured.NestedString(instance.Object, "status", "state")
+				g.Expect(found).To(BeTrue())
+				g.Expect(state).To(Equal("ACTIVE"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Circular Dependencies", func() {
+		It("should reject circular dependencies involving variable nodes", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-data-cycle",
+				generator.WithSchema(
+					"TestDataCycle", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithVariable("nodeA", map[string]interface{}{
+					"val": "${nodeB.val}",
+				}, nil, nil, nil),
+				generator.WithVariable("nodeB", map[string]interface{}{
+					"val": "${nodeA.val}",
+				}, nil, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+			})
+
+			expectRGDInactiveWithError(ctx, rgd, "cycle")
+		})
+	})
+})


### PR DESCRIPTION
KREP-011 introduces a type of resource in the RGD defined using `data`.
Unlike the `template` and `externalRef` resources, this new type does
not map to a kubernetes resource, but instead it holds complex data that 
can be referenced throughout the RGD