### PR TITLE
compile constant CEL expressions at graph eval time

### DIFF
--- a/pkg/cel/ast/inspector.go
+++ b/pkg/cel/ast/inspector.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 )
 
@@ -87,6 +88,19 @@ type ExpressionInspection struct {
 func (e *ExpressionInspection) UsesOmit() bool {
 	for _, fc := range e.FunctionCalls {
 		if fc.Name == "omit" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasNonOperatorCall reports whether the inspected expression contains any
+// non-operator function calls. CEL represents operators (like +, -, /, etc.)
+// as function calls, but they're pure and safe to evaluate at build time.
+// This method distinguishes actual function calls from operators.
+func (e *ExpressionInspection) HasNonOperatorCall() bool {
+	for _, fc := range e.FunctionCalls {
+		if _, isOperator := operators.FindReverse(fc.Name); !isOperator {
 			return true
 		}
 	}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -46,6 +46,7 @@ import (
 	schemaresolver "github.com/kubernetes-sigs/kro/pkg/graph/schema/resolver"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	runtimeresolver "github.com/kubernetes-sigs/kro/pkg/runtime/resolver"
 	"github.com/kubernetes-sigs/kro/pkg/simpleschema"
 )
 
@@ -615,7 +616,7 @@ func extractTemplateDependencies(
 
 	for _, templateVariable := range node.Variables {
 		expression := templateVariable.Expression
-		nodeDeps, iteratorRefs, err := extractDependencies(inspector, expression, iteratorNames)
+		nodeDeps, iteratorRefs, callsAtLeastOneFunction, err := extractDependencies(inspector, expression, iteratorNames)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to extract dependencies: %w", err)
 		}
@@ -628,6 +629,8 @@ func extractTemplateDependencies(
 			templateVariable.Kind = variable.ResourceVariableKindIteration
 		} else if len(nodeDeps) > 0 && templateVariable.Kind == variable.ResourceVariableKindStatic {
 			templateVariable.Kind = variable.ResourceVariableKindDynamic
+		} else if len(expression.References) == 0 && !callsAtLeastOneFunction {
+			templateVariable.Kind = variable.ResourceVariableKindConstant
 		}
 
 		// Dependencies are tracked in Expression.References
@@ -670,7 +673,7 @@ func extractForEachDependencies(
 	for _, iter := range node.ForEach {
 		// Only pass iteratorNames - we want to detect iterator cross-references.
 		// schema references in forEach are valid (e.g schema.spec.regions).
-		nodeDeps, iteratorRefs, err := extractDependencies(inspector, iter.Expression, iteratorNames)
+		nodeDeps, iteratorRefs, _, err := extractDependencies(inspector, iter.Expression, iteratorNames)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract dependencies from forEach iterator %q: %w", iter.Name, err)
 		}
@@ -708,7 +711,7 @@ func buildInstanceNode(
 		statusVariable.Path = path
 
 		// Extract dependencies from the expression
-		deps, _, err := extractDependencies(inspector, statusVariable.Expression, nil)
+		deps, _, _, err := extractDependencies(inspector, statusVariable.Expression, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract dependencies from expression %q: %w", statusVariable.Expression, err)
 		}
@@ -893,15 +896,16 @@ func inspectExpressionRestricted(inspector *ast.Inspector, expr string, allowedI
 func extractDependencies(inspector *ast.Inspector, expr *krocel.Expression, iteratorVars []string) (
 	resourceDeps []string,
 	iteratorRefs []string,
+	callsAtLeastOneFunction bool,
 	err error,
 ) {
 	inspectionResult, err := inspector.Inspect(expr.Original)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to inspect expression: %w", err)
+		return nil, nil, false, fmt.Errorf("failed to inspect expression: %w", err)
 	}
 
 	if !features.FeatureGate.Enabled(features.CELOmitFunction) && inspectionResult.UsesOmit() {
-		return nil, nil, fmt.Errorf("omit() requires the CELOmitFunction feature gate to be enabled")
+		return nil, nil, false, fmt.Errorf("omit() requires the CELOmitFunction feature gate to be enabled")
 	}
 
 	// Populate expression references
@@ -935,14 +939,15 @@ func extractDependencies(inspector *ast.Inspector, expr *krocel.Expression, iter
 			}
 		} else {
 			// Truly unknown resource
-			return nil, nil, fmt.Errorf("references unknown identifiers: [%s]", unknown.ID)
+			return nil, nil, false, fmt.Errorf("references unknown identifiers: [%s]", unknown.ID)
 		}
 	}
 
 	if len(inspectionResult.UnknownFunctions) > 0 {
-		return nil, nil, fmt.Errorf("uses unknown functions: %v", inspectionResult.UnknownFunctions)
+		return nil, nil, false, fmt.Errorf("uses unknown functions: %v", inspectionResult.UnknownFunctions)
 	}
-	return resourceDeps, iteratorRefs, nil
+
+	return resourceDeps, iteratorRefs, inspectionResult.HasNonOperatorCall(), nil
 }
 
 // extractConditionDependencies extracts resource dependencies from condition
@@ -955,7 +960,7 @@ func extractConditionDependencies(
 	var allDeps []string
 
 	for _, expression := range expressions {
-		nodeDeps, _, err := extractDependencies(inspector, expression, nil)
+		nodeDeps, _, _, err := extractDependencies(inspector, expression, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1180,6 +1185,7 @@ func validateAndCompileNode(bc *buildContext, node *Node, inspector *ast.Inspect
 
 // validateAndCompileTemplates validates and compiles CEL template expressions for a single node.
 // For collections with forEach, the env is extended with iterator variable declarations.
+// Constants are evaluated immediately and replaced in the template.
 func validateAndCompileTemplates(
 	bc *buildContext,
 	node *Node,
@@ -1204,6 +1210,8 @@ func validateAndCompileTemplates(
 		}
 	}
 
+	var constantDescriptors []variable.FieldDescriptor
+	values := make(map[string]any)
 	for _, templateVariable := range node.Variables {
 		// Compute expected type for this field
 		expectedType := expectedTypeForField(bc, &templateVariable.FieldDescriptor, nodeSchema, node.Meta.ID)
@@ -1220,7 +1228,44 @@ func validateAndCompileTemplates(
 		if err := validateExpressionType(outputType, expectedType, displayExpr, node.Meta.ID, templateVariable.Path, bc.typeProvider); err != nil {
 			return err
 		}
+
+		// Evaluate constant expressions immediately
+		if templateVariable.Kind.IsConstant() {
+			out, _, err := expression.Program.Eval(map[string]any{})
+			if err != nil {
+				return fmt.Errorf("constant at %q: %w", templateVariable.Path, err)
+			}
+
+			native, err := conversion.GoNativeType(out)
+			if err != nil {
+				return fmt.Errorf("convert constant at %q: %w", templateVariable.Path, err)
+			}
+
+			values[expression.Original] = native
+			constantDescriptors = append(constantDescriptors, variable.FieldDescriptor{
+				Path:       templateVariable.Path,
+				Expression: expression,
+			})
+		}
 	}
+
+	// Update node and template with value of constant expressions
+	if len(constantDescriptors) > 0 {
+		res := runtimeresolver.NewResolver(node.Template.Object, values)
+		summary := res.Resolve(constantDescriptors)
+		if len(summary.Errors) > 0 {
+			return fmt.Errorf("resolve constants: %v", summary.Errors)
+		}
+
+		filtered := make([]*variable.ResourceField, 0, len(node.Variables))
+		for _, v := range node.Variables {
+			if !v.Kind.IsConstant() {
+				filtered = append(filtered, v)
+			}
+		}
+		node.Variables = filtered
+	}
+
 	return nil
 }
 

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -25,6 +25,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiservercel "k8s.io/apiserver/pkg/cel"
@@ -4297,7 +4298,7 @@ func TestBuilderHelperCases(t *testing.T) {
 			name: "extractDependencies reports unknown functions",
 			run: func(t *testing.T) {
 				inspector := newUnitInspector(t, "resource")
-				_, _, err := extractDependencies(inspector, expr("missingFn()"), nil)
+				_, _, _, err := extractDependencies(inspector, expr("missingFn()"), nil)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "uses unknown functions")
 			},
@@ -4306,7 +4307,7 @@ func TestBuilderHelperCases(t *testing.T) {
 			name: "extractDependencies accepts omit as a known function",
 			run: func(t *testing.T) {
 				inspector := newUnitInspector(t, "schema", "resource")
-				deps, _, err := extractDependencies(inspector, expr("schema.spec.x != '' ? schema.spec.x : omit()"), nil)
+				deps, _, _, err := extractDependencies(inspector, expr("schema.spec.x != '' ? schema.spec.x : omit()"), nil)
 				require.NoError(t, err)
 				assert.Empty(t, deps, "omit() should not produce resource dependencies")
 			},
@@ -4315,7 +4316,7 @@ func TestBuilderHelperCases(t *testing.T) {
 			name: "extractDependencies accepts standalone omit call",
 			run: func(t *testing.T) {
 				inspector := newUnitInspector(t, "schema")
-				deps, _, err := extractDependencies(inspector, expr("omit()"), nil)
+				deps, _, _, err := extractDependencies(inspector, expr("omit()"), nil)
 				require.NoError(t, err)
 				assert.Empty(t, deps)
 			},
@@ -4325,9 +4326,35 @@ func TestBuilderHelperCases(t *testing.T) {
 			run: func(t *testing.T) {
 				disableOmitFeatureGate(t)
 				inspector := newUnitInspector(t, "schema")
-				_, _, err := extractDependencies(inspector, expr("omit()"), nil)
+				_, _, _, err := extractDependencies(inspector, expr("omit()"), nil)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "CELOmitFunction feature gate")
+			},
+		},
+		{
+			name: "extractDependencies detects function calls",
+			run: func(t *testing.T) {
+				inspector := newUnitInspector(t, "schema")
+
+				// Expression with function call should return true
+				_, _, callsFn, err := extractDependencies(inspector, expr("size(schema.spec.items)"), nil)
+				require.NoError(t, err)
+				assert.True(t, callsFn, "expression with function call should set callsAtLeastOneFunction=true")
+
+				// Expression with only references should return false
+				_, _, callsFn, err = extractDependencies(inspector, expr("schema.spec.name"), nil)
+				require.NoError(t, err)
+				assert.False(t, callsFn, "expression with only references should set callsAtLeastOneFunction=false")
+
+				// Constant expression should return false
+				_, _, callsFn, err = extractDependencies(inspector, expr("'constant'"), nil)
+				require.NoError(t, err)
+				assert.False(t, callsFn, "constant expression should set callsAtLeastOneFunction=false")
+
+				// Operators don't count as function calls
+				_, _, callsFn, err = extractDependencies(inspector, expr("1 + 2"), nil)
+				require.NoError(t, err)
+				assert.False(t, callsFn, "operators should not set callsAtLeastOneFunction=true")
 			},
 		},
 		{
@@ -4414,4 +4441,98 @@ func TestBuilderHelperCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, tt.run)
 	}
+}
+
+func TestEvaluateAndReplaceConstants(t *testing.T) {
+	fakeResolver, fakeDiscovery := k8s.NewFakeResolver()
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory2.NewMemCacheClient(fakeDiscovery))
+	builder := &Builder{
+		schemaResolver: fakeResolver,
+		restMapper:     restMapper,
+	}
+
+	t.Run("constants are evaluated and replaced in template", func(t *testing.T) {
+		rgd := generator.NewResourceGraphDefinition("test-eval",
+			generator.WithSchema(
+				"TestApp", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "test-config",
+				},
+				"data": map[string]interface{}{
+					"result": "${'hello-world'}",
+				},
+			}, nil, nil),
+		)
+
+		graph, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		require.NoError(t, err)
+		require.NotNil(t, graph)
+
+		cm := graph.Nodes["configmap"]
+		require.NotNil(t, cm)
+
+		// Constants should be removed from Variables
+		assert.Empty(t, cm.Variables, "constants should be removed from Variables")
+
+		// Template should contain literal value
+		data, found, err := unstructured.NestedString(cm.Template.Object, "data", "result")
+		require.NoError(t, err)
+		require.True(t, found, "data.result should exist")
+		assert.Equal(t, "hello-world", data, "constant should be replaced with evaluated value")
+	})
+
+	t.Run("constants are removed but static variables remain", func(t *testing.T) {
+		rgd := generator.NewResourceGraphDefinition("test-mixed",
+			generator.WithSchema(
+				"TestApp", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "test-config",
+				},
+				"data": map[string]interface{}{
+					"constant": "${'literal-value'}",
+					"static":   "${schema.spec.name}",
+				},
+			}, nil, nil),
+		)
+
+		graph, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		require.NoError(t, err)
+		require.NotNil(t, graph)
+
+		cm := graph.Nodes["configmap"]
+		require.NotNil(t, cm)
+
+		// Only static variable should remain
+		assert.Len(t, cm.Variables, 1, "only static variable should remain")
+		assert.Equal(t, "data.static", cm.Variables[0].Path)
+		assert.Equal(t, variable.ResourceVariableKindStatic, cm.Variables[0].Kind)
+
+		// Constant should be replaced with literal
+		data, found, err := unstructured.NestedString(cm.Template.Object, "data", "constant")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, "literal-value", data)
+
+		// Static should still have expression
+		staticData, found, err := unstructured.NestedString(cm.Template.Object, "data", "static")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, "${schema.spec.name}", staticData, "static expression should remain")
+	})
 }

--- a/pkg/graph/variable/variable.go
+++ b/pkg/graph/variable/variable.go
@@ -113,6 +113,11 @@ const (
 	//
 	// Expressions not referencing iterator variables remain static or dynamic.
 	ResourceVariableKindIteration ResourceVariableKind = "iteration"
+	// ResourceVariableKindConstant represents a constant expression.
+	// These have no variable references and no function calls (operators like
+	// +, -, *, / are allowed). They are evaluated once at build time, and the
+	// evaluated value replaces the expression in the template.
+	ResourceVariableKindConstant ResourceVariableKind = "constant"
 )
 
 // String returns the string representation of a ResourceVariableKind.
@@ -138,4 +143,9 @@ func (r ResourceVariableKind) IsIncludeWhen() bool {
 // IsIteration returns true if the ResourceVariableKind is iteration
 func (r ResourceVariableKind) IsIteration() bool {
 	return r == ResourceVariableKindIteration
+}
+
+// IsConstant returns true if the ResourceVariableKind is constant
+func (r ResourceVariableKind) IsConstant() bool {
+	return r == ResourceVariableKindConstant
 }

--- a/pkg/graph/variable/variable_test.go
+++ b/pkg/graph/variable/variable_test.go
@@ -28,6 +28,7 @@ func TestResourceVariableKind(t *testing.T) {
 		isStatic      bool
 		isDynamic     bool
 		isIncludeWhen bool
+		isConstant    bool
 	}{
 		{
 			name:          "Static Kind",
@@ -36,6 +37,7 @@ func TestResourceVariableKind(t *testing.T) {
 			isStatic:      true,
 			isDynamic:     false,
 			isIncludeWhen: false,
+			isConstant:    false,
 		},
 		{
 			name:          "Dynamic Kind",
@@ -44,6 +46,7 @@ func TestResourceVariableKind(t *testing.T) {
 			isStatic:      false,
 			isDynamic:     true,
 			isIncludeWhen: false,
+			isConstant:    false,
 		},
 		{
 			name:          "ReadyWhen Kind",
@@ -52,6 +55,7 @@ func TestResourceVariableKind(t *testing.T) {
 			isStatic:      false,
 			isDynamic:     false,
 			isIncludeWhen: false,
+			isConstant:    false,
 		},
 		{
 			name:          "IncludeWhen Kind",
@@ -60,6 +64,16 @@ func TestResourceVariableKind(t *testing.T) {
 			isStatic:      false,
 			isDynamic:     false,
 			isIncludeWhen: true,
+			isConstant:    false,
+		},
+		{
+			name:          "Constant Kind",
+			kind:          ResourceVariableKindConstant,
+			expectedStr:   "constant",
+			isStatic:      false,
+			isDynamic:     false,
+			isIncludeWhen: false,
+			isConstant:    true,
 		},
 		{
 			name:          "Unknown Kind",
@@ -68,6 +82,7 @@ func TestResourceVariableKind(t *testing.T) {
 			isStatic:      false,
 			isDynamic:     false,
 			isIncludeWhen: false,
+			isConstant:    false,
 		},
 	}
 
@@ -77,6 +92,7 @@ func TestResourceVariableKind(t *testing.T) {
 			assert.Equal(t, tc.isStatic, tc.kind.IsStatic())
 			assert.Equal(t, tc.isDynamic, tc.kind.IsDynamic())
 			assert.Equal(t, tc.isIncludeWhen, tc.kind.IsIncludeWhen())
+			assert.Equal(t, tc.isConstant, tc.kind.IsConstant())
 		})
 	}
 }

--- a/test/integration/suites/core/validation_test.go
+++ b/test/integration/suites/core/validation_test.go
@@ -470,6 +470,52 @@ var _ = Describe("Validation", func() {
 			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 		})
 	})
+
+	Context("Constant Expression Evaluation", func() {
+		It("should reject RGDs with invalid constant expressions like division by zero", func(ctx SpecContext) {
+			rgd := generator.NewResourceGraphDefinition("test-constant-division-by-zero",
+				generator.WithSchema(
+					"TestConstantError", "v1alpha1",
+					map[string]interface{}{},
+					nil,
+				),
+				generator.WithResource("deployment", map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "test-deploy",
+					},
+					"spec": map[string]interface{}{
+						"replicas": "${5 / 0}",
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"app": "test",
+							},
+						},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"app": "test",
+								},
+							},
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "test",
+										"image": "nginx",
+									},
+								},
+							},
+						},
+					},
+				}, nil, nil),
+			)
+
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			expectRGDInactiveWithError(ctx, rgd, "division by zero")
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+	})
 })
 
 func validResourceDef() map[string]interface{} {


### PR DESCRIPTION
Compile constant CEL expressions per RGD instead of per instance

This causes two main advantages 
1. we can catch expression eval errors in constant expressions sooner
2. we only do the work of eval constant expressions per rgd instead of per instance

Test with an rgd with constant expression of `${string(5/0)}`
```
Status:
  Conditions:
    Last Transition Time:  2026-03-18T19:35:45Z
    Message:               condition "KindReady" is awaiting reconciliation
    Observed Generation:   1
    Reason:                AwaitingReconciliation
    Status:                Unknown
    Type:                  KindReady
    Last Transition Time:  2026-03-18T19:35:45Z
    Message:               condition "ControllerReady" is awaiting reconciliation
    Observed Generation:   1
    Reason:                AwaitingReconciliation
    Status:                Unknown
    Type:                  ControllerReady
    Last Transition Time:  2026-03-18T19:35:46Z
    Message:               failed to validate resource "deployment": constant at "spec.template.metadata.labels.app": division by zero
    Observed Generation:   1
    Reason:                InvalidResourceGraph
    Status:                False
    Type:                  ResourceGraphAccepted
    Last Transition Time:  2026-03-18T19:35:46Z
    Message:               failed to validate resource "deployment": constant at "spec.template.metadata.labels.app": division by zero
    Observed Generation:   1
    Reason:                InvalidResourceGraph
    Status:                False
    Type:                  Ready
  State:                   Inactive
Events:                    <none>

```