### PR TITLE
feat(simpleschema): generate CRD printer columns from printColumn markers

### DIFF
--- a/examples/kubernetes/additionalPrinterColumns/rg.yaml
+++ b/examples/kubernetes/additionalPrinterColumns/rg.yaml
@@ -8,9 +8,9 @@ spec:
     kind: Application
     spec:
       name: string
-      image: string | default="nginx"
+      image: string | default="nginx" printColumn="IMAGE"
       ingress:
-        enabled: boolean | default=false
+        enabled: boolean | default=false printColumn="ENABLED"
     status:
       deploymentConditions: ${deployment.status.conditions}
       availableReplicas: ${deployment.status.availableReplicas}
@@ -18,12 +18,6 @@ spec:
       - jsonPath: .status.availableReplicas
         name: Available replicas
         type: integer
-      - jsonPath: .spec.image
-        name: Image
-        type: string
-      - jsonPath: .spec.ingress.enabled
-        name: Enabled Ingress
-        type: boolean
 
   resources:
     - id: deployment

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -198,7 +198,7 @@ spec:
                         IncludeWhen is a list of CEL expressions that determine whether this resource should be created.
                         All expressions must evaluate to true for the resource to be included.
                         If not specified, the resource is always included.
-                        Expressions may reference schema fields and upstream resources. They are
+                        Expressions may reference schema fields and/or fields in other resources in the RGD. They are
                         re-evaluated during reconciliation, so resources may be created later or
                         pruned later as conditions change.
                         Example: ["schema.spec.enableMonitoring == true", "network.status.ready == true"]

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -17,6 +17,7 @@ package graph
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -49,6 +50,8 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/simpleschema"
 )
