### PR TITLE
fix: hash kro.run/node-id label to respect 63-char limit

### DIFF
--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -128,6 +128,25 @@ func TestPlanNodesForDeletionSkipsIgnoredExternalAndMissingNodes(t *testing.T) {
 	assert.Equal(t, v1alpha1.NodeStateDeleted, rcx.StateManager.NodeStates["missing"].State)
 }
 
+func TestPlanNodesForDeletionFindsCollectionChildrenWithRawNodeIDLabel(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+
+	collectionNode := newDeletionCollectionNode(t, "configs")
+
+	preHashChild := newConfigMapObject("one", "default")
+	preHashChild.SetLabels(map[string]string{
+		metadata.InstanceIDLabel: string(instance.GetUID()),
+		metadata.NodeIDLabel:     "configs",
+	})
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collectionNode), preHashChild)
+	node, err := controller.planNodesForDeletion(rcx)
+	require.NoError(t, err)
+	require.NotNil(t, node, "should find collection child with raw node-id label, not treat it as already deleted")
+	assert.Equal(t, "configs", node.Spec.Meta.ID)
+}
+
 func TestPlanNodesForDeletionErrors(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -115,7 +115,7 @@ func TestPlanNodesForDeletionSkipsIgnoredExternalAndMissingNodes(t *testing.T) {
 	currentCollection := newConfigMapObject("one", "default")
 	currentCollection.SetLabels(map[string]string{
 		metadata.InstanceIDLabel: string(instance.GetUID()),
-		metadata.NodeIDLabel:     "configs",
+		metadata.NodeIDLabel:     metadata.SafeNodeID("configs"),
 	})
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(ignoredNode, externalNode, collectionNode, missingNode), currentCollection)

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -372,7 +372,6 @@ func (c *Controller) processRegularNode(
 	}
 
 	return []applyset.Resource{resource}, inProgressState(), nil
-}
 
 // applyDecoratorLabels merges tool labels and adds node/collection identifiers.
 func (c *Controller) applyDecoratorLabels(

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -404,8 +404,8 @@ func (c *Controller) applyDecoratorLabels(
 		labels[k] = v
 	}
 
-	// Add node ID label
-	labels[metadata.NodeIDLabel] = nodeID
+	// Add node ID label (hashed to respect the 63-char Kubernetes limit)
+	labels[metadata.NodeIDLabel] = metadata.SafeNodeID(nodeID)
 
 	// Add collection labels if applicable
 	if collectionInfo != nil {
@@ -414,6 +414,13 @@ func (c *Controller) applyDecoratorLabels(
 	}
 
 	obj.SetLabels(labels)
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[metadata.NodeIDAnnotation] = nodeID
+	obj.SetAnnotations(annotations)
 }
 
 // patchInstanceWithApplySetMetadata applies applyset metadata to the parent instance.

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -372,6 +372,7 @@ func (c *Controller) processRegularNode(
 	}
 
 	return []applyset.Resource{resource}, inProgressState(), nil
+}
 
 // applyDecoratorLabels merges tool labels and adds node/collection identifiers.
 func (c *Controller) applyDecoratorLabels(

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -419,7 +419,7 @@ func (c *Controller) applyDecoratorLabels(
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	annotations[metadata.NodeIDAnnotation] = nodeID
+	annotations[metadata.NodeAnnotation] = nodeID
 	obj.SetAnnotations(annotations)
 }
 

--- a/pkg/controller/instance/resources_collection.go
+++ b/pkg/controller/instance/resources_collection.go
@@ -71,7 +71,7 @@ func (c *Controller) processCollectionNode(
 	// selector listCollectionItems uses to LIST them.
 	selector := labels.SelectorFromSet(labels.Set{
 		metadata.InstanceIDLabel: string(rcx.Instance.GetUID()),
-		metadata.NodeIDLabel:     id,
+		metadata.NodeIDLabel:     metadata.SafeNodeID(id),
 	})
 	requestCollectionWatch(rcx, id, gvr, rcx.Instance.GetNamespace(), selector)
 
@@ -125,7 +125,7 @@ func (c *Controller) listCollectionItems(
 	instanceUID := string(rcx.Instance.GetUID())
 	selector := fmt.Sprintf("%s=%s,%s=%s",
 		metadata.InstanceIDLabel, instanceUID,
-		metadata.NodeIDLabel, nodeID,
+		metadata.NodeIDLabel, metadata.SafeNodeID(nodeID),
 	)
 
 	// List across all namespaces - collection items may span namespaces

--- a/pkg/controller/instance/resources_collection.go
+++ b/pkg/controller/instance/resources_collection.go
@@ -121,21 +121,45 @@ func (c *Controller) listCollectionItems(
 	gvr schema.GroupVersionResource,
 	nodeID string,
 ) ([]*unstructured.Unstructured, error) {
-	// Filter by both instance UID and node ID for precise matching
 	instanceUID := string(rcx.Instance.GetUID())
+
+	items, err := c.listByNodeIDLabel(rcx, gvr, instanceUID, metadata.SafeNodeID(nodeID))
+	if err != nil {
+		return nil, err
+	}
+	if len(items) > 0 {
+		return items, nil
+	}
+
+	// Fallback: children created before the node-id hashing change still carry
+	// the raw node ID as their label value. Without this second lookup the
+	// deletion path would miss them and leave orphans behind.
+	items, err = c.listByNodeIDLabel(rcx, gvr, instanceUID, nodeID)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) > 0 {
+		rcx.Log.V(1).Info("found collection items with raw node-id label from pre-hashing controller version",
+			"nodeID", nodeID, "count", len(items))
+	}
+	return items, nil
+}
+
+func (c *Controller) listByNodeIDLabel(
+	rcx *ReconcileContext,
+	gvr schema.GroupVersionResource,
+	instanceUID, nodeIDValue string,
+) ([]*unstructured.Unstructured, error) {
 	selector := fmt.Sprintf("%s=%s,%s=%s",
 		metadata.InstanceIDLabel, instanceUID,
-		metadata.NodeIDLabel, metadata.SafeNodeID(nodeID),
+		metadata.NodeIDLabel, nodeIDValue,
 	)
-
-	// List across all namespaces - collection items may span namespaces
 	list, err := rcx.Client.Resource(gvr).List(rcx.Ctx, metav1.ListOptions{
 		LabelSelector: selector,
 	})
 	if err != nil {
 		return nil, err
 	}
-
 	items := make([]*unstructured.Unstructured, len(list.Items))
 	for i := range list.Items {
 		items[i] = &list.Items[i]

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -442,12 +442,12 @@ func TestProcessCollectionNodeMatchesChildrenWithRawNodeIDLabel(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
 
-	collectionNode := newCollectionNodeForResources(t, "items")
+	collectionNode := newCollectionNodeForResources(t)
 
 	preHashChild := newConfigMapObject("one", "default")
 	preHashChild.SetLabels(map[string]string{
 		metadata.InstanceIDLabel: string(instance.GetUID()),
-		metadata.NodeIDLabel:     "items",
+		metadata.NodeIDLabel:     "configs",
 	})
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collectionNode), preHashChild)
@@ -455,7 +455,7 @@ func TestProcessCollectionNodeMatchesChildrenWithRawNodeIDLabel(t *testing.T) {
 	runtimeNode := rcx.Runtime.Nodes()[0]
 	desired, err := runtimeNode.GetDesired()
 	require.NoError(t, err)
-	resources, err := controller.processCollectionNode(rcx, runtimeNode, rcx.StateManager.NewNodeState("items"), desired)
+	resources, _, err := controller.processCollectionNode(rcx, runtimeNode, desired)
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 	assert.NotNil(t, resources[0].Current, "should match child with raw node-id label as current")

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -438,6 +438,30 @@ func TestCollectionAndExternalCollectionProcessing(t *testing.T) {
 	assert.Equal(t, v1alpha1.NodeStateSynced, extState.State)
 }
 
+func TestProcessCollectionNodeMatchesChildrenWithRawNodeIDLabel(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
+
+	collectionNode := newCollectionNodeForResources(t, "items")
+
+	preHashChild := newConfigMapObject("one", "default")
+	preHashChild.SetLabels(map[string]string{
+		metadata.InstanceIDLabel: string(instance.GetUID()),
+		metadata.NodeIDLabel:     "items",
+	})
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collectionNode), preHashChild)
+
+	runtimeNode := rcx.Runtime.Nodes()[0]
+	desired, err := runtimeNode.GetDesired()
+	require.NoError(t, err)
+	resources, err := controller.processCollectionNode(rcx, runtimeNode, rcx.StateManager.NewNodeState("items"), desired)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.NotNil(t, resources[0].Current, "should match child with raw node-id label as current")
+	assert.Equal(t, "one", resources[0].Object.GetName())
+}
+
 func TestProcessExternalRefNodePaths(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -338,7 +338,7 @@ func TestProcessNodeCollectionTypes(t *testing.T) {
 	currentCollection := newConfigMapObject("one", "default")
 	currentCollection.SetLabels(map[string]string{
 		metadata.InstanceIDLabel: string(instance.GetUID()),
-		metadata.NodeIDLabel:     "configs",
+		metadata.NodeIDLabel:     metadata.SafeNodeID("configs"),
 	})
 	currentExternal := newConfigMapObject("ext", "default")
 	currentExternal.SetLabels(map[string]string{"app": "demo"})
@@ -409,7 +409,7 @@ func TestCollectionAndExternalCollectionProcessing(t *testing.T) {
 	current := newConfigMapObject("one", "default")
 	current.SetLabels(map[string]string{
 		metadata.InstanceIDLabel: string(instance.GetUID()),
-		metadata.NodeIDLabel:     "configs",
+		metadata.NodeIDLabel:     metadata.SafeNodeID("configs"),
 		"app":                    "demo",
 	})
 	matchingExternal := newConfigMapObject("ext", "default")
@@ -641,10 +641,11 @@ func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
 	controller.applyDecoratorLabels(rcx, obj, "configs", &CollectionInfo{Index: 1, Size: 3})
 
 	assert.Equal(t, "yes", obj.GetLabels()["keep"])
-	assert.Equal(t, "configs", obj.GetLabels()[metadata.NodeIDLabel])
+	assert.Equal(t, metadata.SafeNodeID("configs"), obj.GetLabels()[metadata.NodeIDLabel])
 	assert.Equal(t, "1", obj.GetLabels()[metadata.CollectionIndexLabel])
 	assert.Equal(t, string(instance.GetUID()), obj.GetLabels()[metadata.InstanceIDLabel])
 	assert.Empty(t, obj.GetLabels()[metadata.ManagedByLabelKey])
+	assert.Equal(t, "configs", obj.GetAnnotations()[metadata.NodeAnnotation])
 
 	require.NoError(t, controller.patchInstanceWithApplySetMetadata(rcx, applyset.Metadata{
 		ID:                   "demo",

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -35,8 +35,8 @@ const (
 )
 
 const (
-	NodeIDLabel      = LabelKROPrefix + "node-id"
-	NodeIDAnnotation = LabelKROPrefix + "node-id-original"
+	NodeIDLabel    = LabelKROPrefix + "node-id"
+	NodeAnnotation = LabelKROPrefix + "node"
 
 	// Collection labels for tracking collection membership and position.
 	// These enable querying collection resources and understanding their position.

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -15,10 +15,9 @@
 package metadata
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strconv"
 	"strings"
 
@@ -222,11 +221,12 @@ func NewCollectionItemLabeler(nodeID string, index, size int) GenericLabeler {
 	}
 }
 
-// SafeNodeID returns a deterministic fix length (16 chars) nodeId.
-// k8s label safe representation due to char limit
+// SafeNodeID returns a deterministic fixed-length (16 chars) nodeId
+// using FNV-64a, safe for K8s label values due to the 63-char limit.
 func SafeNodeID(nodeID string) string {
-	hash := sha256.Sum256([]byte(nodeID))
-	return hex.EncodeToString(hash[:])[:16]
+	h := fnv.New64a()
+	h.Write([]byte(nodeID))
+	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 func safeVersion(version string) string {

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -15,6 +15,8 @@
 package metadata
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -34,7 +36,8 @@ const (
 )
 
 const (
-	NodeIDLabel = LabelKROPrefix + "node-id"
+	NodeIDLabel      = LabelKROPrefix + "node-id"
+	NodeIDAnnotation = LabelKROPrefix + "node-id-original"
 
 	// Collection labels for tracking collection membership and position.
 	// These enable querying collection resources and understanding their position.
@@ -213,10 +216,17 @@ func NewKROMetaLabeler() GenericLabeler {
 // - collection-size: the total number of items in the collection (e.g "3")
 func NewCollectionItemLabeler(nodeID string, index, size int) GenericLabeler {
 	return map[string]string{
-		NodeIDLabel:          nodeID,
+		NodeIDLabel:          SafeNodeID(nodeID),
 		CollectionIndexLabel: strconv.Itoa(index),
 		CollectionSizeLabel:  strconv.Itoa(size),
 	}
+}
+
+// SafeNodeID returns a deterministic fix length (16 chars) nodeId.
+// k8s label safe representation due to char limit
+func SafeNodeID(nodeID string) string {
+	hash := sha256.Sum256([]byte(nodeID))
+	return hex.EncodeToString(hash[:])[:16]
 }
 
 func safeVersion(version string) string {

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -32,11 +32,14 @@ import (
 const (
 	// LabelKROPrefix is the label key prefix used to identify KRO owned resources.
 	LabelKROPrefix = v1alpha1.KRODomainName + "/"
+	// InternalLabelKROPrefix is the prefix for internal-only metadata that
+	// should not be treated as part of kro's public API surface.
+	InternalLabelKROPrefix = "internal.kro.run/"
 )
 
 const (
 	NodeIDLabel    = LabelKROPrefix + "node-id"
-	NodeAnnotation = LabelKROPrefix + "node"
+	NodeAnnotation = InternalLabelKROPrefix + "node"
 
 	// Collection labels for tracking collection membership and position.
 	// These enable querying collection resources and understanding their position.

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -331,17 +331,17 @@ func TestSafeNodeID(t *testing.T) {
 		{
 			name:     "short ID",
 			input:    "configMap",
-			expected: "3ca56079224bf9f3",
+			expected: "b2ef5cc0f757c127",
 		},
 		{
 			name:     "long ID exceeding 63 chars",
 			input:    "thisIsAnExtremelyLongResourceIdentifierThatExceedsSixtyThreeCharactersLimit",
-			expected: "f2e632b9df04d066",
+			expected: "813389665a79234e",
 		},
 		{
 			name:     "different short ID",
 			input:    "secret",
-			expected: "2bb80d537b1da3e3",
+			expected: "ab23f0eec020c951",
 		},
 	}
 

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -321,3 +321,39 @@ func TestNewNodeLabeler(t *testing.T) {
 		}, labeler)
 	})
 }
+
+func TestSafeNodeID(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "short ID",
+			input:    "configMap",
+			expected: "3ca56079224bf9f3",
+		},
+		{
+			name:     "long ID exceeding 63 chars",
+			input:    "thisIsAnExtremelyLongResourceIdentifierThatExceedsSixtyThreeCharactersLimit",
+			expected: "f2e632b9df04d066",
+		},
+		{
+			name:     "different short ID",
+			input:    "secret",
+			expected: "2bb80d537b1da3e3",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SafeNodeID(tc.input)
+			assert.Equal(t, tc.expected, result)
+			assert.Len(t, result, 16)
+		})
+	}
+
+	t.Run("deterministic", func(t *testing.T) {
+		assert.Equal(t, SafeNodeID("configMap"), SafeNodeID("configMap"))
+	})
+}

--- a/pkg/metadata/selectors.go
+++ b/pkg/metadata/selectors.go
@@ -60,7 +60,7 @@ func NewInstanceAndResourceGraphDefinitionSelector(instance metav1.Object, resou
 func NewNodeAndInstanceAndResourceGraphDefinitionSelector(node metav1.Object, instance metav1.Object, resourceGraphDefinition metav1.Object) metav1.LabelSelector {
 	return metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			NodeIDLabel:                    node.GetName(),
+			NodeIDLabel:                    SafeNodeID(node.GetName()),
 			InstanceIDLabel:                string(instance.GetUID()),
 			ResourceGraphDefinitionIDLabel: string(resourceGraphDefinition.GetUID()),
 		},

--- a/pkg/metadata/selectors_test.go
+++ b/pkg/metadata/selectors_test.go
@@ -74,7 +74,7 @@ func TestNewNodeAndInstanceAndResourceGraphDefinitionSelector(t *testing.T) {
 	selector := NewNodeAndInstanceAndResourceGraphDefinitionSelector(node, instance, rgd)
 
 	assert.Equal(t, map[string]string{
-		NodeIDLabel:                    "test-node",
+		NodeIDLabel:                    SafeNodeID("test-node"),
 		InstanceIDLabel:                "instance-123",
 		ResourceGraphDefinitionIDLabel: "rgd-123",
 	}, selector.MatchLabels)

--- a/test/integration/suites/core/applyset_test.go
+++ b/test/integration/suites/core/applyset_test.go
@@ -1895,7 +1895,7 @@ func verifyChildResourceLabelsWithNodeID(
 ) {
 	verifyChildResourceLabels(g, labels, applySetID, instance)
 
-	// Verify exact node ID
-	g.Expect(labels).To(HaveKeyWithValue(metadata.NodeIDLabel, nodeID),
-		"child should have exact node-id label")
+	// Verify hashed node ID label
+	g.Expect(labels).To(HaveKeyWithValue(metadata.NodeIDLabel, metadata.SafeNodeID(nodeID)),
+		"child should have hashed node-id label")
 }

--- a/test/integration/suites/core/readiness_test.go
+++ b/test/integration/suites/core/readiness_test.go
@@ -31,6 +31,7 @@ import (
 
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/controller/resourcegraphdefinition"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
@@ -225,7 +226,7 @@ var _ = Describe("Readiness", func() {
 			// Verify deployment specs
 			g.Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			g.Expect(*deployment.Spec.Replicas).To(Equal(int32(replicas)))
-			g.Expect(deployment.Annotations).To(HaveLen(0))
+			g.Expect(deployment.Annotations).To(HaveKeyWithValue(metadata.NodeIDAnnotation, "deployment"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		// Verify Service is not created yet
@@ -273,8 +274,8 @@ var _ = Describe("Readiness", func() {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// validate service spec
-			g.Expect(service.Annotations).To(HaveLen(1))
-			g.Expect(service.Annotations["app"]).To(Equal("service"))
+			g.Expect(service.Annotations).To(HaveKeyWithValue("app", "service"))
+			g.Expect(service.Annotations).To(HaveKeyWithValue(metadata.NodeIDAnnotation, "service"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		// Delete instance

--- a/test/integration/suites/core/readiness_test.go
+++ b/test/integration/suites/core/readiness_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Readiness", func() {
 			// Verify deployment specs
 			g.Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			g.Expect(*deployment.Spec.Replicas).To(Equal(int32(replicas)))
-			g.Expect(deployment.Annotations).To(HaveKeyWithValue(metadata.NodeIDAnnotation, "deployment"))
+			g.Expect(deployment.Annotations).To(HaveKeyWithValue(metadata.NodeAnnotation, "deployment"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		// Verify Service is not created yet
@@ -275,7 +275,7 @@ var _ = Describe("Readiness", func() {
 
 			// validate service spec
 			g.Expect(service.Annotations).To(HaveKeyWithValue("app", "service"))
-			g.Expect(service.Annotations).To(HaveKeyWithValue(metadata.NodeIDAnnotation, "service"))
+			g.Expect(service.Annotations).To(HaveKeyWithValue(metadata.NodeAnnotation, "service"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		// Delete instance

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -127,7 +127,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 
 | Annotation | Description |
 |------------|-------------|
-| `kro.run/node` | The human-readable resource ID from the RGD (e.g., `workerPods`). This preserves the readable ID since `kro.run/node-id` stores a fixed-length hash to comply with the Kubernetes 63-character label value limit. |
+| `kro.run/node` | The human-readable node identifier based on the RGD (e.g., `workerPods`). This preserves a readable identifier since `kro.run/node-id` stores a fixed-length hash to comply with the Kubernetes 63-character label value limit. |
 
 These labels and annotations allow you to identify exactly which instance owns each managed resource, which is essential when multiple instances of the same RGD exist in a cluster. For collection resources, see [Collection Labels](./rgd/02-resource-definitions/04-collections.md#collection-labels) for more details.
 

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -113,7 +113,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `kro.run/instance-version` | API version of the instance |
 | `kro.run/instance-kind` | Kind of the instance |
 | `app.kubernetes.io/managed-by` | Set to `"kro"` |
-| `kro.run/node-id` | FNV-64a hash of the resource ID from the RGD, encoded as a 16-character hex string. The human-readable ID is stored in the `kro.run/node` annotation. |
+| `kro.run/node-id` | FNV-64a hash of the resource ID from the RGD, encoded as a 16-character hex string. The human-readable ID is stored in the `internal.kro.run/node` annotation. |
 | `applyset.kubernetes.io/part-of` | Links the resource to its parent instance (matches the instance's `applyset.kubernetes.io/id`) |
 
 **Collection-specific labels** (only on resources created via `forEach`):
@@ -127,7 +127,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 
 | Annotation | Description |
 |------------|-------------|
-| `kro.run/node` | The human-readable node identifier based on the RGD (e.g., `workerPods`). This preserves a readable identifier since `kro.run/node-id` stores a fixed-length hash to comply with the Kubernetes 63-character label value limit. |
+| `internal.kro.run/node` | The human-readable node identifier based on the RGD (e.g., `workerPods`). This preserves a readable identifier since `kro.run/node-id` stores a fixed-length hash to comply with the Kubernetes 63-character label value limit. |
 
 These labels and annotations allow you to identify exactly which instance owns each managed resource, which is essential when multiple instances of the same RGD exist in a cluster. For collection resources, see [Collection Labels](./rgd/02-resource-definitions/04-collections.md#collection-labels) for more details.
 

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -113,7 +113,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `kro.run/instance-version` | API version of the instance |
 | `kro.run/instance-kind` | Kind of the instance |
 | `app.kubernetes.io/managed-by` | Set to `"kro"` |
-| `kro.run/node-id` | Resource ID from the RGD |
+| `kro.run/node-id` | FNV-64a hash of the resource ID from the RGD, encoded as a 16-character hex string. The human-readable ID is stored in the `kro.run/node-id-original` annotation. |
 | `applyset.kubernetes.io/part-of` | Links the resource to its parent instance (matches the instance's `applyset.kubernetes.io/id`) |
 
 **Collection-specific labels** (only on resources created via `forEach`):
@@ -123,7 +123,13 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `kro.run/collection-index` | Position in the collection (0-indexed) |
 | `kro.run/collection-size` | Total number of items in the collection |
 
-These labels allow you to identify exactly which instance owns each managed resource, which is essential when multiple instances of the same RGD exist in a cluster. For collection resources, see [Collection Labels](./rgd/02-resource-definitions/04-collections.md#collection-labels) for more details.
+**Annotations:**
+
+| Annotation | Description |
+|------------|-------------|
+| `kro.run/node-id-original` | The original human-readable resource ID from the RGD (e.g., `workerPods`). This preserves the readable ID since `kro.run/node-id` stores a fixed-length hash to comply with the Kubernetes 63-character label value limit. |
+
+These labels and annotations allow you to identify exactly which instance owns each managed resource, which is essential when multiple instances of the same RGD exist in a cluster. For collection resources, see [Collection Labels](./rgd/02-resource-definitions/04-collections.md#collection-labels) for more details.
 
 </TabItem>
 </Tabs>

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -113,7 +113,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `kro.run/instance-version` | API version of the instance |
 | `kro.run/instance-kind` | Kind of the instance |
 | `app.kubernetes.io/managed-by` | Set to `"kro"` |
-| `kro.run/node-id` | FNV-64a hash of the resource ID from the RGD, encoded as a 16-character hex string. The human-readable ID is stored in the `kro.run/node-id-original` annotation. |
+| `kro.run/node-id` | FNV-64a hash of the resource ID from the RGD, encoded as a 16-character hex string. The human-readable ID is stored in the `kro.run/node` annotation. |
 | `applyset.kubernetes.io/part-of` | Links the resource to its parent instance (matches the instance's `applyset.kubernetes.io/id`) |
 
 **Collection-specific labels** (only on resources created via `forEach`):
@@ -127,7 +127,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 
 | Annotation | Description |
 |------------|-------------|
-| `kro.run/node-id-original` | The original human-readable resource ID from the RGD (e.g., `workerPods`). This preserves the readable ID since `kro.run/node-id` stores a fixed-length hash to comply with the Kubernetes 63-character label value limit. |
+| `kro.run/node` | The human-readable resource ID from the RGD (e.g., `workerPods`). This preserves the readable ID since `kro.run/node-id` stores a fixed-length hash to comply with the Kubernetes 63-character label value limit. |
 
 These labels and annotations allow you to identify exactly which instance owns each managed resource, which is essential when multiple instances of the same RGD exist in a cluster. For collection resources, see [Collection Labels](./rgd/02-resource-definitions/04-collections.md#collection-labels) for more details.
 

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
@@ -810,15 +810,7 @@ used for querying or debugging:
 The `kro.run/node-id` label stores a deterministic hash rather than the raw
 resource ID because Kubernetes limits label values to 63 characters. The
 original ID is preserved in the `kro.run/node` annotation for
-traceability.
-
-These labels and annotations enable:
-- **Querying**: Find all items in a collection by label selector:
-  `kubectl get pods -l kro.run/node-id=39edeed848ad0ddc`
-- **Finding by resource ID**: Since `kro.run/node` is an annotation (not a label), use jsonpath to filter by the human-readable ID:
-  `kubectl get pods -o jsonpath='{.items[?(@.metadata.annotations.kro\.run/node=="workerPods")].metadata.name}'`
-- **Ordering**: Understand item position via `collection-index`
-- **Debugging**: The `kro.run/node` annotation provides the human-readable resource ID for tracing resources back to their source RGD
+traceability and debugging.
 
 :::note
 The combination of `instance-id` + `node-id` + `collection-index` uniquely

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
@@ -805,11 +805,11 @@ used for querying or debugging:
 
 | Annotation | Description | Example |
 |------------|-------------|---------|
-| `kro.run/node` | A human-readable node identifier from the RGD | `workerPods` |
+| `internal.kro.run/node` | A human-readable node identifier from the RGD | `workerPods` |
 
 The `kro.run/node-id` label stores a deterministic hash rather than the raw
 resource ID because Kubernetes limits label values to 63 characters. The
-original ID is preserved in the `kro.run/node` annotation for
+original ID is preserved in the `internal.kro.run/node` annotation for
 traceability and debugging.
 
 :::note

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
@@ -795,7 +795,7 @@ used for querying or debugging:
 
 | Label | Description | Example |
 |-------|-------------|---------|
-| `kro.run/node-id` | FNV-64a hash of the resource ID from the RGD (16-char hex) | `39edeed848ad0ddc` |
+| `kro.run/node-id` | FNV-64a hash of the node identifier from the RGD (16-char hex) | `39edeed848ad0ddc` |
 | `kro.run/collection-index` | Position in the collection (0-indexed) | `0`, `1`, `2` |
 | `kro.run/collection-size` | Total number of items in the collection | `3` |
 | `kro.run/instance-id` | UID of the instance that owns this resource | `a1b2c3...` |

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
@@ -787,26 +787,43 @@ creates multiple resources at runtime, but dependencies treat it as one unit.
 
 ## Collection Labels
 
-kro automatically applies labels to each resource in a collection to track
-membership and ordering. These labels are part of kro's public API and can be
+kro automatically applies labels and annotations to each resource in a collection to track
+membership and ordering. These are part of kro's public API and can be 
 used for querying or debugging:
+
+**Labels:**
 
 | Label | Description | Example |
 |-------|-------------|---------|
-| `kro.run/node-id` | The resource ID from the RGD | `workerPods` |
+| `kro.run/node-id` | FNV-64a hash of the resource ID from the RGD (16-char hex) | `39edeed848ad0ddc` |
 | `kro.run/collection-index` | Position in the collection (0-indexed) | `0`, `1`, `2` |
 | `kro.run/collection-size` | Total number of items in the collection | `3` |
 | `kro.run/instance-id` | UID of the instance that owns this resource | `a1b2c3...` |
 
-These labels enable:
-- **Querying**: Find all items in a collection with `kubectl get pods -l kro.run/node-id=workerPods`
+
+**Annotations:**
+
+| Annotation | Description | Example |
+|------------|-------------|---------|
+| `kro.run/node-id-original` | The original human-readable resource ID from the RGD | `workerPods` |
+
+The `kro.run/node-id` label stores a deterministic hash rather than the raw
+resource ID because Kubernetes limits label values to 63 characters. The
+original ID is preserved in the `kro.run/node-id-original` annotation for
+traceability.
+
+These labels and annotations enable:
+- **Querying**: Find all items in a collection by label selector:
+  `kubectl get pods -l kro.run/node-id=39edeed848ad0ddc`
+- **Finding by resource ID**: Since `kro.run/node-id-original` is an annotation (not a label), use jsonpath to filter by the human-readable ID:
+  `kubectl get pods -o jsonpath='{.items[?(@.metadata.annotations.kro\.run/node-id-original=="workerPods")].metadata.name}'`
 - **Ordering**: Understand item position via `collection-index`
-- **Debugging**: Trace resources back to their source instance and RGD
+- **Debugging**: The `kro.run/node-id-original` annotation provides the human-readable resource ID for tracing resources back to their source RGD
 
 :::note
 The combination of `instance-id` + `node-id` + `collection-index` uniquely
-identifies each collection item. These labels are managed by kro - do not
-modify them manually.
+identifies each collection item. These labels and annotations are managed by
+kro - do not modify them manually.
 :::
 
 See [Constraints & Gotchas](#constraints--gotchas) for label management notes.

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
@@ -805,7 +805,7 @@ used for querying or debugging:
 
 | Annotation | Description | Example |
 |------------|-------------|---------|
-| `kro.run/node` | The human-readable resource ID from the RGD | `workerPods` |
+| `kro.run/node` | A human-readable node identifier from the RGD | `workerPods` |
 
 The `kro.run/node-id` label stores a deterministic hash rather than the raw
 resource ID because Kubernetes limits label values to 63 characters. The

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
@@ -805,20 +805,20 @@ used for querying or debugging:
 
 | Annotation | Description | Example |
 |------------|-------------|---------|
-| `kro.run/node-id-original` | The original human-readable resource ID from the RGD | `workerPods` |
+| `kro.run/node` | The human-readable resource ID from the RGD | `workerPods` |
 
 The `kro.run/node-id` label stores a deterministic hash rather than the raw
 resource ID because Kubernetes limits label values to 63 characters. The
-original ID is preserved in the `kro.run/node-id-original` annotation for
+original ID is preserved in the `kro.run/node` annotation for
 traceability.
 
 These labels and annotations enable:
 - **Querying**: Find all items in a collection by label selector:
   `kubectl get pods -l kro.run/node-id=39edeed848ad0ddc`
-- **Finding by resource ID**: Since `kro.run/node-id-original` is an annotation (not a label), use jsonpath to filter by the human-readable ID:
-  `kubectl get pods -o jsonpath='{.items[?(@.metadata.annotations.kro\.run/node-id-original=="workerPods")].metadata.name}'`
+- **Finding by resource ID**: Since `kro.run/node` is an annotation (not a label), use jsonpath to filter by the human-readable ID:
+  `kubectl get pods -o jsonpath='{.items[?(@.metadata.annotations.kro\.run/node=="workerPods")].metadata.name}'`
 - **Ordering**: Understand item position via `collection-index`
-- **Debugging**: The `kro.run/node-id-original` annotation provides the human-readable resource ID for tracing resources back to their source RGD
+- **Debugging**: The `kro.run/node` annotation provides the human-readable resource ID for tracing resources back to their source RGD
 
 :::note
 The combination of `instance-id` + `node-id` + `collection-index` uniquely


### PR DESCRIPTION
Proposal for: https://github.com/kubernetes-sigs/kro/issues/1055

### Summary:
The kro.run/node-id label is set from the RGD resource id. When that ID is longer than 63 characters, Kubernetes rejects the resource because label values are limited to 63 characters. RGDs with long IDs become Active, but instance reconciliation fails at apply time.

### Change:
 Setting the label to a 16-character hex digest of the node ID (SHA-256), and store the full original ID in the annotation `kro.run/node-id-original`. This keeps labels within the 63-char limit and preserves the original ID for debugging.

Note: (first time contributor) My understanding is that this change does not introduce a breaking change, basically on the next reconciliation cycle, the controller applies by resource name and updates the label (and adds the annotation) on existing objects. With two reconcile cycles everything should be consistent.

**Migration fallback for collection children during upgrade:**

When the controller upgrades from non-hashing to hashing on node-ids, existing collection children still carry the raw (unhashed) kro.run/node-id label. listCollectionItems now performs a two-step lookup: it first queries by the hashed label value, and if no items are found, falls back to querying by the raw value. This ensures the deletion path doesn't miss pre-upgrade children and leave orphans. The fallback is safe to remove (in later major versions) once all clusters have completed at least one reconciliation cycle after the upgrade.
