### PR TITLE
Add a Grafana dashboard for KRO controller metrics.

### DIFF
--- a/config/grafana/dashboard-scale-testing.json
+++ b/config/grafana/dashboard-scale-testing.json
@@ -1,0 +1,9643 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Scale Test - Dynamic Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 401,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_registered_gvrs{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Registered GVRs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 402,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed Instance GVRs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 403,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_handler_count_total{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Handlers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 404,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_watch_count{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Watches",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 405,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_queue_length{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "DC Queue Length",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 406,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_stale_registrations{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Stale Registrations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 407,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(dynamic_controller_register_rollback_total{namespace=\"kro\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Register Rollbacks (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 408,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_watch_request_count{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Watch Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 460,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_register_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Registers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "id": 461,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_deregister_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Deregisters",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "id": 462,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_register_failures_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Register Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "id": 463,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_deregister_failures_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Deregister Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "id": 464,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_register_rollback_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Rollbacks",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "id": 465,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(workqueue_adds_total{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Queue Adds",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "workqueue_work_duration_seconds for the dynamic-controller queue; includes queue item processing around handler execution and is not the same as handler reconcile runtime",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 409,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "D"
+        }
+      ],
+      "title": "DC Workqueue Processing Duration (p50 / p90 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "workqueue_queue_duration_seconds for the dynamic-controller queue; time items spend waiting before a worker starts processing them",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 410,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "D"
+        }
+      ],
+      "title": "DC Queue Wait (p50 / p90 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "Dynamic-controller queue throughput and backlog signals from the shared workqueue",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 411,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(workqueue_adds_total{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "adds/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(workqueue_retries_total{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "retries/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "workqueue_depth{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}",
+          "interval": "10s",
+          "legendFormat": "queue depth",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "workqueue_unfinished_work_seconds{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}",
+          "interval": "10s",
+          "legendFormat": "unfinished (s)",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(workqueue_work_duration_seconds_count{namespace=\"kro\",controller=\"dynamic-controller-queue\"}[1m]))",
+          "interval": "10s",
+          "legendFormat": "completions/s",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(dynamic_controller_requeue_total{type=\"requeue_after\"}[1m]))",
+          "interval": "10s",
+          "legendFormat": "requeue_after/s",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(rate(workqueue_work_duration_seconds_count{namespace=\"kro\",controller=\"dynamic-controller-queue\"}[1m])) - sum(rate(workqueue_adds_total{namespace=\"kro\",controller=\"dynamic-controller-queue\"}[1m]))",
+          "interval": "10s",
+          "legendFormat": "net drain/s",
+          "refId": "G"
+        }
+      ],
+      "title": "DC Throughput & Backpressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 412,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "register/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_deregister_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "deregister/s",
+          "refId": "B"
+        }
+      ],
+      "title": "GVR Registration Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 413,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_failures_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "register fail/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_deregister_failures_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "deregister fail/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_rollback_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "rollback/s",
+          "refId": "C"
+        }
+      ],
+      "title": "Registration Errors (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 414,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "instance GVRs",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_registered_gvrs{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "parent GVRs",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_handler_count_total{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "handlers",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_watch_count{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "watches",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_stale_registrations{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "stale",
+          "refId": "E"
+        }
+      ],
+      "title": "DC Inventory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "dynamic_controller_reconcile_duration_seconds recorded in DynamicController.syncFunc around actual handler execution",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 22
+      },
+      "id": 415,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "D"
+        }
+      ],
+      "title": "DC Handler Reconcile Duration (p50 / p90 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "Dynamic-controller throughput and error signals from reconcile, requeue, handler error, and routed-match counters",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 22
+      },
+      "id": 416,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_reconcile_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "reconcile/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_requeue_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "requeue/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_errors_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "handler error/s",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_route_match_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "route match/s",
+          "refId": "D"
+        }
+      ],
+      "title": "DC Reconcile / Requeue / Error Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "id": 417,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "cpu cores",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}) / 1073741824",
+          "interval": "10s",
+          "legendFormat": "memory GiB",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(go_goroutines{namespace=\"kro\",service=\"kro-metrics\"}) / 1000",
+          "interval": "10s",
+          "legendFormat": "goroutines (k)",
+          "refId": "C"
+        }
+      ],
+      "title": "CPU / Memory / Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 418,
+      "panels": [],
+      "title": "Scale Test - Instance Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 30
+      },
+      "id": 419,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(apiserver_storage_objects{resource=\"resourcegraphdefinitions.kro.run\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGDs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 30
+      },
+      "id": 420,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(max by (resource) (apiserver_storage_objects{resource=~\".+\\\\.kro\\\\.run\",resource!=\"resourcegraphdefinitions.kro.run\"}))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 30
+      },
+      "id": 421,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "(count(kube_configmap_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_secret_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_serviceaccount_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_deployment_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_role_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_rolebinding_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_service_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_buckets_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_vpcs_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_tables_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_subnets_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_routetables_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_securitygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_dbinstances_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_dbsubnetgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5001stacks_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5002platforms_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5003workloads_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5004securities_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5005data_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5006clones_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5007platformcoregroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5008platformconfiggroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5009platformauthgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5010platformrbacgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5011platformackgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5012workloadswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5013workloadsapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5014workloadsworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5015workloadsbatchgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5016securitysecretsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5017securityidentitygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5018securitypolicygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5019datanetworkgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5020datastoragegroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5021dataeventsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5022cloneswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5023clonesapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5024clonesworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5025clonesmixedgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5026platformcoreprimaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5027platformcoresecondaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5028platformconfigmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5029platformauthmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5030platformrbacmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5031platformnetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5032platformdatamains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5033webmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5034webedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5035apimains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5036apiadmins_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5037workermains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5038batchmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5039securitysecretsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5040securityidentitymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5041securitypolicymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5042datanetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5043datanetworkedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5044datastoragemains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5045datastoragearchives_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5046dataeventsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5047webclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5048apiclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5049workerclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5050mixedclonea_info{kro_owned=\"true\"}) or vector(0))",
+          "interval": "10s",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Managed Children",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 30
+      },
+      "id": 466,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_instance_watch_count{parent_gvr=~\".*/.*stacks$\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "stacks",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Stacks",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 30
+      },
+      "id": 422,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(instance_controller_status_update_conflicts_total{namespace=\"kro\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Conflicts (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 30
+      },
+      "id": 423,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(instance_controller_status_update_retries_total{namespace=\"kro\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Retries (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 34
+      },
+      "id": 450,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(instance_controller_applyset_apply_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Applies",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 34
+      },
+      "id": 451,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(instance_controller_applyset_prune_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Prunes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 34
+      },
+      "id": 452,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(instance_controller_desired_objects_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Desired Objects",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 34
+      },
+      "id": 453,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(instance_controller_planned_nodes_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Planned Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 34
+      },
+      "id": 454,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(instance_controller_status_update_conflicts_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Status Conflicts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 34
+      },
+      "id": 455,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(instance_controller_status_update_retries_total{namespace=\"kro\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Status Retries",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 428,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count(kube_configmap_labels{label_kro_run_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "ConfigMap",
+          "refId": "A"
+        },
+        {
+          "expr": "count(kube_secret_labels{label_kro_run_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "Secret",
+          "refId": "B"
+        },
+        {
+          "expr": "count(kube_serviceaccount_labels{label_kro_run_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "ServiceAccount",
+          "refId": "C"
+        },
+        {
+          "expr": "count(kube_deployment_labels{label_kro_run_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "Deployment",
+          "refId": "D"
+        },
+        {
+          "expr": "count(kube_role_labels{label_kro_run_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "Role",
+          "refId": "E"
+        },
+        {
+          "expr": "count(kube_rolebinding_labels{label_kro_run_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "RoleBinding",
+          "refId": "F"
+        },
+        {
+          "expr": "count(kube_service_labels{label_kro_run_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "kube_service_labels",
+          "refId": "G"
+        },
+        {
+          "expr": "count(kube_buckets_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "S3 Bucket",
+          "refId": "H"
+        },
+        {
+          "expr": "count(kube_vpcs_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "VPC",
+          "refId": "I"
+        },
+        {
+          "expr": "count(kube_subnets_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "Subnet",
+          "refId": "J"
+        },
+        {
+          "expr": "count(kube_routetables_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "RouteTable",
+          "refId": "K"
+        },
+        {
+          "expr": "count(kube_securitygroups_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "SecurityGroup",
+          "refId": "L"
+        },
+        {
+          "expr": "count(kube_tables_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "DynamoDB Table",
+          "refId": "M"
+        },
+        {
+          "expr": "count(kube_dbinstances_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "DBInstance",
+          "refId": "N"
+        },
+        {
+          "expr": "count(kube_dbsubnetgroups_info{kro_owned=\"true\"}) or vector(0)",
+          "interval": "10s",
+          "legendFormat": "DBSubnetGroup",
+          "refId": "O"
+        },
+        {
+          "expr": "(count(kube_graphheavy5001stacks_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5002platforms_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5003workloads_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5004securities_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5005data_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5006clones_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5007platformcoregroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5008platformconfiggroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5009platformauthgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5010platformrbacgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5011platformackgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5012workloadswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5013workloadsapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5014workloadsworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5015workloadsbatchgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5016securitysecretsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5017securityidentitygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5018securitypolicygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5019datanetworkgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5020datastoragegroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5021dataeventsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5022cloneswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5023clonesapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5024clonesworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5025clonesmixedgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5026platformcoreprimaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5027platformcoresecondaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5028platformconfigmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5029platformauthmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5030platformrbacmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5031platformnetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5032platformdatamains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5033webmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5034webedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5035apimains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5036apiadmins_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5037workermains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5038batchmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5039securitysecretsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5040securityidentitymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5041securitypolicymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5042datanetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5043datanetworkedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5044datastoragemains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5045datastoragearchives_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5046dataeventsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5047webclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5048apiclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5049workerclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_graphheavy5050mixedclonea_info{kro_owned=\"true\"}) or vector(0))",
+          "interval": "10s",
+          "legendFormat": "kro Instances",
+          "refId": "P"
+        }
+      ],
+      "title": "Managed Children by Kind",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 429,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, max by (resource) (apiserver_storage_objects{resource=~\".+\\\\.kro\\\\.run\",resource!=\"resourcegraphdefinitions.kro.run\"}))",
+          "interval": "10s",
+          "legendFormat": "{{resource}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Instances by RGD Type (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 45
+      },
+      "id": 430,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_applyset_apply_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "apply/s",
+          "refId": "A"
+        }
+      ],
+      "title": "ApplySet Apply Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 45
+      },
+      "id": 431,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_applyset_prune_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "prune/s",
+          "refId": "A"
+        }
+      ],
+      "title": "ApplySet Prune Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 45
+      },
+      "id": 432,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_desired_objects_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "desired objects/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_planned_nodes_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "planned nodes/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Desired Objects & Planned Nodes (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 45
+      },
+      "id": 433,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_status_update_conflicts_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "conflicts/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_status_update_retries_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "retries/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Status Conflicts & Retries (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 52
+      },
+      "id": 434,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "D"
+        }
+      ],
+      "title": "ApplySet Apply Duration (p50 / p90 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 52
+      },
+      "id": 435,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "D"
+        }
+      ],
+      "title": "ApplySet Prune Duration (p50 / p90 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "workqueue_work_duration_seconds for the dynamic-controller queue; includes queue item processing around handler execution and is not the same as handler reconcile runtime",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 52
+      },
+      "id": 436,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",controller=\"dynamic-controller-queue\",name=\"dynamic-controller-queue\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "D"
+        }
+      ],
+      "title": "DC Workqueue Processing Duration (p50 / p90 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 60
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}[2m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 60
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Working Set",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 60
+      },
+      "id": 98,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(go_goroutines{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 60
+      },
+      "id": 7,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(container_memory_working_set_bytes{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}) / clamp_min(sum(kube_pod_container_resource_limits{namespace=\"kro\",container=\"kro\",resource=\"memory\",unit=\"byte\"}), 1)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Limit Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 65
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(controller_runtime_reconcile_total{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 65
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(workqueue_depth{namespace=\"kro\",service=\"kro-metrics\",name=\"ResourceGraphDefinition\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 65
+      },
+      "id": 6,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(controller_runtime_active_workers{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}) / clamp_min(sum(controller_runtime_max_concurrent_reconciles{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}), 1)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Worker Utilization",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 65
+      },
+      "id": 94,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * (1 - sum(rate(controller_runtime_reconcile_errors_total{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m])) / clamp_min(sum(rate(controller_runtime_reconcile_total{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m])), 1))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile Success",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 70
+      },
+      "id": 99,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_reconcile_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Reconcile Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 70
+      },
+      "id": 100,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_queue_length{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Queue Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 70
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed GVRs (Dynamic)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 70
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Handler Errors (errors/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 75
+      },
+      "id": 95,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m])))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "p99 of dynamic_controller_reconcile_duration_seconds, recorded in DynamicController.syncFunc around the actual handler execution path",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 75
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Handler Reconcile p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 75
+      },
+      "id": 96,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * (1 - sum(rate(rgd_graph_build_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) / clamp_min(sum(rate(rgd_graph_build_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])), 1)) or vector(100)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RGDs"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "scheme"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Instances"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "scheme"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 75
+      },
+      "id": 97,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(apiserver_storage_objects{resource=\"resourcegraphdefinitions.kro.run\",job=\"apiserver-direct\"})",
+          "interval": "10s",
+          "legendFormat": "RGDs",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(max by (resource) (apiserver_storage_objects{resource=~\".+\\\\.kro\\\\.run\",resource!=\"resourcegraphdefinitions.kro.run\",job=\"apiserver-direct\"}))",
+          "interval": "10s",
+          "legendFormat": "Instances",
+          "refId": "B"
+        }
+      ],
+      "title": "kro Objects (API Server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 80
+      },
+      "id": 220,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(max by (resource) (apiserver_storage_objects{resource=~\".+\\\\.kro\\\\.run\",resource!=\"resourcegraphdefinitions.kro.run\",job=\"apiserver-direct\"}))",
+          "interval": "10s",
+          "legendFormat": "Instances",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 80
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "(count(kube_configmap_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_secret_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_serviceaccount_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_deployment_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_role_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_rolebinding_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_service_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_buckets_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_vpcs_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_tables_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_subnets_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_routetables_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_securitygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_dbinstances_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_dbsubnetgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5001stacks_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5002platforms_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5003workloads_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5004securities_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5005data_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5006clones_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5007platformcoregroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5008platformconfiggroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5009platformauthgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5010platformrbacgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5011platformackgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5012workloadswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5013workloadsapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5014workloadsworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5015workloadsbatchgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5016securitysecretsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5017securityidentitygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5018securitypolicygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5019datanetworkgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5020datastoragegroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5021dataeventsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5022cloneswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5023clonesapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5024clonesworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5025clonesmixedgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5026platformcoreprimaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5027platformcoresecondaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5028platformconfigmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5029platformauthmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5030platformrbacmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5031platformnetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5032platformdatamains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5033webmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5034webedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5035apimains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5036apiadmins_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5037workermains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5038batchmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5039securitysecretsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5040securityidentitymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5041securitypolicymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5042datanetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5043datanetworkedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5044datastoragemains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5045datastoragearchives_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5046dataeventsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5047webclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5048apiclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5049workerclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5050mixedclonea_info{kro_owned=\"true\"}) or vector(0))",
+          "interval": "10s",
+          "legendFormat": "{{__name__}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed Child Resources",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "kube_(.+)_labels",
+            "renamePattern": "$1"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 80
+      },
+      "id": 206,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval])))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "title": "CEL Eval Latency (p50 / p90 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 80
+      },
+      "id": 105,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"hit\"})",
+          "interval": "10s",
+          "legendFormat": "hits",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"miss\"})",
+          "interval": "10s",
+          "legendFormat": "misses",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"error\"})",
+          "interval": "10s",
+          "legendFormat": "errors",
+          "refId": "C"
+        }
+      ],
+      "title": "CEL Builder Cache Totals",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 88
+      },
+      "id": 204,
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (le) (increase(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "interval": "10s",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile Duration",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "Heatmap of dynamic_controller_reconcile_duration_seconds buckets from DynamicController.syncFunc; this is the controller's own reconcile timer, not the workqueue processing timer",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 88
+      },
+      "id": 205,
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (le) (increase(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "interval": "10s",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Handler Reconcile Duration",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 96
+      },
+      "id": 106,
+      "panels": [],
+      "title": "API Server Interaction",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 97
+      },
+      "id": 107,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "leader_election_master_status{namespace=\"kro\",service=\"kro-metrics\"}",
+          "interval": "10s",
+          "legendFormat": "Leader",
+          "refId": "A"
+        }
+      ],
+      "title": "Leader Election",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 4,
+        "y": 97
+      },
+      "id": 108,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Request Rate (req/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 9,
+        "y": 97
+      },
+      "id": 109,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\",code=~\"4..|5..\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Errors (req/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 97
+      },
+      "id": 110,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\",code=\"429\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Throttled (429/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100000
+              },
+              {
+                "color": "red",
+                "value": 1000000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 97
+      },
+      "id": 111,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Requests Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 101
+      },
+      "id": 112,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (method, code) (rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{method}} {{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Requests by Verb and Status (req/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 101
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (method) (rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Request Rate by Verb (req/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 109
+      },
+      "id": 207,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "title": "API Request Latency (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 109
+      },
+      "id": 208,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (verb, le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "API Request Latency by Verb (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 117
+      },
+      "id": 209,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rest_client_rate_limiter_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rest_client_rate_limiter_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Rate Limiter Latency (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 117
+      },
+      "id": 210,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (code, method) (rate(rest_client_request_retries_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{method}} {{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Retries by Code/Method (retries/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 125
+      },
+      "id": 211,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(rest_client_request_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (verb, le) (rate(rest_client_request_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Request Size by Verb (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 125
+      },
+      "id": 212,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(rest_client_response_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (verb, le) (rate(rest_client_response_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Response Size by Verb (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 133
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(apiserver_flowcontrol_current_executing_seats{priority_level=\"kro-priority\"})",
+          "interval": "10s",
+          "legendFormat": "executing seats (all instances)",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(apiserver_flowcontrol_current_limit_seats{priority_level=\"kro-priority\"})",
+          "interval": "10s",
+          "legendFormat": "limit seats (all instances)",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(apiserver_flowcontrol_nominal_limit_seats{priority_level=\"kro-priority\"})",
+          "interval": "10s",
+          "legendFormat": "nominal seats (all instances)",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(apiserver_flowcontrol_request_dispatch_no_accommodation_total{priority_level=\"kro-priority\"}[1m]))",
+          "interval": "10s",
+          "legendFormat": "throttled/s",
+          "refId": "D"
+        }
+      ],
+      "title": "API Server Concurrent Execution Seats (kro)",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 133
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(apiserver_current_inflight_requests{request_kind=\"readOnly\"})",
+          "interval": "10s",
+          "legendFormat": "readOnly inflight",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(apiserver_current_inflight_requests{request_kind=\"mutating\"})",
+          "interval": "10s",
+          "legendFormat": "mutating inflight",
+          "refId": "B"
+        }
+      ],
+      "title": "API Server Inflight Requests",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 141
+      },
+      "id": 8,
+      "panels": [],
+      "title": "RGD Reconciler and Workqueue",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 142
+      },
+      "id": 9,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_active_workers{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 142
+      },
+      "id": 10,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_max_concurrent_reconciles{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Max Concurrent",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 142
+      },
+      "id": 11,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_reconcile_panics_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Panics Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 142
+      },
+      "id": 12,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_reconcile_errors_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Errors Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 142
+      },
+      "id": 13,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_terminal_reconcile_errors_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Terminal Errors Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 142
+      },
+      "id": 14,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_reconcile_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconciles Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 147
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{controller}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95 {{controller}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{controller}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Reconcile Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 147
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (workqueue_depth{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "{{controller}} / {{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 155
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (controller, name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (controller, name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95 {{controller}} / {{name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (controller, name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{controller}} / {{name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Workqueue Queue Wait (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 155
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (controller, name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (controller, name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95 {{controller}} / {{name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (controller, name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{controller}} / {{name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Workqueue Processing Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 163
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (rate(workqueue_adds_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "adds {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (rate(workqueue_retries_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "retries {{controller}} / {{name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Adds vs Retries Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 163
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (workqueue_unfinished_work_seconds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "unfinished {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max by (controller, name) (workqueue_longest_running_processor_seconds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "longest {{controller}} / {{name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Unfinished Work vs Longest Running",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 171
+      },
+      "id": 21,
+      "panels": [],
+      "title": "Dynamic Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 172
+      },
+      "id": 22,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed GVRs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 172
+      },
+      "id": 23,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_queue_length{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Length",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 172
+      },
+      "id": 24,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Errors (errors/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 172
+      },
+      "id": 25,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_handler_count_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Handlers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 172
+      },
+      "id": 26,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_attach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Attach Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 172
+      },
+      "id": 27,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_detach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Detach Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 177
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_reconcile_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{gvr}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Rate Top 10 (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 177
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.50, sum by (gvr, le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p50 {{gvr}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.95, sum by (gvr, le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p95 {{gvr}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.99, sum by (gvr, le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p99 {{gvr}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Reconcile Duration Top 10 (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 185
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr, type) (rate(dynamic_controller_requeue_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "requeue {{gvr}} / {{type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_handler_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "handler errors {{gvr}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Requeue and Handler Error Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 185
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.50, sum by (gvr, le) (rate(dynamic_controller_informer_sync_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p50 {{gvr}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.95, sum by (gvr, le) (rate(dynamic_controller_informer_sync_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p95 {{gvr}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.99, sum by (gvr, le) (rate(dynamic_controller_informer_sync_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p99 {{gvr}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Informer Sync Duration Top 10 (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 193
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr, event_type) (rate(dynamic_controller_informer_events_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{gvr}} / {{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Informer Events Top 10 (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 193
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_queue_length{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "queue length",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "gvr count",
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Length vs Managed GVRs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 201
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (dynamic_controller_handler_count_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "active {{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Count by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 201
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (rate(dynamic_controller_handler_attach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "attach {{type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (rate(dynamic_controller_handler_detach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "detach {{type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Handler Attach/Detach Rates by Type",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 209
+      },
+      "id": 36,
+      "panels": [],
+      "title": "Schema Resolver",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 210
+      },
+      "id": 37,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(schema_resolver_cache_size{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 210
+      },
+      "id": 38,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) / clamp_min(sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) + sum(rate(schema_resolver_cache_misses_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])), 1e-9)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 210
+      },
+      "id": 39,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hits (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 210
+      },
+      "id": 40,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_misses_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Misses (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 210
+      },
+      "id": 41,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_evictions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Evictions (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 210
+      },
+      "id": 42,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 215
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "hits",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_misses_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "misses",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_evictions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "evictions",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_singleflight_deduplicated_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "deduplicated",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "errors",
+          "refId": "E"
+        }
+      ],
+      "title": "Cache Activity (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 215
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(schema_resolver_api_call_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(schema_resolver_api_call_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(schema_resolver_api_call_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "API Call Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 223
+      },
+      "id": 45,
+      "panels": [],
+      "title": "Go Runtime and Container",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 224
+      },
+      "id": 46,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_goroutines{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 224
+      },
+      "id": 47,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Threads",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 224
+      },
+      "id": 48,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_open_fds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 224
+      },
+      "id": 49,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_resident_memory_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RSS",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 224
+      },
+      "id": 50,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_memstats_heap_inuse_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Heap In Use",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 224
+      },
+      "id": 51,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_sched_gomaxprocs_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "GOMAXPROCS",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 229
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"})",
+          "interval": "10s",
+          "legendFormat": "working set",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(process_resident_memory_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "rss",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(go_memstats_heap_inuse_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "heap in use",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(go_memstats_sys_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "go sys",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_pod_container_resource_limits{namespace=\"kro\",container=\"kro\",resource=\"memory\",unit=\"byte\"})",
+          "interval": "10s",
+          "legendFormat": "memory limit",
+          "refId": "E"
+        }
+      ],
+      "title": "Memory Footprint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "threads"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gomaxprocs"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 229
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "cpu cores",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "threads",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_sched_gomaxprocs_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "gomaxprocs",
+          "refId": "C"
+        }
+      ],
+      "title": "CPU, Threads, and GOMAXPROCS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 237
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.50, sum by (le) (rate(go_gc_pauses_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.95, sum by (le) (rate(go_gc_pauses_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.99, sum by (le) (rate(go_gc_pauses_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "GC Pause",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 237
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.50, sum by (le) (rate(go_sched_latencies_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.95, sum by (le) (rate(go_sched_latencies_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.99, sum by (le) (rate(go_sched_latencies_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Scheduler Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 237
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_gc_heap_live_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "heap live",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_gc_heap_goal_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "heap goal",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_gc_gomemlimit_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "gomemlimit",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_memstats_next_gc_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "next gc",
+          "refId": "D"
+        }
+      ],
+      "title": "Heap Targets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 245
+      },
+      "id": 57,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_open_fds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "open fds",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_max_fds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "max fds",
+          "refId": "B"
+        }
+      ],
+      "title": "FD Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 245
+      },
+      "id": 58,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(process_network_receive_bytes_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "rx",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(process_network_transmit_bytes_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "tx",
+          "refId": "B"
+        }
+      ],
+      "title": "Network I/O Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 253
+      },
+      "id": 61,
+      "panels": [],
+      "title": "Watch Layer and Routing",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 254
+      },
+      "id": 62,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Informers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 254
+      },
+      "id": 63,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_instance_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Instance Watches",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 254
+      },
+      "id": 64,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_watch_request_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Watch Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 254
+      },
+      "id": 65,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(rate(dynamic_controller_route_match_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) / clamp_min(sum(rate(dynamic_controller_route_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])), 1e-9)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Route Match Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 259
+      },
+      "id": 66,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "informers",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_instance_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "instance watches",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_watch_request_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "watch requests",
+          "refId": "C"
+        }
+      ],
+      "title": "Watch Inventory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 259
+      },
+      "id": 67,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, dynamic_controller_instance_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "{{parent_gvr}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Instance Watches Top 10",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 267
+      },
+      "id": 68,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr, type) (dynamic_controller_watch_request_count{namespace=\"kro\",service=\"kro-metrics\"}))",
+          "interval": "10s",
+          "legendFormat": "{{gvr}} / {{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Watch Requests Top 10",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 267
+      },
+      "id": 69,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_route_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "routed {{gvr}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_route_match_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "matched {{gvr}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Route Throughput Top 10 (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 275
+      },
+      "id": 70,
+      "panels": [],
+      "title": "CEL and Runtime Engine",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 276
+      },
+      "id": 71,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cel_expr_eval_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "CEL Eval Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 276
+      },
+      "id": 72,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_eval_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Node Eval Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 276
+      },
+      "id": 73,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_creation_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Creation Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 276
+      },
+      "id": 74,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_eval_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Node Eval Errors (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 281
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "CEL Eval Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 281
+      },
+      "id": 76,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(runtime_node_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(runtime_node_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(runtime_node_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Runtime Node Eval Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 289
+      },
+      "id": 77,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(runtime_creation_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(runtime_creation_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(runtime_creation_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Runtime Creation Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 289
+      },
+      "id": 78,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_ignored_check_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "ignored checks",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_ignored_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "ignored nodes",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_ready_check_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "ready checks",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_not_ready_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "not ready",
+          "refId": "D"
+        }
+      ],
+      "title": "Conditional Checks and Outcomes (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 297
+      },
+      "id": 79,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(runtime_collection_size_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(runtime_collection_size_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(runtime_collection_size_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Collection Expansion Size (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 305
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (cache) (cel_builder_cache_entries{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "{{cache}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Builder Cache Entries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 305
+      },
+      "id": 91,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (cache) (rate(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"hit\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{cache}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Builder Cache Hit Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 305
+      },
+      "id": 92,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (cache) (rate(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"miss\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{cache}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Builder Cache Miss Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 305
+      },
+      "id": 93,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (cache, le) (rate(cel_builder_cache_fill_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{cache}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (cache, le) (rate(cel_builder_cache_fill_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{cache}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Builder Cache Fill Duration (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 310
+      },
+      "id": 80,
+      "panels": [],
+      "title": "RGD Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 311
+      },
+      "id": 81,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_graph_build_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Rate (ops/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 311
+      },
+      "id": 82,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_graph_build_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Errors (errors/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 311
+      },
+      "id": 83,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_deletions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Deletion Rate (ops/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 311
+      },
+      "id": 84,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_state_transitions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "State Transitions (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 316
+      },
+      "id": 85,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rgd_graph_build_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rgd_graph_build_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rgd_graph_build_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Graph Build Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 316
+      },
+      "id": 86,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rgd_deletion_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rgd_deletion_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rgd_deletion_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Deletion Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 324
+      },
+      "id": 87,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rgd_graph_build_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Builds Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 324
+      },
+      "id": 88,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rgd_graph_build_errors_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Errors Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 324
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (from, to) (rate(rgd_state_transitions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{from}}\u2192{{to}}",
+          "refId": "A"
+        }
+      ],
+      "title": "State Transitions (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 332
+      },
+      "id": 221,
+      "panels": [],
+      "title": "Instance Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 333
+      },
+      "id": 222,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_applyset_apply_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "apply/s",
+          "refId": "A"
+        }
+      ],
+      "title": "ApplySet Apply Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 333
+      },
+      "id": 223,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_applyset_prune_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "prune/s",
+          "refId": "A"
+        }
+      ],
+      "title": "ApplySet Prune Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 333
+      },
+      "id": 224,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_desired_objects_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "desired objects/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Desired Objects Rate (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 333
+      },
+      "id": 225,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_planned_nodes_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "planned nodes/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Planned Nodes Rate (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 338
+      },
+      "id": 226,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_status_update_conflicts_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "conflicts/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Update Conflicts (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 338
+      },
+      "id": 227,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_status_update_retries_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "retries/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Update Retries (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 338
+      },
+      "id": 228,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "ApplySet Apply Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 343
+      },
+      "id": 229,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "ApplySet Prune Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 351
+      },
+      "id": 230,
+      "panels": [],
+      "title": "Dynamic Controller Registration",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 352
+      },
+      "id": 231,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_registered_gvrs{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Registered GVRs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 352
+      },
+      "id": 232,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_stale_registrations{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Stale Registrations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 352
+      },
+      "id": 233,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "register/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Register Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 352
+      },
+      "id": 234,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_deregister_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "deregister/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Deregister Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 357
+      },
+      "id": 235,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_failures_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Register Failures (errors/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 357
+      },
+      "id": 236,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_deregister_failures_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Deregister Failures (errors/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 357
+      },
+      "id": 237,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_rollback_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "rollbacks/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Register Rollbacks (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 362
+      },
+      "id": 238,
+      "panels": [],
+      "title": "Additional Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 363
+      },
+      "id": 239,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cel_cache_session_ast_reuse_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "ast reuse/s",
+          "refId": "A"
+        }
+      ],
+      "title": "CEL AST Reuse Rate (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 363
+      },
+      "id": 240,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(controller_runtime_reconcile_timeouts_total{namespace=\"kro\",controller=\"ResourceGraphDefinition\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "timeouts/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Timeouts (events/s)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 41,
+  "tags": [
+    "kro",
+    "controller",
+    "performance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timezone": "",
+  "title": "kro / Scale Testing",
+  "uid": "kro-scale-testing"
+}

--- a/config/grafana/dashboard.json
+++ b/config/grafana/dashboard.json
@@ -1,0 +1,6827 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 60
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}[2m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 60
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Working Set",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 60
+      },
+      "id": 98,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(go_goroutines{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 60
+      },
+      "id": 7,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(container_memory_working_set_bytes{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}) / clamp_min(sum(kube_pod_container_resource_limits{namespace=\"kro\",container=\"kro\",resource=\"memory\",unit=\"byte\"}), 1)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Limit Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 65
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(controller_runtime_reconcile_total{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 65
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(workqueue_depth{namespace=\"kro\",service=\"kro-metrics\",name=\"ResourceGraphDefinition\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 65
+      },
+      "id": 6,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(controller_runtime_active_workers{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}) / clamp_min(sum(controller_runtime_max_concurrent_reconciles{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}), 1)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Worker Utilization",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 65
+      },
+      "id": 94,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * (1 - sum(rate(controller_runtime_reconcile_errors_total{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m])) / clamp_min(sum(rate(controller_runtime_reconcile_total{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m])), 1))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile Success",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 70
+      },
+      "id": 99,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_reconcile_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Reconcile Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 70
+      },
+      "id": 100,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_queue_length{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Queue Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 70
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed GVRs (Dynamic)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 70
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Handler Errors (errors/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 75
+      },
+      "id": 95,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[5m])))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "p99 of dynamic_controller_reconcile_duration_seconds, recorded in DynamicController.syncFunc around the actual handler execution path",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 75
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Handler Reconcile p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 75
+      },
+      "id": 96,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * (1 - sum(rate(rgd_graph_build_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) / clamp_min(sum(rate(rgd_graph_build_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])), 1)) or vector(100)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RGDs"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "scheme"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Instances"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "scheme"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 75
+      },
+      "id": 97,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(apiserver_storage_objects{resource=\"resourcegraphdefinitions.kro.run\",job=\"apiserver-direct\"})",
+          "interval": "10s",
+          "legendFormat": "RGDs",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(max by (resource) (apiserver_storage_objects{resource=~\".+\\\\.kro\\\\.run\",resource!=\"resourcegraphdefinitions.kro.run\",job=\"apiserver-direct\"}))",
+          "interval": "10s",
+          "legendFormat": "Instances",
+          "refId": "B"
+        }
+      ],
+      "title": "kro Objects (API Server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 80
+      },
+      "id": 220,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(max by (resource) (apiserver_storage_objects{resource=~\".+\\\\.kro\\\\.run\",resource!=\"resourcegraphdefinitions.kro.run\",job=\"apiserver-direct\"}))",
+          "interval": "10s",
+          "legendFormat": "Instances",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 80
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "(count(kube_configmap_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_secret_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_serviceaccount_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_deployment_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_role_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_rolebinding_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_service_labels{label_kro_run_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_buckets_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_vpcs_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_tables_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_subnets_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_routetables_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_securitygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_dbinstances_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_dbsubnetgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5001stacks_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5002platforms_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5003workloads_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5004securities_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5005data_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5006clones_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5007platformcoregroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5008platformconfiggroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5009platformauthgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5010platformrbacgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5011platformackgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5012workloadswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5013workloadsapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5014workloadsworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5015workloadsbatchgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5016securitysecretsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5017securityidentitygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5018securitypolicygroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5019datanetworkgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5020datastoragegroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5021dataeventsgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5022cloneswebgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5023clonesapigroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5024clonesworkergroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5025clonesmixedgroups_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5026platformcoreprimaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5027platformcoresecondaries_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5028platformconfigmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5029platformauthmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5030platformrbacmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5031platformnetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5032platformdatamains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5033webmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5034webedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5035apimains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5036apiadmins_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5037workermains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5038batchmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5039securitysecretsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5040securityidentitymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5041securitypolicymains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5042datanetworkmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5043datanetworkedges_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5044datastoragemains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5045datastoragearchives_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5046dataeventsmains_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5047webclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5048apiclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5049workerclonea_info{kro_owned=\"true\"}) or vector(0)) + (count(kube_customresource_kube_graphheavy5050mixedclonea_info{kro_owned=\"true\"}) or vector(0))",
+          "interval": "10s",
+          "legendFormat": "{{__name__}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed Child Resources",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "kube_(.+)_labels",
+            "renamePattern": "$1"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 80
+      },
+      "id": 206,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval])))",
+          "interval": "10s",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "title": "CEL Eval Latency (p50 / p90 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 80
+      },
+      "id": 105,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"hit\"})",
+          "interval": "10s",
+          "legendFormat": "hits",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"miss\"})",
+          "interval": "10s",
+          "legendFormat": "misses",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"error\"})",
+          "interval": "10s",
+          "legendFormat": "errors",
+          "refId": "C"
+        }
+      ],
+      "title": "CEL Builder Cache Totals",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 88
+      },
+      "id": 204,
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (le) (increase(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\",controller=\"ResourceGraphDefinition\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "interval": "10s",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "RGD Reconcile Duration",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "Heatmap of dynamic_controller_reconcile_duration_seconds buckets from DynamicController.syncFunc; this is the controller's own reconcile timer, not the workqueue processing timer",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 88
+      },
+      "id": 205,
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (le) (increase(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "interval": "10s",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Dynamic Handler Reconcile Duration",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 96
+      },
+      "id": 106,
+      "panels": [],
+      "title": "API Server Interaction",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 97
+      },
+      "id": 107,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "leader_election_master_status{namespace=\"kro\",service=\"kro-metrics\"}",
+          "interval": "10s",
+          "legendFormat": "Leader",
+          "refId": "A"
+        }
+      ],
+      "title": "Leader Election",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 4,
+        "y": 97
+      },
+      "id": 108,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Request Rate (req/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 9,
+        "y": 97
+      },
+      "id": 109,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\",code=~\"4..|5..\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Errors (req/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 97
+      },
+      "id": 110,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\",code=\"429\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Throttled (429/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100000
+              },
+              {
+                "color": "red",
+                "value": 1000000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 97
+      },
+      "id": 111,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "API Requests Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 101
+      },
+      "id": 112,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (method, code) (rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{method}} {{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Requests by Verb and Status (req/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 101
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (method) (rate(rest_client_requests_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Request Rate by Verb (req/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 109
+      },
+      "id": 207,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "title": "API Request Latency (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 109
+      },
+      "id": 208,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (verb, le) (rate(rest_client_request_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "API Request Latency by Verb (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 117
+      },
+      "id": 209,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rest_client_rate_limiter_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rest_client_rate_limiter_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Rate Limiter Latency (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 117
+      },
+      "id": 210,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (code, method) (rate(rest_client_request_retries_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{method}} {{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Retries by Code/Method (retries/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 125
+      },
+      "id": 211,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(rest_client_request_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (verb, le) (rate(rest_client_request_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Request Size by Verb (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 125
+      },
+      "id": 212,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (verb, le) (rate(rest_client_response_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (verb, le) (rate(rest_client_response_size_bytes_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{verb}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Response Size by Verb (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 133
+      },
+      "id": 8,
+      "panels": [],
+      "title": "RGD Reconciler and Workqueue",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 134
+      },
+      "id": 9,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_active_workers{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 134
+      },
+      "id": 10,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_max_concurrent_reconciles{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Max Concurrent",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 134
+      },
+      "id": 11,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_reconcile_panics_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Panics Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 134
+      },
+      "id": 12,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_reconcile_errors_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Errors Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 134
+      },
+      "id": 13,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_terminal_reconcile_errors_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Terminal Errors Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 134
+      },
+      "id": 14,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(controller_runtime_reconcile_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconciles Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 139
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{controller}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95 {{controller}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{controller}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Reconcile Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 139
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (workqueue_depth{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "{{controller}} / {{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 147
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (controller, name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (controller, name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95 {{controller}} / {{name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (controller, name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{controller}} / {{name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Workqueue Queue Wait (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 147
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (controller, name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (controller, name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95 {{controller}} / {{name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (controller, name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{controller}} / {{name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Workqueue Processing Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 155
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (rate(workqueue_adds_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "adds {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (rate(workqueue_retries_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "retries {{controller}} / {{name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Adds vs Retries Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 155
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller, name) (workqueue_unfinished_work_seconds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "unfinished {{controller}} / {{name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max by (controller, name) (workqueue_longest_running_processor_seconds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "longest {{controller}} / {{name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Unfinished Work vs Longest Running",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 163
+      },
+      "id": 21,
+      "panels": [],
+      "title": "Dynamic Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 164
+      },
+      "id": 22,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Managed GVRs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 164
+      },
+      "id": 23,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_queue_length{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Length",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 164
+      },
+      "id": 24,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Errors (errors/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 164
+      },
+      "id": 25,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_handler_count_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Handlers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 164
+      },
+      "id": 26,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_attach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Attach Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 164
+      },
+      "id": 27,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_handler_detach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Detach Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 169
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_reconcile_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{gvr}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Rate Top 10 (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 169
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.50, sum by (gvr, le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p50 {{gvr}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.95, sum by (gvr, le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p95 {{gvr}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.99, sum by (gvr, le) (rate(dynamic_controller_reconcile_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p99 {{gvr}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Reconcile Duration Top 10 (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 177
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr, type) (rate(dynamic_controller_requeue_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "requeue {{gvr}} / {{type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_handler_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "handler errors {{gvr}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Requeue and Handler Error Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 177
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.50, sum by (gvr, le) (rate(dynamic_controller_informer_sync_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p50 {{gvr}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.95, sum by (gvr, le) (rate(dynamic_controller_informer_sync_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p95 {{gvr}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, histogram_quantile(0.99, sum by (gvr, le) (rate(dynamic_controller_informer_sync_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m]))))",
+          "interval": "10s",
+          "legendFormat": "p99 {{gvr}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Informer Sync Duration Top 10 (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 185
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr, event_type) (rate(dynamic_controller_informer_events_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "{{gvr}} / {{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Informer Events Top 10 (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 185
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_queue_length{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "queue length",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_gvr_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "gvr count",
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Length vs Managed GVRs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 193
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (dynamic_controller_handler_count_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "active {{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Count by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 193
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (rate(dynamic_controller_handler_attach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "attach {{type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (rate(dynamic_controller_handler_detach_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "detach {{type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Handler Attach/Detach Rates by Type",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 201
+      },
+      "id": 36,
+      "panels": [],
+      "title": "Schema Resolver",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 202
+      },
+      "id": 37,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(schema_resolver_cache_size{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 202
+      },
+      "id": 38,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) / clamp_min(sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) + sum(rate(schema_resolver_cache_misses_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])), 1e-9)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 202
+      },
+      "id": 39,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hits (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 202
+      },
+      "id": 40,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_misses_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Misses (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 202
+      },
+      "id": 41,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_evictions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Evictions (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 202
+      },
+      "id": 42,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 207
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_hits_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "hits",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_misses_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "misses",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_cache_evictions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "evictions",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_singleflight_deduplicated_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "deduplicated",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(schema_resolver_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "errors",
+          "refId": "E"
+        }
+      ],
+      "title": "Cache Activity (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 207
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(schema_resolver_api_call_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(schema_resolver_api_call_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(schema_resolver_api_call_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "API Call Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 215
+      },
+      "id": 45,
+      "panels": [],
+      "title": "Go Runtime and Container",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 216
+      },
+      "id": 46,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_goroutines{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 216
+      },
+      "id": 47,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Threads",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 216
+      },
+      "id": 48,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_open_fds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 216
+      },
+      "id": 49,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_resident_memory_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "RSS",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 216
+      },
+      "id": 50,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_memstats_heap_inuse_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Heap In Use",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 216
+      },
+      "id": 51,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_sched_gomaxprocs_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "GOMAXPROCS",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 221
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"})",
+          "interval": "10s",
+          "legendFormat": "working set",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(process_resident_memory_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "rss",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(go_memstats_heap_inuse_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "heap in use",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(go_memstats_sys_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "go sys",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_pod_container_resource_limits{namespace=\"kro\",container=\"kro\",resource=\"memory\",unit=\"byte\"})",
+          "interval": "10s",
+          "legendFormat": "memory limit",
+          "refId": "E"
+        }
+      ],
+      "title": "Memory Footprint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "threads"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gomaxprocs"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 221
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"kro\",container=\"kro\",pod=~\"kro-.*\",image!=\"\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "cpu cores",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "threads",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_sched_gomaxprocs_threads{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "gomaxprocs",
+          "refId": "C"
+        }
+      ],
+      "title": "CPU, Threads, and GOMAXPROCS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 229
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.50, sum by (le) (rate(go_gc_pauses_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.95, sum by (le) (rate(go_gc_pauses_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.99, sum by (le) (rate(go_gc_pauses_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "GC Pause",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 229
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.50, sum by (le) (rate(go_sched_latencies_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.95, sum by (le) (rate(go_sched_latencies_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "1000 * histogram_quantile(0.99, sum by (le) (rate(go_sched_latencies_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Scheduler Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 229
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_gc_heap_live_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "heap live",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_gc_heap_goal_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "heap goal",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_gc_gomemlimit_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "gomemlimit",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(go_memstats_next_gc_bytes{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "next gc",
+          "refId": "D"
+        }
+      ],
+      "title": "Heap Targets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 237
+      },
+      "id": 57,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_open_fds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "open fds",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(process_max_fds{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "max fds",
+          "refId": "B"
+        }
+      ],
+      "title": "FD Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 237
+      },
+      "id": 58,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(process_network_receive_bytes_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "rx",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(process_network_transmit_bytes_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "tx",
+          "refId": "B"
+        }
+      ],
+      "title": "Network I/O Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 245
+      },
+      "id": 61,
+      "panels": [],
+      "title": "Watch Layer and Routing",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 246
+      },
+      "id": 62,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Informers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 246
+      },
+      "id": 63,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_instance_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Instance Watches",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 246
+      },
+      "id": 64,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_watch_request_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Watch Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 246
+      },
+      "id": 65,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(rate(dynamic_controller_route_match_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])) / clamp_min(sum(rate(dynamic_controller_route_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])), 1e-9)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Route Match Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 251
+      },
+      "id": 66,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "informers",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_instance_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "instance watches",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dynamic_controller_watch_request_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "watch requests",
+          "refId": "C"
+        }
+      ],
+      "title": "Watch Inventory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 251
+      },
+      "id": 67,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, dynamic_controller_instance_watch_count{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "{{parent_gvr}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Instance Watches Top 10",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 259
+      },
+      "id": 68,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr, type) (dynamic_controller_watch_request_count{namespace=\"kro\",service=\"kro-metrics\"}))",
+          "interval": "10s",
+          "legendFormat": "{{gvr}} / {{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Watch Requests Top 10",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 259
+      },
+      "id": 69,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_route_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "routed {{gvr}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (gvr) (rate(dynamic_controller_route_match_total{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "matched {{gvr}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Route Throughput Top 10 (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 267
+      },
+      "id": 70,
+      "panels": [],
+      "title": "CEL and Runtime Engine",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 268
+      },
+      "id": 71,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cel_expr_eval_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "CEL Eval Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 268
+      },
+      "id": 72,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_eval_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Node Eval Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 268
+      },
+      "id": 73,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_creation_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Creation Rate (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 268
+      },
+      "id": 74,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_eval_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Node Eval Errors (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 273
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cel_expr_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "CEL Eval Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 273
+      },
+      "id": 76,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(runtime_node_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(runtime_node_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(runtime_node_eval_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Runtime Node Eval Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 281
+      },
+      "id": 77,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(runtime_creation_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(runtime_creation_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(runtime_creation_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Runtime Creation Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 281
+      },
+      "id": 78,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_ignored_check_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "ignored checks",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_ignored_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "ignored nodes",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_ready_check_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "ready checks",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(runtime_node_not_ready_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "not ready",
+          "refId": "D"
+        }
+      ],
+      "title": "Conditional Checks and Outcomes (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 289
+      },
+      "id": 79,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(runtime_collection_size_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(runtime_collection_size_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(runtime_collection_size_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Collection Expansion Size (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 297
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (cache) (cel_builder_cache_entries{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "legendFormat": "{{cache}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Builder Cache Entries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 297
+      },
+      "id": 91,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (cache) (rate(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"hit\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{cache}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Builder Cache Hit Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 297
+      },
+      "id": 92,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (cache) (rate(cel_builder_cache_requests_total{namespace=\"kro\",service=\"kro-metrics\",result=\"miss\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{cache}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Builder Cache Miss Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 297
+      },
+      "id": 93,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (cache, le) (rate(cel_builder_cache_fill_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50 {{cache}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (cache, le) (rate(cel_builder_cache_fill_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99 {{cache}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Builder Cache Fill Duration (p50 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 302
+      },
+      "id": 80,
+      "panels": [],
+      "title": "RGD Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 303
+      },
+      "id": 81,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_graph_build_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Rate (ops/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 303
+      },
+      "id": 82,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_graph_build_errors_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Errors (errors/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 303
+      },
+      "id": 83,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_deletions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Deletion Rate (ops/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 303
+      },
+      "id": 84,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(rgd_state_transitions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "State Transitions (events/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 308
+      },
+      "id": 85,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rgd_graph_build_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rgd_graph_build_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rgd_graph_build_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Graph Build Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 308
+      },
+      "id": 86,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rgd_deletion_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rgd_deletion_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rgd_deletion_duration_seconds_bucket{namespace=\"kro\",service=\"kro-metrics\"}[5m])))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Deletion Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 316
+      },
+      "id": 87,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rgd_graph_build_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Builds Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 316
+      },
+      "id": 88,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rgd_graph_build_errors_total{namespace=\"kro\",service=\"kro-metrics\"})",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Graph Build Errors Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 316
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (from, to) (rate(rgd_state_transitions_total{namespace=\"kro\",service=\"kro-metrics\"}[5m]))",
+          "interval": "10s",
+          "legendFormat": "{{from}}\u2192{{to}}",
+          "refId": "A"
+        }
+      ],
+      "title": "State Transitions (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 324
+      },
+      "id": 221,
+      "panels": [],
+      "title": "Instance Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 325
+      },
+      "id": 222,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_applyset_apply_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "apply/s",
+          "refId": "A"
+        }
+      ],
+      "title": "ApplySet Apply Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 325
+      },
+      "id": 223,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_applyset_prune_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "prune/s",
+          "refId": "A"
+        }
+      ],
+      "title": "ApplySet Prune Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 325
+      },
+      "id": 224,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_desired_objects_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "desired objects/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Desired Objects Rate (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 325
+      },
+      "id": 225,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_planned_nodes_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "planned nodes/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Planned Nodes Rate (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 330
+      },
+      "id": 226,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_status_update_conflicts_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "conflicts/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Update Conflicts (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 330
+      },
+      "id": 227,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(instance_controller_status_update_retries_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "retries/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Update Retries (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 330
+      },
+      "id": 228,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(instance_controller_applyset_apply_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "ApplySet Apply Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 335
+      },
+      "id": 229,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(instance_controller_applyset_prune_duration_seconds_bucket{namespace=\"kro\"}[2m])) by (le))",
+          "interval": "10s",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "ApplySet Prune Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 343
+      },
+      "id": 230,
+      "panels": [],
+      "title": "Dynamic Controller Registration",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 344
+      },
+      "id": 231,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_registered_gvrs{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Registered GVRs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 344
+      },
+      "id": 232,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "max(dynamic_controller_stale_registrations{namespace=\"kro\"}) or vector(0)",
+          "interval": "10s",
+          "refId": "A"
+        }
+      ],
+      "title": "Stale Registrations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 344
+      },
+      "id": 233,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "register/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Register Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 344
+      },
+      "id": 234,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_deregister_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "deregister/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Deregister Rate (ops/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 349
+      },
+      "id": 235,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_failures_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Register Failures (errors/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 349
+      },
+      "id": 236,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_deregister_failures_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Deregister Failures (errors/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 349
+      },
+      "id": 237,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dynamic_controller_register_rollback_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "rollbacks/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Register Rollbacks (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 354
+      },
+      "id": 238,
+      "panels": [],
+      "title": "Additional Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 355
+      },
+      "id": 239,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cel_cache_session_ast_reuse_total{namespace=\"kro\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "ast reuse/s",
+          "refId": "A"
+        }
+      ],
+      "title": "CEL AST Reuse Rate (events/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 355
+      },
+      "id": 240,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(controller_runtime_reconcile_timeouts_total{namespace=\"kro\",controller=\"ResourceGraphDefinition\"}[2m]))",
+          "interval": "10s",
+          "legendFormat": "timeouts/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Timeouts (events/s)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 41,
+  "tags": [
+    "kro"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timezone": "",
+  "title": "kro",
+  "uid": "kro-controller-metrics"
+}

--- a/website/docs/docs/advanced/04-metrics.md
+++ b/website/docs/docs/advanced/04-metrics.md
@@ -26,6 +26,9 @@ metrics:
     interval: 1m
 ```
 
+A prebuilt Grafana dashboard for these metrics is available at
+[`config/grafana/dashboard.json`](https://raw.githubusercontent.com/kubernetes-sigs/kro/refs/heads/main/config/grafana/dashboard.json).
+
 ## Dynamic Controller Metrics
 
 | Metric | Type | Description | Stability |


### PR DESCRIPTION
Store the dashboard at `config/grafana/dashboard.json` and link to the raw
GitHub URL from the metrics docs for direct import.

screenshot:

<img width="1537" height="4827" alt="Screenshot 2026-03-08 at 12-37-49 KRO Controller Metrics - Dashboards - Grafana" src="https://github.com/user-attachments/assets/59604e8f-4df0-480e-b930-b7b584af2e5b" />

