### PR TITLE
fix: reject reserved status field names at build time

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -794,7 +794,8 @@ func buildStatusSchema(
 // path reserved by the instance controller (e.g. "state", "conditions").
 func validateReservedStatusFields(fieldDescriptors []variable.FieldDescriptor) error {
 	for _, fd := range fieldDescriptors {
-		if strings.HasPrefix(fd.Path, ReservedStatusFieldState) || strings.HasPrefix(fd.Path, ReservedStatusFieldConditions) {
+		if fd.Path == ReservedStatusFieldState || strings.HasPrefix(fd.Path, ReservedStatusFieldState+".") ||
+			fd.Path == ReservedStatusFieldConditions || strings.HasPrefix(fd.Path, ReservedStatusFieldConditions+".") {
 			return fmt.Errorf(
 				"status field at path %q uses a reserved status field managed by kro",
 				fd.Path,

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -730,13 +730,11 @@ func buildStatusSchema(
 	// Reject reserved status field names. The instance controller uses "state"
 	// and "conditions" for lifecycle tracking and will silently overwrite any
 	// user-defined values for these fields.
-	reservedStatusFields := map[string]bool{"state": true, "conditions": true}
 	for _, fd := range fieldDescriptors {
-		topLevel := strings.SplitN(fd.Path, ".", 2)[0]
-		if reservedStatusFields[topLevel] {
+		if strings.HasPrefix(fd.Path, "state") || strings.HasPrefix(fd.Path, "conditions") {
 			return nil, nil, nil, fmt.Errorf(
-				"status field %q uses reserved name %q: kro reserves \"state\" and \"conditions\" for instance lifecycle tracking",
-				fd.Path, topLevel,
+				"status field at path %q uses a reserved status field managed by kro",
+				fd.Path,
 			)
 		}
 	}

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -218,6 +218,58 @@ func TestGraphBuilder_Validation(t *testing.T) {
 			errMsg:  "status fields without expressions are not supported",
 		},
 		{
+			name: "reserved status field name: state",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"state": "${vpc.status.state}",
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "uses reserved name \"state\"",
+		},
+		{
+			name: "reserved status field name: conditions",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"conditions": "${vpc.status.conditions}",
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "uses reserved name \"conditions\"",
+		},
+		{
 			name: "invalid resource type",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
@@ -684,8 +736,8 @@ func TestGraphBuilder_Validation(t *testing.T) {
 						"replicas": "integer | default=3",
 					},
 					map[string]interface{}{
-						"state": "${vpc.status.state}",
-						"id":    "${vpc.status.vpcID}",
+						"vpcState": "${vpc.status.state}",
+						"id":       "${vpc.status.vpcID}",
 					},
 				),
 				generator.WithResource("vpc", map[string]interface{}{
@@ -710,8 +762,8 @@ func TestGraphBuilder_Validation(t *testing.T) {
 						"name": "string",
 					},
 					map[string]interface{}{
-						"state": "${vpc.status.?state}",
-						"vpcID": "${vpc.status.?vpcID}",
+						"vpcState": "${vpc.status.?state}",
+						"vpcID":    "${vpc.status.?vpcID}",
 					},
 				),
 				generator.WithResource("vpc", map[string]interface{}{
@@ -1937,7 +1989,7 @@ func TestGraphBuilder_CELTypeChecking(t *testing.T) {
 						"name": "string",
 					},
 					map[string]interface{}{
-						"state": "${vpc.status.?state}",
+						"vpcState": "${vpc.status.?state}",
 					},
 				),
 				generator.WithResource("vpc", map[string]interface{}{

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -270,6 +270,112 @@ func TestGraphBuilder_Validation(t *testing.T) {
 			errMsg:  "uses a reserved status field managed by kro",
 		},
 		{
+			name: "reserved status field subpath: state object",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"state": map[string]interface{}{
+							"subfield": "${vpc.status.state}",
+						},
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "uses a reserved status field managed by kro",
+		},
+		{
+			name: "reserved status field subpath: conditions object",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"conditions": map[string]interface{}{
+							"ready": "${vpc.status.conditions}",
+						},
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: true,
+			errMsg:  "uses a reserved status field managed by kro",
+		},
+		{
+			name: "allowed status field: stateValue",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"stateValue": "${vpc.status.state}",
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: false,
+		},
+		{
+			name: "allowed status field: conditionsz",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					map[string]interface{}{
+						"conditionsz": "${vpc.status.conditions}",
+					},
+				),
+				generator.WithResource("vpc", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "test-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				}, nil, nil),
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid resource type",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -241,7 +241,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 				}, nil, nil),
 			},
 			wantErr: true,
-			errMsg:  "uses reserved name \"state\"",
+			errMsg:  "uses a reserved status field managed by kro",
 		},
 		{
 			name: "reserved status field name: conditions",
@@ -267,7 +267,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 				}, nil, nil),
 			},
 			wantErr: true,
-			errMsg:  "uses reserved name \"conditions\"",
+			errMsg:  "uses a reserved status field managed by kro",
 		},
 		{
 			name: "invalid resource type",

--- a/pkg/graph/node.go
+++ b/pkg/graph/node.go
@@ -41,6 +41,12 @@ const (
 	MetadataNamePath = "metadata.name"
 	// MetadataNamespacePath is the path to the resource namespace field.
 	MetadataNamespacePath = "metadata.namespace"
+	// ReservedStatusFieldState is the status field reserved by the instance
+	// controller for lifecycle state tracking.
+	ReservedStatusFieldState = "state"
+	// ReservedStatusFieldConditions is the status field reserved by the
+	// instance controller for condition reporting.
+	ReservedStatusFieldConditions = "conditions"
 )
 
 // NodeType identifies the kind of node in the resource graph.


### PR DESCRIPTION
This PR adds validation to reject reserved top-level status field names
`state` and `conditions` in ResourceGraphDefinition.

These fields are managed internally by the instance controller for lifecycle
tracking. Previously, users could define them in the status schema, but their
values were silently overwritten at runtime.

The graph builder now fails early if these reserved names are used.

Changes:
- Added validation in buildStatusSchema
- Simplified check using strings.HasPrefix
- Added unit tests covering both reserved names
- Updated existing tests to avoid reserved fields
