### PR TITLE
resourcegraphdefinition: wait for CRD deletion to complete

### DIFF
--- a/pkg/client/crd.go
+++ b/pkg/client/crd.go
@@ -218,7 +218,29 @@ func (w *CRDWrapper) Delete(ctx context.Context, name string) error {
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete CRD: %w", err)
 	}
-	return nil
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return w.waitForDelete(ctx, name)
+}
+
+// waitForDelete waits for a CRD to be fully removed from the API server.
+func (w *CRDWrapper) waitForDelete(ctx context.Context, name string) error {
+	log := logr.FromContext(ctx)
+	log.Info("Waiting for CRD to be deleted", "name", name)
+
+	return wait.PollUntilContextTimeout(ctx, w.pollInterval, w.timeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := w.Get(ctx, name)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+
+			return false, nil
+		})
 }
 
 // waitForReady waits for a CRD to become ready

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup_test.go
@@ -18,13 +18,57 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgotesting "k8s.io/client-go/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 )
+
+type reactorCRDManager struct {
+	client       *apiextensionsfake.Clientset
+	pollInterval time.Duration
+	timeout      time.Duration
+}
+
+func (m *reactorCRDManager) Ensure(context.Context, extv1.CustomResourceDefinition, bool) error {
+	return nil
+}
+
+func (m *reactorCRDManager) Get(ctx context.Context, name string) (*extv1.CustomResourceDefinition, error) {
+	return m.client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (m *reactorCRDManager) Delete(ctx context.Context, name string) error {
+	err := m.client.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return wait.PollUntilContextTimeout(ctx, m.pollInterval, m.timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := m.Get(ctx, name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+}
 
 func TestExtractCRDName(t *testing.T) {
 	tests := []struct {
@@ -176,4 +220,59 @@ func TestCleanupResourceGraphDefinitionCRD(t *testing.T) {
 			assert.Equal(t, tt.wantDeleted, manager.deleted)
 		})
 	}
+}
+
+func TestCleanupResourceGraphDefinitionWaitsForCRDToDisappear(t *testing.T) {
+	rgd := newTestRGD("cleanup-waits")
+	crdName := extractCRDName(rgd.Spec.Schema.Group, rgd.Spec.Schema.Kind)
+	gvr := metadata.GetResourceGraphDefinitionInstanceGVR(
+		rgd.Spec.Schema.Group,
+		rgd.Spec.Schema.APIVersion,
+		rgd.Spec.Schema.Kind,
+	)
+
+	clientset := apiextensionsfake.NewSimpleClientset(&extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: crdName},
+	})
+
+	deleteRequested := false
+	getCallsAfterDelete := 0
+	clientset.PrependReactor("delete", "customresourcedefinitions", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		deleteRequested = true
+		return true, nil, nil
+	})
+	clientset.PrependReactor("get", "customresourcedefinitions", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		if !deleteRequested {
+			return false, nil, nil
+		}
+
+		getCallsAfterDelete++
+		if getCallsAfterDelete < 3 {
+			return true, &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: action.(clientgotesting.GetAction).GetName()},
+			}, nil
+		}
+
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{
+			Group:    extv1.SchemeGroupVersion.Group,
+			Resource: "customresourcedefinitions",
+		}, action.(clientgotesting.GetAction).GetName())
+	})
+
+	dc := newRunningDynamicController(t)
+	require.NoError(t, dc.Register(context.Background(), gvr, func(context.Context, ctrl.Request) error { return nil }))
+
+	reconciler := &ResourceGraphDefinitionReconciler{
+		allowCRDDeletion:  true,
+		dynamicController: dc,
+		crdManager: &reactorCRDManager{
+			client:       clientset,
+			pollInterval: 5 * time.Millisecond,
+			timeout:      250 * time.Millisecond,
+		},
+	}
+
+	err := reconciler.cleanupResourceGraphDefinition(context.Background(), rgd)
+	require.NoError(t, err)
+	assert.Equal(t, 3, getCallsAfterDelete)
 }


### PR DESCRIPTION
This patch makes deletion follow the same behavioral contract that creation
already relies on. On create, the RGD controller blocks until the generated
CRD is actually ready before marking the kind ready and continuing
reconciliation. On delete, cleanup was weaker: it treated a successful
DELETE request as if the CRD were already gone.

This is intentionally a narrow behavioral correction, not a larger
lifecycle redesign. Longer term, the options we can consider include moving
this kind of waiting out of reconcile and into a requeue / event-driven
model, or revisiting whether more of this lifecycle should be expressed via
ownerReferences. If we want to go further than that, and especially if we
want explicit transitional states such as Activating and Deactivating, that
should go through KREP-level design work rather than being folded into this
fix.

That mismatch showed up in the integration suite. The test
"CRD CRD Creation [It] should delete CRD when ResourceGraphDefinition is
deleted" removes an RGD and then polls the generated CRD until it returns
NotFound. In CI we observed the controller log "Deleting CRD", proceed with
cleanup, and remove the finalizer, while the API server continued to serve
the CRD. The test eventually timed out with "Expected an error, got nil".
This change makes deletion honor the stronger contract by polling for
NotFound after CRD deletion is requested and only reporting cleanup success
once the CRD has actually disappeared. The change is covered by an RGD
controller unit test, while the existing integration spec remains the
end-to-end regression.