+
+var jsonPathIdentifierRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // NewBuilder creates a new GraphBuilder instance.
 func NewBuilder(clientConfig *rest.Config, httpClient *http.Client) (*Builder, error) {
@@ -207,14 +210,14 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 
 	// Build instance spec schema from SimpleSchema.
 	// This is independent of resources - just YAML parsing.
-	instanceSpecSchema, err := buildInstanceSpecSchema(rgd.Spec.Schema)
+	instanceSpecSchema, generatedPrinterColumns, err := buildInstanceSpecSchema(rgd.Spec.Schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build resourcegraphdefinition %q: %w", rgd.Name, err)
 	}
 
 	// Synthesize CRD early with empty status.
 	// We'll update the status later after inferring it from CEL expressions.
-	instanceCRD := crd.SynthesizeCRD(
+	instanceCRD := crd.SynthesizeCRDWithPrinterColumns(
 		rgd.Spec.Schema.Group,
 		rgd.Spec.Schema.APIVersion,
 		rgd.Spec.Schema.Kind,
@@ -223,6 +226,7 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 		false,                   // don't add default fields yet
 		crdScope,
 		rgd.Spec.Schema,
+		generatedPrinterColumns,
 	)
 
 	// Create a single expression inspector for all AST inspection operations.
@@ -730,13 +734,13 @@ func buildInstanceNode(
 // buildInstanceSpecSchema builds the instance spec schema that will be
 // used to generate the CRD for the instance resource. The instance spec
 // schema is expected to be defined using the "SimpleSchema" format.
-func buildInstanceSpecSchema(rgSchema *v1alpha1.Schema) (*extv1.JSONSchemaProps, error) {
+func buildInstanceSpecSchema(rgSchema *v1alpha1.Schema) (*extv1.JSONSchemaProps, []extv1.CustomResourceColumnDefinition, error) {
 	// We need to unmarshal the instance schema to a map[string]interface{} to
 	// make it easier to work with.
 	instanceSpec := map[string]interface{}{}
 	err := yaml.UnmarshalStrict(rgSchema.Spec.Raw, &instanceSpec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal spec schema: %w", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal spec schema: %w", err)
 	}
 
 	// Also the custom types must be unmarshalled to a map[string]interface{} to
@@ -744,16 +748,97 @@ func buildInstanceSpecSchema(rgSchema *v1alpha1.Schema) (*extv1.JSONSchemaProps,
 	customTypes := map[string]interface{}{}
 	err = yaml.UnmarshalStrict(rgSchema.Types.Raw, &customTypes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal predefined types: %w", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal predefined types: %w", err)
 	}
 
 	// The instance resource has a schema defined using the "SimpleSchema" format.
-	instanceSchema, err := simpleschema.ToOpenAPISpec(instanceSpec, customTypes)
+	instanceSchema, printerColumns, err := simpleschema.ToOpenAPISpec(instanceSpec, customTypes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build OpenAPI schema for instance: %v", err)
+		return nil, nil, fmt.Errorf("failed to build OpenAPI schema for instance: %v", err)
 	}
 
-	return instanceSchema, nil
+	generatedPrinterColumns, err := buildInstanceSpecPrinterColumns(printerColumns)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return instanceSchema, generatedPrinterColumns, nil
+}
+
+func buildInstanceSpecPrinterColumns(printerColumns []simpleschema.PrinterColumn) ([]extv1.CustomResourceColumnDefinition, error) {
+	if len(printerColumns) == 0 {
+		return nil, nil
+	}
+
+	// Sort by path for deterministic column ordering (map iteration in
+	// simpleschema is non-deterministic).
+	slices.SortFunc(printerColumns, func(a, b simpleschema.PrinterColumn) int {
+		return slices.Compare(a.Path, b.Path)
+	})
+
+	result := make([]extv1.CustomResourceColumnDefinition, 0, len(printerColumns))
+	seenPaths := make(map[string]struct{}, len(printerColumns))
+	for _, column := range printerColumns {
+		pathKey := strings.Join(column.Path, "\x00")
+		if _, ok := seenPaths[pathKey]; ok {
+			continue
+		}
+		seenPaths[pathKey] = struct{}{}
+
+		columnType, err := buildCRDPrinterColumnType(column.TargetType)
+		if err != nil {
+			fieldPath := strings.Join(column.Path, ".")
+			return nil, fmt.Errorf("spec field %q: printColumn marker only supports scalar fields, got type: %s", fieldPath, column.TargetType)
+		}
+		if strings.TrimSpace(column.Title) == "" {
+			fieldPath := strings.Join(column.Path, ".")
+			return nil, fmt.Errorf("spec field %q: printColumn requires a non-empty title", fieldPath)
+		}
+		jsonPath, err := buildPrinterColumnJSONPath(".spec", column.Path)
+		if err != nil {
+			fieldPath := strings.Join(column.Path, ".")
+			return nil, fmt.Errorf("spec field %q: %w", fieldPath, err)
+		}
+
+		result = append(result, extv1.CustomResourceColumnDefinition{
+			Name:     column.Title,
+			Type:     columnType,
+			JSONPath: jsonPath,
+		})
+	}
+
+	return result, nil
+}
+
+func buildCRDPrinterColumnType(targetType string) (string, error) {
+	switch targetType {
+	case "string", "integer", "boolean", "number":
+		return targetType, nil
+	case "float":
+		return "number", nil
+	default:
+		return "", fmt.Errorf("unsupported printer column type: %s", targetType)
+	}
+}
+
+func buildPrinterColumnJSONPath(prefix string, path []string) (string, error) {
+	var builder strings.Builder
+	builder.WriteString(prefix)
+
+	for _, segment := range path {
+		if !jsonPathIdentifierRE.MatchString(segment) {
+			return "", fmt.Errorf(
+				"printColumn only supports identifier-safe field names (matching %q), got %q",
+				jsonPathIdentifierRE.String(),
+				segment,
+			)
+		}
+
+		builder.WriteByte('.')
+		builder.WriteString(segment)
+	}
+
+	return builder.String(), nil
 }
 
 // buildStatusSchema builds the status schema for the instance resource.

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -37,11 +37,116 @@ import (
 	celcache "github.com/kubernetes-sigs/kro/pkg/cel/cache"
 	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
+	"github.com/kubernetes-sigs/kro/pkg/simpleschema"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
 )
 
 var defaultRGDConfig = RGDConfig{MaxCollectionDimensionSize: 5}
+
+func TestBuildInstanceSpecPrinterColumns(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []simpleschema.PrinterColumn
+		want        []extv1.CustomResourceColumnDefinition
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "scalar columns are converted to CRD printer columns",
+			input: []simpleschema.PrinterColumn{
+				{
+					Path:       []string{"image"},
+					TargetType: "string",
+					Title:      "IMAGE",
+				},
+				{
+					Path:       []string{"port"},
+					TargetType: "float",
+					Title:      "PORT",
+				},
+			},
+			want: []extv1.CustomResourceColumnDefinition{
+				{
+					Name:     "IMAGE",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+				{
+					Name:     "PORT",
+					Type:     "number",
+					JSONPath: ".spec.port",
+				},
+			},
+		},
+		{
+			name: "explicit titles are preserved",
+			input: []simpleschema.PrinterColumn{
+				{
+					Path:       []string{"image"},
+					TargetType: "string",
+					Title:      "CONTAINERIMAGE",
+				},
+			},
+			want: []extv1.CustomResourceColumnDefinition{
+				{
+					Name:     "CONTAINERIMAGE",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+			},
+		},
+		{
+			name: "empty title is rejected by builder",
+			input: []simpleschema.PrinterColumn{
+				{
+					Path:       []string{"className"},
+					TargetType: "string",
+					Title:      "",
+				},
+			},
+			wantErr:     true,
+			errContains: `spec field "className": printColumn requires a non-empty title`,
+		},
+		{
+			name: "non scalar columns are rejected by builder",
+			input: []simpleschema.PrinterColumn{
+				{
+					Path:       []string{"config"},
+					TargetType: "object",
+				},
+			},
+			wantErr:     true,
+			errContains: `spec field "config": printColumn marker only supports scalar fields`,
+		},
+		{
+			name: "non identifier path segments are rejected",
+			input: []simpleschema.PrinterColumn{
+				{
+					Path:       []string{"image-tag"},
+					TargetType: "string",
+					Title:      "IMAGE",
+				},
+			},
+			wantErr:     true,
+			errContains: `spec field "image-tag": printColumn only supports identifier-safe field names`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildInstanceSpecPrinterColumns(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestLookupSchemaAtField_AdditionalProperties(t *testing.T) {
 	tests := []struct {
@@ -3942,7 +4047,7 @@ func TestBuildInstanceSpecSchema(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := buildInstanceSpecSchema(tt.schema)
+			_, _, err := buildInstanceSpecSchema(tt.schema)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})

--- a/pkg/graph/crd/crd.go
+++ b/pkg/graph/crd/crd.go
@@ -28,10 +28,39 @@ import (
 // with the provided spec and status schemas.
 // scope must be either extv1.NamespaceScoped or extv1.ClusterScoped; defaults to NamespaceScoped.
 func SynthesizeCRD(group, apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool, scope extv1.ResourceScope, rgSchema *v1alpha1.Schema) *extv1.CustomResourceDefinition {
-	return newCRD(group, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride), scope, rgSchema.AdditionalPrinterColumns, rgSchema.Metadata)
+	return SynthesizeCRDWithPrinterColumns(group, apiVersion, kind, spec, status, statusFieldsOverride, scope, rgSchema, nil)
 }
 
-func newCRD(group, apiVersion, kind string, schema *extv1.JSONSchemaProps, scope extv1.ResourceScope, additionalPrinterColumns []extv1.CustomResourceColumnDefinition, metadata *v1alpha1.CRDMetadata) *extv1.CustomResourceDefinition {
+// SynthesizeCRDWithPrinterColumns generates a CRD and appends generated printer columns
+// after the configured CRD-level columns.
+func SynthesizeCRDWithPrinterColumns(
+	group, apiVersion, kind string,
+	spec, status extv1.JSONSchemaProps,
+	statusFieldsOverride bool,
+	scope extv1.ResourceScope,
+	rgSchema *v1alpha1.Schema,
+	generatedPrinterColumns []extv1.CustomResourceColumnDefinition,
+) *extv1.CustomResourceDefinition {
+	return newCRD(
+		group,
+		apiVersion,
+		kind,
+		newCRDSchema(spec, status, statusFieldsOverride),
+		scope,
+		rgSchema.AdditionalPrinterColumns,
+		generatedPrinterColumns,
+		rgSchema.Metadata,
+	)
+}
+
+func newCRD(
+	group, apiVersion, kind string,
+	schema *extv1.JSONSchemaProps,
+	scope extv1.ResourceScope,
+	additionalPrinterColumns []extv1.CustomResourceColumnDefinition,
+	generatedPrinterColumns []extv1.CustomResourceColumnDefinition,
+	metadata *v1alpha1.CRDMetadata,
+) *extv1.CustomResourceDefinition {
 	pluralKind := flect.Pluralize(strings.ToLower(kind))
 	if scope == "" {
 		scope = extv1.NamespaceScoped
@@ -72,7 +101,7 @@ func newCRD(group, apiVersion, kind string, schema *extv1.JSONSchemaProps, scope
 					Subresources: &extv1.CustomResourceSubresources{
 						Status: &extv1.CustomResourceSubresourceStatus{},
 					},
-					AdditionalPrinterColumns: newCRDAdditionalPrinterColumns(additionalPrinterColumns),
+					AdditionalPrinterColumns: newCRDAdditionalPrinterColumns(additionalPrinterColumns, generatedPrinterColumns),
 				},
 			},
 		},
@@ -113,12 +142,31 @@ func newCRDSchema(spec, status extv1.JSONSchemaProps, statusFieldsOverride bool)
 	}
 }
 
-func newCRDAdditionalPrinterColumns(additionalPrinterColumns []extv1.CustomResourceColumnDefinition) []extv1.CustomResourceColumnDefinition {
-	if len(additionalPrinterColumns) == 0 {
-		return defaultAdditionalPrinterColumns
+func newCRDAdditionalPrinterColumns(
+	additionalPrinterColumns []extv1.CustomResourceColumnDefinition,
+	generatedPrinterColumns []extv1.CustomResourceColumnDefinition,
+) []extv1.CustomResourceColumnDefinition {
+	baseColumns := additionalPrinterColumns
+	if len(baseColumns) == 0 {
+		baseColumns = defaultAdditionalPrinterColumns
 	}
 
-	return additionalPrinterColumns
+	mergedColumns := make([]extv1.CustomResourceColumnDefinition, 0, len(baseColumns)+len(generatedPrinterColumns))
+	mergedColumns = append(mergedColumns, baseColumns...)
+
+	seenJSONPaths := make(map[string]struct{}, len(baseColumns))
+	for _, column := range baseColumns {
+		seenJSONPaths[column.JSONPath] = struct{}{}
+	}
+	for _, column := range generatedPrinterColumns {
+		if _, ok := seenJSONPaths[column.JSONPath]; ok {
+			continue
+		}
+		seenJSONPaths[column.JSONPath] = struct{}{}
+		mergedColumns = append(mergedColumns, column)
+	}
+
+	return mergedColumns
 }
 
 // SetCRDStatus updates the status schema in a CRD.

--- a/pkg/graph/crd/crd_test.go
+++ b/pkg/graph/crd/crd_test.go
@@ -34,11 +34,13 @@ func TestSynthesizeCRD(t *testing.T) {
 		statusFieldsOverride bool
 		schema               *v1alpha1.Schema
 		scope                extv1.ResourceScope
+		generatedColumns     []extv1.CustomResourceColumnDefinition
 		expectedName         string
 		expectedGroup        string
 		expectedScope        extv1.ResourceScope
 		expectedLabels       map[string]string
 		expectedAnnotations  map[string]string
+		expectedColumns      []extv1.CustomResourceColumnDefinition
 	}{
 		{
 			name:                 "standard group and kind - namespaced",
@@ -53,6 +55,7 @@ func TestSynthesizeCRD(t *testing.T) {
 			expectedName:         "widgets.kro.com",
 			expectedGroup:        "kro.com",
 			expectedScope:        extv1.NamespaceScoped,
+			expectedColumns:      defaultAdditionalPrinterColumns,
 		},
 		{
 			name:                 "mixes case kind - namespaced",
@@ -67,6 +70,7 @@ func TestSynthesizeCRD(t *testing.T) {
 			expectedName:         "databases.kro.com",
 			expectedGroup:        "kro.com",
 			expectedScope:        extv1.NamespaceScoped,
+			expectedColumns:      defaultAdditionalPrinterColumns,
 		},
 		{
 			name:                 "cluster-scoped kind",
@@ -81,6 +85,7 @@ func TestSynthesizeCRD(t *testing.T) {
 			expectedName:         "clusterpolicies.kro.com",
 			expectedGroup:        "kro.com",
 			expectedScope:        extv1.ClusterScoped,
+			expectedColumns:      defaultAdditionalPrinterColumns,
 		},
 		{
 			name:                 "with labels and annotations",
@@ -110,6 +115,7 @@ func TestSynthesizeCRD(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"description": "Widget CRD",
 			},
+			expectedColumns: defaultAdditionalPrinterColumns,
 		},
 		{
 			name:                 "with empty labels and annotations",
@@ -126,15 +132,54 @@ func TestSynthesizeCRD(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			},
+			expectedName:    "widgets.kro.com",
+			expectedGroup:   "kro.com",
+			expectedScope:   extv1.NamespaceScoped,
+			expectedColumns: defaultAdditionalPrinterColumns,
+		},
+		{
+			name:                 "appends generated columns after defaults",
+			group:                "kro.com",
+			apiVersion:           "v1",
+			kind:                 "Widget",
+			spec:                 extv1.JSONSchemaProps{Type: "object"},
+			status:               extv1.JSONSchemaProps{Type: "object"},
+			statusFieldsOverride: true,
+			schema:               &v1alpha1.Schema{},
+			generatedColumns: []extv1.CustomResourceColumnDefinition{
+				{
+					Name:     "Image",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+			},
 			expectedName:  "widgets.kro.com",
 			expectedGroup: "kro.com",
 			expectedScope: extv1.NamespaceScoped,
+			expectedColumns: append(
+				append([]extv1.CustomResourceColumnDefinition{}, defaultAdditionalPrinterColumns...),
+				extv1.CustomResourceColumnDefinition{
+					Name:     "Image",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+			),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			crd := SynthesizeCRD(tt.group, tt.apiVersion, tt.kind, tt.spec, tt.status, tt.statusFieldsOverride, tt.scope, tt.schema)
+			crd := SynthesizeCRDWithPrinterColumns(
+				tt.group,
+				tt.apiVersion,
+				tt.kind,
+				tt.spec,
+				tt.status,
+				tt.statusFieldsOverride,
+				tt.scope,
+				tt.schema,
+				tt.generatedColumns,
+			)
 
 			assert.Equal(t, tt.expectedName, crd.Name)
 			assert.Equal(t, tt.expectedGroup, crd.Spec.Group)
@@ -154,7 +199,7 @@ func TestSynthesizeCRD(t *testing.T) {
 			require.NotNil(t, version.Subresources.Status)
 
 			assert.Equal(t, tt.expectedScope, crd.Spec.Scope)
-			assert.Equal(t, defaultAdditionalPrinterColumns, version.AdditionalPrinterColumns)
+			assert.Equal(t, tt.expectedColumns, version.AdditionalPrinterColumns)
 
 			if tt.expectedLabels == nil {
 				assert.Nil(t, crd.Labels)
@@ -181,6 +226,7 @@ func TestNewCRD(t *testing.T) {
 		kind                   string
 		scope                  extv1.ResourceScope
 		printerColumns         []extv1.CustomResourceColumnDefinition
+		generatedColumns       []extv1.CustomResourceColumnDefinition
 		expectedName           string
 		expectedKind           string
 		expectedPlural         string
@@ -290,12 +336,80 @@ func TestNewCRD(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "generated printer columns appended after defaults",
+			group:         "kro.com",
+			apiVersion:    "v2beta1",
+			kind:          "WebHook",
+			expectedScope: extv1.NamespaceScoped,
+			generatedColumns: []extv1.CustomResourceColumnDefinition{
+				{
+					Name:     "Image",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+			},
+			expectedName:     "webhooks.kro.com",
+			expectedKind:     "WebHook",
+			expectedPlural:   "webhooks",
+			expectedSingular: "webhook",
+			expectedPrinterColumns: append(
+				append([]extv1.CustomResourceColumnDefinition{}, defaultAdditionalPrinterColumns...),
+				extv1.CustomResourceColumnDefinition{
+					Name:     "Image",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+			),
+		},
+		{
+			name:          "generated printer columns respect explicit columns",
+			group:         "kro.com",
+			apiVersion:    "v2beta1",
+			kind:          "WebHook",
+			expectedScope: extv1.NamespaceScoped,
+			printerColumns: []extv1.CustomResourceColumnDefinition{
+				{
+					Name:     "Image",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+			},
+			generatedColumns: []extv1.CustomResourceColumnDefinition{
+				{
+					Name:     "Image",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+				{
+					Name:     "Tier",
+					Type:     "string",
+					JSONPath: ".spec.tier",
+				},
+			},
+			expectedName:     "webhooks.kro.com",
+			expectedKind:     "WebHook",
+			expectedPlural:   "webhooks",
+			expectedSingular: "webhook",
+			expectedPrinterColumns: []extv1.CustomResourceColumnDefinition{
+				{
+					Name:     "Image",
+					Type:     "string",
+					JSONPath: ".spec.image",
+				},
+				{
+					Name:     "Tier",
+					Type:     "string",
+					JSONPath: ".spec.tier",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			schema := &extv1.JSONSchemaProps{Type: "object"}
-			crd := newCRD(tt.group, tt.apiVersion, tt.kind, schema, tt.scope, tt.printerColumns, nil)
+			crd := newCRD(tt.group, tt.apiVersion, tt.kind, schema, tt.scope, tt.printerColumns, tt.generatedColumns, nil)
 
 			assert.Equal(t, tt.expectedName, crd.Name)
 			assert.Equal(t, tt.group, crd.Spec.Group)

--- a/pkg/simpleschema/markers.go
+++ b/pkg/simpleschema/markers.go
@@ -87,6 +87,8 @@ const (
 	MarkerTypeMinItems MarkerType = "minItems"
 	// MarkerTypeMaxItems represents the `maxItems` marker.
 	MarkerTypeMaxItems MarkerType = "maxItems"
+	// MarkerTypePrintColumn marks a scalar field for CRD printer column generation.
+	MarkerTypePrintColumn MarkerType = "printColumn"
 )
 
 func markerTypeFromString(s string) (MarkerType, error) {
@@ -94,7 +96,7 @@ func markerTypeFromString(s string) (MarkerType, error) {
 	case MarkerTypeRequired, MarkerTypeDefault, MarkerTypeDescription,
 		MarkerTypeMinimum, MarkerTypeMaximum, MarkerTypeValidation, MarkerTypeEnum, MarkerTypeImmutable,
 		MarkerTypePattern, MarkerTypeUniqueItems, MarkerTypeMinLength, MarkerTypeMaxLength, MarkerTypeMinItems,
-		MarkerTypeMaxItems:
+		MarkerTypeMaxItems, MarkerTypePrintColumn:
 		return MarkerType(s), nil
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnknownMarker, s)
@@ -258,6 +260,8 @@ func applyMarker(schema *extv1.JSONSchemaProps, marker *Marker, key string, pare
 		return applyMinItemsMarker(schema, marker)
 	case MarkerTypeMaxItems:
 		return applyMaxItemsMarker(schema, marker)
+	case MarkerTypePrintColumn:
+		return nil
 	default:
 		return fmt.Errorf("%w: %s", ErrUnknownMarker, marker.MarkerType)
 	}

--- a/pkg/simpleschema/markers_test.go
+++ b/pkg/simpleschema/markers_test.go
@@ -79,6 +79,18 @@ func TestApplyMarkers(t *testing.T) {
 			markers:    `description="A helpful description"`,
 			want:       &extv1.JSONSchemaProps{Type: "string", Description: "A helpful description"},
 		},
+		{
+			name:       "printColumn marker is schema no-op",
+			schemaType: "string",
+			markers:    `printColumn="IMAGE"`,
+			want:       &extv1.JSONSchemaProps{Type: "string"},
+		},
+		{
+			name:       "printColumn title marker is schema no-op",
+			schemaType: "string",
+			markers:    `printColumn="CONTAINERIMAGE"`,
+			want:       &extv1.JSONSchemaProps{Type: "string"},
+		},
 		// Minimum/Maximum markers
 		{
 			name:       "minimum",
@@ -431,6 +443,22 @@ func TestParseMarkers(t *testing.T) {
 				{MarkerType: MarkerTypeDefault, Key: "default", Value: "5"},
 				{MarkerType: MarkerTypeDescription, Key: "description", Value: "This is a description"},
 			},
+		},
+		{
+			name:  "printColumn marker",
+			input: `printColumn="IMAGE"`,
+			want: []*Marker{
+				{MarkerType: MarkerTypePrintColumn, Key: "printColumn", Value: "IMAGE"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "printColumn marker with title",
+			input: `printColumn="CONTAINERIMAGE"`,
+			want: []*Marker{
+				{MarkerType: MarkerTypePrintColumn, Key: "printColumn", Value: "CONTAINERIMAGE"},
+			},
+			wantErr: false,
 		},
 		{
 			name:  "complex markers with array as default value",

--- a/pkg/simpleschema/printercolumns.go
+++ b/pkg/simpleschema/printercolumns.go
@@ -1,0 +1,53 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simpleschema
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PrinterColumn describes a field marked with printColumn in SimpleSchema.
+// It captures only the logical path and the inferred schema type.
+type PrinterColumn struct {
+	Path       []string
+	TargetType string
+	Title      string
+}
+
+type printerColumnConfig struct {
+	Enabled bool
+	Title   string
+}
+
+func parsePrinterColumnConfig(markers []*Marker) (printerColumnConfig, error) {
+	config := printerColumnConfig{}
+	for _, marker := range markers {
+		if marker.MarkerType != MarkerTypePrintColumn {
+			continue
+		}
+
+		if config.Enabled {
+			return printerColumnConfig{}, fmt.Errorf("duplicate printColumn marker; only one is allowed per field")
+		}
+
+		config.Enabled = true
+		config.Title = strings.TrimSpace(marker.Value)
+		if config.Title == "" {
+			return printerColumnConfig{}, fmt.Errorf("printColumn requires a non-empty title")
+		}
+	}
+	return config, nil
+}

--- a/pkg/simpleschema/simpleschema.go
+++ b/pkg/simpleschema/simpleschema.go
@@ -20,7 +20,8 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-// ToOpenAPISpec converts a SimpleSchema object to an OpenAPI schema.
+// ToOpenAPISpec converts a SimpleSchema object to an OpenAPI schema and returns
+// any printer column intents inferred from printColumn markers on spec fields.
 //
 // The first input obj is a map[string]interface{} where the key is the field
 // name and the value is the field type.
@@ -28,12 +29,16 @@ import (
 // The second input customTypes is a map[string]interface{} where the key is
 // the type name and the value its specification. These custom types will be
 // available as predefined types in the transformer.
-func ToOpenAPISpec(obj map[string]interface{}, customTypes map[string]interface{}) (*extv1.JSONSchemaProps, error) {
+func ToOpenAPISpec(obj map[string]interface{}, customTypes map[string]interface{}) (*extv1.JSONSchemaProps, []PrinterColumn, error) {
 	t, err := newTransformer(customTypes)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return t.buildSchema(obj)
+	schema, printerColumns, err := t.buildSchema(obj, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return schema, printerColumns, nil
 }
 
 // FromOpenAPISpec converts an OpenAPI schema to a SimpleSchema object.

--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -17,6 +17,7 @@ package simpleschema
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -26,8 +27,9 @@ import (
 
 // customType stores the schema and required state for a custom type.
 type customType struct {
-	Schema   extv1.JSONSchemaProps
-	Required bool
+	Schema         extv1.JSONSchemaProps
+	Required       bool
+	PrinterColumns []PrinterColumn
 }
 
 type transformer struct {
@@ -97,11 +99,15 @@ func (t *transformer) loadCustomTypes(customTypes map[string]interface{}) error 
 
 	for _, name := range order {
 		spec := customTypes[name]
-		schema, required, err := t.buildCustomTypeSchema(name, spec)
+		schema, required, printerColumns, err := t.buildCustomTypeSchema(name, spec)
 		if err != nil {
 			return fmt.Errorf("building schema for %s: %w", name, err)
 		}
-		t.customTypes[name] = customType{Schema: *schema, Required: required}
+		t.customTypes[name] = customType{
+			Schema:         *schema,
+			Required:       required,
+			PrinterColumns: printerColumns,
+		}
 	}
 
 	return nil
@@ -110,41 +116,51 @@ func (t *transformer) loadCustomTypes(customTypes map[string]interface{}) error 
 // buildCustomTypeSchema builds a schema for a custom type definition.
 // Returns the schema and whether the type has required=true marker.
 // Precondition: spec is string or map[string]interface{} (parseSpec validates this).
-func (t *transformer) buildCustomTypeSchema(name string, spec interface{}) (*extv1.JSONSchemaProps, bool, error) {
+func (t *transformer) buildCustomTypeSchema(name string, spec interface{}) (*extv1.JSONSchemaProps, bool, []PrinterColumn, error) {
 	switch val := spec.(type) {
 	case string:
 		// Type alias: "MyType": "string | default=foo"
 		dummyParent := &extv1.JSONSchemaProps{}
-		schema, err := t.buildFieldFromString(name, val, dummyParent)
+		schema, printerColumns, err := t.buildFieldFromString(name, val, dummyParent, nil)
 		if err != nil {
-			return nil, false, err
+			return nil, false, nil, err
 		}
 		required := len(dummyParent.Required) > 0
-		return schema, required, nil
+		return schema, required, printerColumns, nil
 	default:
 		// Struct type: "MyType": { "field": "string" }
-		schema, err := t.buildSchema(val.(map[string]interface{}))
+		schema, printerColumns, err := t.buildSchema(val.(map[string]interface{}), nil)
 		if err != nil {
-			return nil, false, err
+			return nil, false, nil, err
 		}
-		return schema, false, nil
+		return schema, false, printerColumns, nil
 	}
 }
 
-func (t *transformer) buildSchema(spec map[string]interface{}) (*extv1.JSONSchemaProps, error) {
+func (t *transformer) buildSchema(spec map[string]interface{}, path []string) (*extv1.JSONSchemaProps, []PrinterColumn, error) {
 	schema := &extv1.JSONSchemaProps{
 		Type:       "object",
 		Properties: make(map[string]extv1.JSONSchemaProps),
 	}
 
 	childHasDefault := false
+	var printerColumns []PrinterColumn
 
-	for fieldName, fieldSpec := range spec {
-		fieldSchema, err := t.buildFieldSchema(fieldName, fieldSpec, schema)
+	fieldNames := make([]string, 0, len(spec))
+	for fieldName := range spec {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Strings(fieldNames)
+
+	for _, fieldName := range fieldNames {
+		fieldSpec := spec[fieldName]
+		fieldPath := extendPath(path, fieldName)
+		fieldSchema, fieldPrinterColumns, err := t.buildFieldSchema(fieldName, fieldSpec, schema, fieldPath)
 		if err != nil {
-			return nil, fmt.Errorf("field %s: %w", fieldName, err)
+			return nil, nil, fmt.Errorf("field %s: %w", fieldName, err)
 		}
 		schema.Properties[fieldName] = *fieldSchema
+		printerColumns = append(printerColumns, fieldPrinterColumns...)
 
 		if fieldSchema.Default != nil {
 			childHasDefault = true
@@ -158,41 +174,117 @@ func (t *transformer) buildSchema(spec map[string]interface{}) (*extv1.JSONSchem
 		schema.Default = &extv1.JSON{Raw: []byte("{}")}
 	}
 
-	return schema, nil
+	return schema, printerColumns, nil
 }
 
-func (t *transformer) buildFieldSchema(name string, spec interface{}, parent *extv1.JSONSchemaProps) (*extv1.JSONSchemaProps, error) {
+func (t *transformer) buildFieldSchema(name string, spec interface{}, parent *extv1.JSONSchemaProps, path []string) (*extv1.JSONSchemaProps, []PrinterColumn, error) {
 	switch val := spec.(type) {
 	case string:
-		return t.buildFieldFromString(name, val, parent)
+		return t.buildFieldFromString(name, val, parent, path)
 	case map[string]interface{}:
-		return t.buildSchema(val)
+		return t.buildSchema(val, path)
 	default:
-		return nil, fmt.Errorf("unexpected type: %T", spec)
+		return nil, nil, fmt.Errorf("unexpected type: %T", spec)
 	}
 }
 
-func (t *transformer) buildFieldFromString(name, fieldValue string, parent *extv1.JSONSchemaProps) (*extv1.JSONSchemaProps, error) {
+func (t *transformer) buildFieldFromString(name, fieldValue string, parent *extv1.JSONSchemaProps, path []string) (*extv1.JSONSchemaProps, []PrinterColumn, error) {
 	typ, markers, err := ParseField(fieldValue)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	schema, err := typ.Schema(t)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	var printerColumns []PrinterColumn
 
 	// Check if this is a custom type that has required=true
 	if custom, ok := typ.(types.Custom); ok {
-		if t.IsRequired(string(custom)) {
+		customType := t.customTypes[string(custom)]
+		if customType.Required {
 			parent.Required = append(parent.Required, name)
 		}
 	}
 
-	if err := applyMarkers(schema, markers, name, parent); err != nil {
-		return nil, err
+	printConfig, err := parsePrinterColumnConfig(markers)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return schema, nil
+	if err := applyMarkers(schema, markers, name, parent); err != nil {
+		return nil, nil, err
+	}
+
+	customTypesPrinterColumns, err := t.printerColumnsForType(typ)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(customTypesPrinterColumns) > 0 {
+		if printConfig.Enabled && len(customTypesPrinterColumns) > 1 {
+			return nil, nil, fmt.Errorf("printColumn on field %q references custom type with %d printer columns; title override is only allowed when the custom type produces exactly one column", name, len(customTypesPrinterColumns))
+		}
+		overrideTitle := ""
+		if printConfig.Enabled && len(customTypesPrinterColumns) == 1 {
+			overrideTitle = printConfig.Title
+		}
+		for _, column := range customTypesPrinterColumns {
+			expandedColumn := PrinterColumn{
+				Path:       extendPath(path, column.Path...),
+				TargetType: column.TargetType,
+				Title:      column.Title,
+			}
+			if overrideTitle != "" {
+				expandedColumn.Title = overrideTitle
+			}
+			printerColumns = append(printerColumns, expandedColumn)
+		}
+		return schema, printerColumns, nil
+	}
+
+	if printConfig.Enabled {
+		printerColumns = append(printerColumns, PrinterColumn{
+			Path:       append([]string(nil), path...),
+			TargetType: schema.Type,
+			Title:      printConfig.Title,
+		})
+	}
+
+	return schema, printerColumns, nil
+}
+
+func (t *transformer) printerColumnsForType(typ types.Type) ([]PrinterColumn, error) {
+	switch val := typ.(type) {
+	case types.Custom:
+		return t.customTypes[string(val)].PrinterColumns, nil
+	case types.Slice:
+		printerColumns, err := t.printerColumnsForType(val.Elem)
+		if err != nil {
+			return nil, err
+		}
+		if len(printerColumns) > 0 {
+			return nil, fmt.Errorf("printColumn markers inside array types are not supported")
+		}
+		return nil, nil
+	case types.Map:
+		printerColumns, err := t.printerColumnsForType(val.Value)
+		if err != nil {
+			return nil, err
+		}
+		if len(printerColumns) > 0 {
+			return nil, fmt.Errorf("printColumn markers inside map types are not supported")
+		}
+		return nil, nil
+	default:
+		return nil, nil
+	}
+}
+
+func extendPath(path []string, segments ...string) []string {
+	extended := make([]string, 0, len(path)+len(segments))
+	extended = append(extended, path...)
+	extended = append(extended, segments...)
+	return extended
 }

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -26,11 +26,12 @@ import (
 
 func TestBuildOpenAPISchema(t *testing.T) {
 	tests := []struct {
-		name    string
-		obj     map[string]interface{}
-		types   map[string]interface{}
-		want    *extv1.JSONSchemaProps
-		wantErr bool
+		name          string
+		obj           map[string]interface{}
+		types         map[string]interface{}
+		want          *extv1.JSONSchemaProps
+		requiredTypes map[string]bool
+		wantErr       bool
 	}{
 		{
 			name: "Complex nested schema",
@@ -124,6 +125,28 @@ func TestBuildOpenAPISchema(t *testing.T) {
 						},
 					},
 				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Required custom type marks field as required",
+			obj: map[string]interface{}{
+				"value": "RequiredString",
+			},
+			types: map[string]interface{}{
+				"RequiredString": "string | required=true",
+				"OptionalString": "string",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type:     "object",
+				Required: []string{"value"},
+				Properties: map[string]extv1.JSONSchemaProps{
+					"value": {Type: "string"},
+				},
+			},
+			requiredTypes: map[string]bool{
+				"RequiredString": true,
+				"OptionalString": false,
 			},
 			wantErr: false,
 		},
@@ -1069,11 +1092,22 @@ func TestBuildOpenAPISchema(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ToOpenAPISpec(tt.obj, tt.types)
+			got, _, err := ToOpenAPISpec(tt.obj, tt.types)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildOpenAPISchema() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
+			if tt.requiredTypes != nil {
+				transformer, err := newTransformer(tt.types)
+				if err != nil {
+					t.Fatalf("newTransformer() error = %v", err)
+				}
+				for typeName, wantRequired := range tt.requiredTypes {
+					assert.Equal(t, wantRequired, transformer.IsRequired(typeName))
+				}
+			}
+
 			assert.Equal(t, got, tt.want)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BuildOpenAPISchema() = %+v, want %+v", got, tt.want)
@@ -1284,7 +1318,7 @@ func TestDefaultPropagation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ToOpenAPISpec(tt.obj, tt.types)
+			got, _, err := ToOpenAPISpec(tt.obj, tt.types)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ToOpenAPISpec() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1292,6 +1326,280 @@ func TestDefaultPropagation(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ToOpenAPISpec() mismatch:\ngot:  %+v\nwant: %+v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestToOpenAPISpecPrinterColumns(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         map[string]interface{}
+		types       map[string]interface{}
+		wantColumns []PrinterColumn
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "scalar spec fields generate printer columns",
+			obj: map[string]interface{}{
+				"image": `string | printColumn="IMAGE"`,
+				"port":  `float | printColumn="PORT"`,
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "string",
+					Path:       []string{"image"},
+					Title:      "IMAGE",
+				},
+				{
+					TargetType: "float",
+					Path:       []string{"port"},
+					Title:      "PORT",
+				},
+			},
+		},
+		{
+			name: "scalar spec fields can override printer column titles",
+			obj: map[string]interface{}{
+				"image": `string | printColumn="CONTAINERIMAGE"`,
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "string",
+					Path:       []string{"image"},
+					Title:      "CONTAINERIMAGE",
+				},
+			},
+		},
+		{
+			name: "empty printColumn title returns error",
+			obj: map[string]interface{}{
+				"image": `string | printColumn=""`,
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate printColumn markers are rejected",
+			obj: map[string]interface{}{
+				"image": `string | printColumn="IMAGE" printColumn="IMG"`,
+			},
+			wantErr: true,
+		},
+		{
+			name: "nested object fields generate nested json paths",
+			obj: map[string]interface{}{
+				"ingress": map[string]interface{}{
+					"className": `string | printColumn="CLASSNAME"`,
+					"enabled":   `boolean | printColumn="ENABLED"`,
+				},
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "string",
+					Path:       []string{"ingress", "className"},
+					Title:      "CLASSNAME",
+				},
+				{
+					TargetType: "boolean",
+					Path:       []string{"ingress", "enabled"},
+					Title:      "ENABLED",
+				},
+			},
+		},
+		{
+			name: "custom type printer columns expand without a reference marker",
+			obj: map[string]interface{}{
+				"ingress": "Ingress",
+				"port":    "Port",
+			},
+			types: map[string]interface{}{
+				"Ingress": map[string]interface{}{
+					"enabled": `boolean | printColumn="ENABLED"`,
+				},
+				"Port": `integer | printColumn="PORT"`,
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "boolean",
+					Path:       []string{"ingress", "enabled"},
+					Title:      "ENABLED",
+				},
+				{
+					TargetType: "integer",
+					Path:       []string{"port"},
+					Title:      "PORT",
+				},
+			},
+		},
+		{
+			name: "custom type printer columns allow single-column title override at the reference field",
+			obj: map[string]interface{}{
+				"ingress": `Ingress | printColumn="INGRESS"`,
+				"port":    `Port | printColumn="PORT"`,
+			},
+			types: map[string]interface{}{
+				"Ingress": map[string]interface{}{
+					"enabled": `boolean | printColumn="ENABLED"`,
+				},
+				"Port": `integer | printColumn="VALUE"`,
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "boolean",
+					Path:       []string{"ingress", "enabled"},
+					Title:      "INGRESS",
+				},
+				{
+					TargetType: "integer",
+					Path:       []string{"port"},
+					Title:      "PORT",
+				},
+			},
+		},
+		{
+			name: "custom type printer columns can be overridden when exactly one column is generated",
+			obj: map[string]interface{}{
+				"release": `ReleaseChannel | printColumn="RELEASE"`,
+			},
+			types: map[string]interface{}{
+				"ReleaseChannel": `string | printColumn="CHANNEL"`,
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "string",
+					Path:       []string{"release"},
+					Title:      "RELEASE",
+				},
+			},
+		},
+		{
+			name: "printColumn on multi-column custom type is rejected",
+			obj: map[string]interface{}{
+				"ingress": `Ingress | printColumn="INGRESS"`,
+			},
+			types: map[string]interface{}{
+				"Ingress": map[string]interface{}{
+					"className": `string | printColumn="CLASSNAME"`,
+					"enabled":   `boolean | printColumn="ENABLED"`,
+				},
+			},
+			wantErr:     true,
+			errContains: `field ingress: printColumn on field "ingress" references custom type with 2 printer columns`,
+		},
+		{
+			name: "array of printer-marked custom type is rejected",
+			obj: map[string]interface{}{
+				"ports": "[]Port",
+			},
+			types: map[string]interface{}{
+				"Port": `integer | printColumn="PORT"`,
+			},
+			wantErr:     true,
+			errContains: `field ports: printColumn markers inside array types are not supported`,
+		},
+		{
+			name: "map of printer-marked custom type is rejected",
+			obj: map[string]interface{}{
+				"ingresses": "map[string]Ingress",
+			},
+			types: map[string]interface{}{
+				"Ingress": map[string]interface{}{
+					"enabled": `boolean | printColumn="ENABLED"`,
+				},
+			},
+			wantErr:     true,
+			errContains: `field ingresses: printColumn markers inside map types are not supported`,
+		},
+		{
+			name: "alias wrapping collection of printer-marked custom type is rejected",
+			obj: map[string]interface{}{
+				"ports": "PortList",
+			},
+			types: map[string]interface{}{
+				"Port":     `integer | printColumn="PORT"`,
+				"PortList": `[]Port`,
+			},
+			wantErr:     true,
+			errContains: `building schema for PortList: printColumn markers inside array types are not supported`,
+		},
+		{
+			name: "deeply nested custom type printer columns keep distinct paths",
+			obj: map[string]interface{}{
+				"platform": map[string]interface{}{
+					"networking": map[string]interface{}{
+						"ingress": "Ingress",
+					},
+				},
+			},
+			types: map[string]interface{}{
+				"Ingress": map[string]interface{}{
+					"className": `string | printColumn="CLASSNAME"`,
+					"enabled":   `boolean | printColumn="ENABLED"`,
+				},
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "string",
+					Path:       []string{"platform", "networking", "ingress", "className"},
+					Title:      "CLASSNAME",
+				},
+				{
+					TargetType: "boolean",
+					Path:       []string{"platform", "networking", "ingress", "enabled"},
+					Title:      "ENABLED",
+				},
+			},
+		},
+		{
+			name: "non scalar field keeps printer intent",
+			obj: map[string]interface{}{
+				"config": `object | printColumn="CONFIG"`,
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "object",
+					Path:       []string{"config"},
+					Title:      "CONFIG",
+				},
+			},
+		},
+		{
+			name: "custom object field keeps printer intent",
+			obj: map[string]interface{}{
+				"config": `Config | printColumn="CONFIG"`,
+			},
+			types: map[string]interface{}{
+				"Config": map[string]interface{}{
+					"name": "string",
+				},
+			},
+			wantColumns: []PrinterColumn{
+				{
+					TargetType: "object",
+					Path:       []string{"config"},
+					Title:      "CONFIG",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema, gotColumns, err := ToOpenAPISpec(tt.obj, tt.types)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ToOpenAPISpec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if schema == nil {
+				t.Fatal("ToOpenAPISpec() returned nil schema")
+			}
+			assert.Equal(t, tt.wantColumns, gotColumns)
 		})
 	}
 }
@@ -1487,7 +1795,7 @@ func TestComplexSchemaE2E(t *testing.T) {
 		},
 	}
 
-	got, err := ToOpenAPISpec(obj, types)
+	got, _, err := ToOpenAPISpec(obj, types)
 	if err != nil {
 		t.Fatalf("ToOpenAPISpec() error = %v", err)
 	}

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -107,6 +107,67 @@ var _ = Describe("CRD", func() {
 			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 		})
 
+		It("should generate printer columns for nested custom types with printColumn", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-crd-kubectl-print",
+				generator.WithSchema(
+					"PrintColumnTest", "v1alpha1",
+					map[string]interface{}{
+						"image": `string | printColumn="CONTAINERIMAGE"`,
+						"platform": map[string]interface{}{
+							"networking": map[string]interface{}{
+								"ingress": "IngressSettings",
+							},
+						},
+						"release": map[string]interface{}{
+							"channel": `ReleaseChannel | printColumn="RELEASE"`,
+						},
+					},
+					nil,
+					generator.WithTypes(map[string]interface{}{
+						"IngressSettings": map[string]interface{}{
+							"className": `string | printColumn="CLASSNAME"`,
+							"enabled":   `boolean | printColumn="ENABLED"`,
+						},
+						"ReleaseChannel": `string | printColumn="CHANNEL"`,
+					}),
+				),
+			)
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			Eventually(func(g Gomega, ctx SpecContext) {
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{
+					Name: "printcolumntests.kro.run",
+				}, crd)).To(Succeed())
+
+				cols := crd.Spec.Versions[0].AdditionalPrinterColumns
+				columnsByJSONPath := make(map[string]apiextensionsv1.CustomResourceColumnDefinition, len(cols))
+				for _, column := range cols {
+					columnsByJSONPath[column.JSONPath] = column
+				}
+
+				g.Expect(columnsByJSONPath).To(HaveKey(".spec.image"))
+				g.Expect(columnsByJSONPath[".spec.image"].Name).To(Equal("CONTAINERIMAGE"))
+				g.Expect(columnsByJSONPath[".spec.image"].Type).To(Equal("string"))
+
+				g.Expect(columnsByJSONPath).To(HaveKey(".spec.platform.networking.ingress.className"))
+				g.Expect(columnsByJSONPath[".spec.platform.networking.ingress.className"].Name).To(Equal("CLASSNAME"))
+				g.Expect(columnsByJSONPath[".spec.platform.networking.ingress.className"].Type).To(Equal("string"))
+
+				g.Expect(columnsByJSONPath).To(HaveKey(".spec.platform.networking.ingress.enabled"))
+				g.Expect(columnsByJSONPath[".spec.platform.networking.ingress.enabled"].Name).To(Equal("ENABLED"))
+				g.Expect(columnsByJSONPath[".spec.platform.networking.ingress.enabled"].Type).To(Equal("boolean"))
+
+				g.Expect(columnsByJSONPath).To(HaveKey(".spec.release.channel"))
+				g.Expect(columnsByJSONPath[".spec.release.channel"].Name).To(Equal("RELEASE"))
+				g.Expect(columnsByJSONPath[".spec.release.channel"].Type).To(Equal("string"))
+
+				g.Expect(crd.Spec.Versions[0].AdditionalPrinterColumns).To(HaveLen(7))
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
 		It("should update CRD when ResourceGraphDefinition is updated", func(ctx SpecContext) {
 			// Create initial ResourceGraphDefinition
 			rgd := generator.NewResourceGraphDefinition("test-crd-update",

--- a/website/docs/api/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/website/docs/api/crds/kro.run_resourcegraphdefinitions.yaml
@@ -198,7 +198,7 @@ spec:
                         IncludeWhen is a list of CEL expressions that determine whether this resource should be created.
                         All expressions must evaluate to true for the resource to be included.
                         If not specified, the resource is always included.
-                        Expressions may reference schema fields and upstream resources. They are
+                        Expressions may reference schema fields and/or fields in other resources in the RGD. They are
                         re-evaluated during reconciliation, so resources may be created later or
                         pruned later as conditions change.
                         Example: ["schema.spec.enableMonitoring == true", "network.status.ready == true"]

--- a/website/docs/api/specifications/simple-schema.md
+++ b/website/docs/api/specifications/simple-schema.md
@@ -235,6 +235,7 @@ Fields can have multiple markers for validation and documentation:
 name: string | required=true default="app" description="Application name"
 replicas: integer | default=3 minimum=1 maximum=10
 mode: string | enum="debug,info,warn,error" default="info"
+image: string | printColumn="IMAGE"
 ```
 
 ### Supported Markers
@@ -252,8 +253,11 @@ mode: string | enum="debug,info,warn,error" default="info"
 - `uniqueItems=true`: Ensures array elements are unique
 - `minItems=number`: Minimum number of items in arrays
 - `maxItems=number`: Maximum number of items in arrays
+- `printColumn="Title"`: Adds a printer column and uses `Title` as the column header
 
 Multiple markers can be combined using the `|` separator.
+
+`printColumn` only supports fields whose generated JSONPath uses identifier-safe segments.
 
 ### String Validation Markers
 
@@ -438,19 +442,45 @@ override them with its own values.
 
 ## Additional Printer Columns
 
-You can define `additionalPrinterColumns` for the created CRD through the ResourceGraphDefinition by setting them on `spec.schema.additionalPrinterColumns`.
+Fields in `schema.spec` can opt into generated CRD printer columns directly:
 
 ```kro
 schema:
   spec:
-    image: string | default="nginx"
+    image: string | default="nginx" printColumn="CONTAINERIMAGE"
+    ingress:
+      enabled: boolean | default=false printColumn="ENABLED"
+```
+
+This generates printer columns with inferred names, types, and JSONPaths such as
+`.spec.image` and `.spec.ingress.enabled`.
+
+For custom types, any scalar subfields inside that type that are marked with
+`printColumn` expand under every reference path where that type is used.
+
+```kro
+schema:
+  spec:
+    ingress: IngressSettings
+  types:
+    IngressSettings:
+      className: string | printColumn="CLASSNAME"
+      enabled: boolean | printColumn="ENABLED"
+```
+
+This generates columns like `CLASSNAME` and `ENABLED`.
+
+For status fields or any case that needs an explicit JSONPath, you can still define
+`additionalPrinterColumns` on `spec.schema.additionalPrinterColumns`.
+
+```kro
+schema:
+  spec:
+    image: string | default="nginx" printColumn="IMAGE"
   status:
     availableReplicas: ${deployment.status.availableReplicas}
   additionalPrinterColumns:
     - jsonPath: .status.availableReplicas
       name: Available replicas
       type: integer
-    - jsonPath: .spec.image
-      name: Image
-      type: string
 ```

--- a/website/src/theme/CodeBlock/highlighter.ts
+++ b/website/src/theme/CodeBlock/highlighter.ts
@@ -9,7 +9,8 @@
 export const MARKER_KEYWORDS = new Set([
   'required', 'default', 'optional', 'description', 'enum',
   'minimum', 'maximum', 'immutable', 'pattern',
-  'minLength', 'maxLength', 'uniqueItems', 'minItems', 'maxItems'
+  'minLength', 'maxLength', 'uniqueItems', 'minItems', 'maxItems',
+  'printColumn'
 ]);
 
 // kro-specific keywords


### PR DESCRIPTION
Teach SimpleSchema to parse `printColumn="TITLE"` and carry printer-column
intent through schema transformation into CRD `additionalPrinterColumns`.

Generated columns are inferred from scalar spec fields, expanded through
custom types, merged with explicit CRD columns, and deduped by JSONPath.
Invalid marker usage now fails fast (empty title, non-scalar target type,
or unsupported path segment for Kubernetes JSONPath).

Update unit and integration tests, docs, examples, and website highlighting.

Example UX:
```yaml
schema:
  spec:
    image: string | default="nginx" printColumn="IMAGE"
    ingress:
      enabled: boolean | default=false printColumn="ENABLED"
```