### PR TITLE
feat(resolver): add CRD informer-backed schema resolver with lazy extraction

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -239,9 +239,8 @@ func main() {
 		os.Exit(1)
 	}
 	crdInformerFactory := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClientset, 0)
-	crdResolver := schemaresolver.NewCRDSchemaResolver(
-		crdInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
-	)
+	crdInformer := crdInformerFactory.Apiextensions().V1().CustomResourceDefinitions()
+	crdResolver := schemaresolver.NewCRDSchemaResolver(crdInformer)
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		crdInformerFactory.Start(ctx.Done())
 		crdInformerFactory.WaitForCacheSync(ctx.Done())
@@ -270,6 +269,7 @@ func main() {
 		dc,
 		resourceGraphDefinitionGraphBuilder,
 		instanceRequeueInterval,
+		crdInformer.Informer(),
 		resourceGraphDefinitionConcurrentReconciles,
 		graph.RGDConfig{
 			MaxCollectionSize:          rgdMaxCollectionSize,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -27,10 +27,10 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -230,9 +230,7 @@ func main() {
 		BurstLimit:      burstLimit,
 	}, set.Metadata(), set.RESTMapper())
 
-	// Schema resolution: core → CRD informer → fallback discovery.
-	coreResolver := schemaresolver.DefaultCoreResolver()
-
+	// Shared CRD informer for schema resolution and RGD controller.
 	apiextensionsClientset, err := apiextensionsclient.NewForConfigAndClient(restConfig, set.HTTPClient())
 	if err != nil {
 		setupLog.Error(err, "unable to create apiextensions clientset")
@@ -240,7 +238,6 @@ func main() {
 	}
 	crdInformerFactory := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClientset, 0)
 	crdInformer := crdInformerFactory.Apiextensions().V1().CustomResourceDefinitions()
-	crdResolver := schemaresolver.NewCRDSchemaResolver(crdInformer)
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		crdInformerFactory.Start(ctx.Done())
 		crdInformerFactory.WaitForCacheSync(ctx.Done())
@@ -248,18 +245,23 @@ func main() {
 		crdInformerFactory.Shutdown()
 		return nil
 	})); err != nil {
-		setupLog.Error(err, "unable to register CRD informer factory with manager")
+		setupLog.Error(err, "unable to register CRD informer with manager")
 		os.Exit(1)
 	}
 
+	// Schema resolution: core -> CRD informer -> fallback discovery.
+	crdResolver, err := schemaresolver.NewCRDSchemaResolver(crdInformer)
+	if err != nil {
+		setupLog.Error(err, "unable to create CRD schema resolver")
+		os.Exit(1)
+	}
 	fallbackResolver, err := schemaresolver.DefaultFallbackResolver(restConfig, set.HTTPClient())
 	if err != nil {
 		setupLog.Error(err, "unable to create fallback schema resolver")
 		os.Exit(1)
 	}
-
 	resourceGraphDefinitionGraphBuilder := graph.NewBuilder(
-		schemaresolver.NewChainedResolver(coreResolver, crdResolver, fallbackResolver),
+		schemaresolver.NewChainedResolver(schemaresolver.DefaultCoreResolver(), crdResolver, fallbackResolver),
 		set.RESTMapper(),
 	)
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -26,10 +27,14 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 
 	xv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
@@ -37,6 +42,7 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
 	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
+	schemaresolver "github.com/kubernetes-sigs/kro/pkg/graph/schema/resolver"
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 	// +kubebuilder:scaffold:imports
 )
@@ -224,11 +230,39 @@ func main() {
 		BurstLimit:      burstLimit,
 	}, set.Metadata(), set.RESTMapper())
 
-	resourceGraphDefinitionGraphBuilder, err := graph.NewBuilder(restConfig, set.HTTPClient())
+	// Schema resolution: core → CRD informer → fallback discovery.
+	coreResolver := schemaresolver.DefaultCoreResolver()
+
+	apiextensionsClientset, err := apiextensionsclient.NewForConfigAndClient(restConfig, set.HTTPClient())
 	if err != nil {
-		setupLog.Error(err, "unable to create resource graph definition graph builder")
+		setupLog.Error(err, "unable to create apiextensions clientset")
 		os.Exit(1)
 	}
+	crdInformerFactory := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClientset, 0)
+	crdResolver := schemaresolver.NewCRDSchemaResolver(
+		crdInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+	)
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		crdInformerFactory.Start(ctx.Done())
+		crdInformerFactory.WaitForCacheSync(ctx.Done())
+		<-ctx.Done()
+		crdInformerFactory.Shutdown()
+		return nil
+	})); err != nil {
+		setupLog.Error(err, "unable to register CRD informer factory with manager")
+		os.Exit(1)
+	}
+
+	fallbackResolver, err := schemaresolver.DefaultFallbackResolver(restConfig, set.HTTPClient())
+	if err != nil {
+		setupLog.Error(err, "unable to create fallback schema resolver")
+		os.Exit(1)
+	}
+
+	resourceGraphDefinitionGraphBuilder := graph.NewBuilder(
+		schemaresolver.NewChainedResolver(coreResolver, crdResolver, fallbackResolver),
+		set.RESTMapper(),
+	)
 
 	rgd := resourcegraphdefinitionctrl.NewResourceGraphDefinitionReconciler(
 		set,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"os"
 	"strings"
@@ -30,11 +29,7 @@ import (
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 
 	xv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
@@ -230,29 +225,10 @@ func main() {
 		BurstLimit:      burstLimit,
 	}, set.Metadata(), set.RESTMapper())
 
-	// Shared CRD informer for schema resolution and RGD controller.
-	apiextensionsClientset, err := apiextensionsclient.NewForConfigAndClient(restConfig, set.HTTPClient())
-	if err != nil {
-		setupLog.Error(err, "unable to create apiextensions clientset")
-		os.Exit(1)
-	}
-	crdInformerFactory := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClientset, 0)
-	crdInformer := crdInformerFactory.Apiextensions().V1().CustomResourceDefinitions()
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		crdInformerFactory.Start(ctx.Done())
-		crdInformerFactory.WaitForCacheSync(ctx.Done())
-		<-ctx.Done()
-		crdInformerFactory.Shutdown()
-		return nil
-	})); err != nil {
-		setupLog.Error(err, "unable to register CRD informer with manager")
-		os.Exit(1)
-	}
-
-	// Schema resolution: core -> CRD informer -> fallback discovery.
-	crdResolver, err := schemaresolver.NewCRDSchemaResolver(crdInformer)
-	if err != nil {
-		setupLog.Error(err, "unable to create CRD schema resolver")
+	// Schema resolution: core -> CRD informer (via manager cache) -> fallback discovery.
+	crdResolver := schemaresolver.NewCRDSchemaResolver(mgr.GetCache())
+	if err := crdResolver.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to setup CRD schema resolver")
 		os.Exit(1)
 	}
 	fallbackResolver, err := schemaresolver.DefaultFallbackResolver(restConfig, set.HTTPClient())
@@ -271,7 +247,6 @@ func main() {
 		dc,
 		resourceGraphDefinitionGraphBuilder,
 		instanceRequeueInterval,
-		crdInformer.Informer(),
 		resourceGraphDefinitionConcurrentReconciles,
 		graph.RGDConfig{
 			MaxCollectionSize:          rgdMaxCollectionSize,

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -20,18 +20,19 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlrtcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
@@ -61,6 +62,7 @@ type ResourceGraphDefinitionReconciler struct {
 	rgBuilder               resourceGraphBuilder
 	dynamicController       *dynamiccontroller.DynamicController
 	instanceRequeueInterval time.Duration
+	crdInformer             cache.Informer
 	maxConcurrentReconciles int
 	rgdConfig               graph.RGDConfig
 
@@ -73,6 +75,7 @@ func NewResourceGraphDefinitionReconciler(
 	dynamicController *dynamiccontroller.DynamicController,
 	builder *graph.Builder,
 	instanceRequeueInterval time.Duration,
+	crdInformer cache.Informer,
 	maxConcurrentReconciles int,
 	rgdConfig graph.RGDConfig,
 ) *ResourceGraphDefinitionReconciler {
@@ -86,6 +89,7 @@ func NewResourceGraphDefinitionReconciler(
 		instanceRequeueInterval: instanceRequeueInterval,
 		metadataLabeler:         metadata.NewKROMetaLabeler(),
 		rgBuilder:               builder,
+		crdInformer:             crdInformer,
 		maxConcurrentReconciles: maxConcurrentReconciles,
 		rgdConfig:               rgdConfig,
 	}
@@ -127,10 +131,10 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 				MaxConcurrentReconciles: r.maxConcurrentReconciles,
 			},
 		).
-		WatchesMetadata(
-			&extv1.CustomResourceDefinition{},
-			handler.EnqueueRequestsFromMapFunc(r.findRGDsForCRD),
-			builder.WithPredicates(predicate.Funcs{
+		WatchesRawSource(&source.Informer{
+			Informer: r.crdInformer,
+			Handler:  handler.EnqueueRequestsFromMapFunc(r.findRGDsForCRD),
+			Predicates: []predicate.Predicate{predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return true
 				},
@@ -140,8 +144,8 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 				DeleteFunc: func(e event.DeleteEvent) bool {
 					return true
 				},
-			}),
-		).
+			}},
+		}).
 		Complete(reconcile.AsReconciler[*v1alpha1.ResourceGraphDefinition](mgr.GetClient(), r))
 }
 

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -20,19 +20,18 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlrtcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
@@ -62,7 +61,6 @@ type ResourceGraphDefinitionReconciler struct {
 	rgBuilder               resourceGraphBuilder
 	dynamicController       *dynamiccontroller.DynamicController
 	instanceRequeueInterval time.Duration
-	crdInformer             cache.Informer
 	maxConcurrentReconciles int
 	rgdConfig               graph.RGDConfig
 
@@ -75,7 +73,6 @@ func NewResourceGraphDefinitionReconciler(
 	dynamicController *dynamiccontroller.DynamicController,
 	builder *graph.Builder,
 	instanceRequeueInterval time.Duration,
-	crdInformer cache.Informer,
 	maxConcurrentReconciles int,
 	rgdConfig graph.RGDConfig,
 ) *ResourceGraphDefinitionReconciler {
@@ -89,7 +86,6 @@ func NewResourceGraphDefinitionReconciler(
 		instanceRequeueInterval: instanceRequeueInterval,
 		metadataLabeler:         metadata.NewKROMetaLabeler(),
 		rgBuilder:               builder,
-		crdInformer:             crdInformer,
 		maxConcurrentReconciles: maxConcurrentReconciles,
 		rgdConfig:               rgdConfig,
 	}
@@ -131,21 +127,15 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 				MaxConcurrentReconciles: r.maxConcurrentReconciles,
 			},
 		).
-		WatchesRawSource(&source.Informer{
-			Informer: r.crdInformer,
-			Handler:  handler.EnqueueRequestsFromMapFunc(r.findRGDsForCRD),
-			Predicates: []predicate.Predicate{predicate.Funcs{
-				UpdateFunc: func(e event.UpdateEvent) bool {
-					return true
-				},
-				CreateFunc: func(e event.CreateEvent) bool {
-					return false
-				},
-				DeleteFunc: func(e event.DeleteEvent) bool {
-					return true
-				},
-			}},
-		}).
+		Watches(
+			&apiextensionsv1.CustomResourceDefinition{},
+			handler.EnqueueRequestsFromMapFunc(r.findRGDsForCRD),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool { return false },
+				UpdateFunc: func(e event.UpdateEvent) bool { return true },
+				DeleteFunc: func(e event.DeleteEvent) bool { return true },
+			}),
+		).
 		Complete(reconcile.AsReconciler[*v1alpha1.ResourceGraphDefinition](mgr.GetClient(), r))
 }
 

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -485,6 +485,7 @@ func TestNewResourceGraphDefinitionReconciler(t *testing.T) {
 		nil,
 		nil,
 		9*time.Second,
+		nil,
 		7,
 		graph.RGDConfig{MaxCollectionSize: 32},
 	)
@@ -656,7 +657,7 @@ func TestSetupWithManager(t *testing.T) {
 				addErr:            tt.addErr,
 			}
 
-			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 5*time.Second, 3, graph.RGDConfig{})
+			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 5*time.Second, cache.crdInformer, 3, graph.RGDConfig{})
 			reconciler.rgBuilder = newTestBuilder()
 			reconciler.crdManager = &stubCRDManager{}
 			err := reconciler.SetupWithManager(mgr)

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -643,7 +643,7 @@ func TestSetupWithManager(t *testing.T) {
 				v1alpha1.GroupVersion,
 				extv1.SchemeGroupVersion,
 			})
-			cache := &stubCache{
+			stubCch := &stubCache{
 				rgdInformer: &stubInformer{},
 				crdInformer: &stubInformer{},
 			}
@@ -652,12 +652,12 @@ func TestSetupWithManager(t *testing.T) {
 				restMapper:        mapper,
 				logger:            logr.Discard(),
 				scheme:            testScheme(t),
-				cache:             cache,
+				cache:             stubCch,
 				controllerOptions: config.Controller{SkipNameValidation: &skipNameValidation},
 				addErr:            tt.addErr,
 			}
 
-			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 5*time.Second, cache.crdInformer, 3, graph.RGDConfig{})
+			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 5*time.Second, stubCch.crdInformer, 3, graph.RGDConfig{})
 			reconciler.rgBuilder = newTestBuilder()
 			reconciler.crdManager = &stubCRDManager{}
 			err := reconciler.SetupWithManager(mgr)

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -485,7 +485,6 @@ func TestNewResourceGraphDefinitionReconciler(t *testing.T) {
 		nil,
 		nil,
 		9*time.Second,
-		nil,
 		7,
 		graph.RGDConfig{MaxCollectionSize: 32},
 	)
@@ -657,7 +656,7 @@ func TestSetupWithManager(t *testing.T) {
 				addErr:            tt.addErr,
 			}
 
-			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 5*time.Second, stubCch.crdInformer, 3, graph.RGDConfig{})
+			reconciler := NewResourceGraphDefinitionReconciler(fakeSet, true, newRunningDynamicController(t), nil, 5*time.Second, 3, graph.RGDConfig{})
 			reconciler.rgBuilder = newTestBuilder()
 			reconciler.crdManager = &stubCRDManager{}
 			err := reconciler.SetupWithManager(mgr)

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -16,7 +16,6 @@ package graph
 
 import (
 	"fmt"
-	"net/http"
 	"slices"
 	"strings"
 
@@ -29,10 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	apiservercel "k8s.io/apiserver/pkg/cel"
 	"k8s.io/apiserver/pkg/cel/openapi"
-	"k8s.io/apiserver/pkg/cel/openapi/resolver"
-	"k8s.io/client-go/rest"
+	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
 	"k8s.io/kube-openapi/pkg/validation/spec"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
@@ -45,30 +42,20 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
 	"github.com/kubernetes-sigs/kro/pkg/graph/parser"
 	"github.com/kubernetes-sigs/kro/pkg/graph/schema"
-	schemaresolver "github.com/kubernetes-sigs/kro/pkg/graph/schema/resolver"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/simpleschema"
 )
 
-// NewBuilder creates a new GraphBuilder instance.
-func NewBuilder(clientConfig *rest.Config, httpClient *http.Client) (*Builder, error) {
-	schemaResolver, err := schemaresolver.NewCombinedResolver(clientConfig, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create schema resolver: %w", err)
-	}
-
-	rm, err := apiutil.NewDynamicRESTMapper(clientConfig, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic REST mapper: %w", err)
-	}
-
-	rgBuilder := &Builder{
+// NewBuilder creates a new Builder that uses the given schema resolver and
+// REST mapper. The caller is responsible for constructing and starting any
+// resolvers that require a lifecycle (e.g. CRD informer).
+func NewBuilder(schemaResolver openapiresolver.SchemaResolver, restMapper meta.RESTMapper) *Builder {
+	return &Builder{
 		schemaResolver: schemaResolver,
-		restMapper:     rm,
+		restMapper:     restMapper,
 		celCache:       celcache.NewBuilderCache(),
 	}
-	return rgBuilder, nil
 }
 
 // Builder is an object that is responsible for constructing and managing
@@ -96,7 +83,7 @@ func NewBuilder(clientConfig *rest.Config, httpClient *http.Client) (*Builder, e
 // cluster.
 type Builder struct {
 	// schemaResolver is used to resolve the OpenAPI schema for the resources.
-	schemaResolver resolver.SchemaResolver
+	schemaResolver openapiresolver.SchemaResolver
 	restMapper     meta.RESTMapper
 	// celCache holds cached CEL compilation artifacts (DeclTypes, typed
 	// environments, field type maps) scoped to this Builder instance.

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -15,8 +15,6 @@
 package graph
 
 import (
-	"net/http"
-	"os"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -28,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	memory2 "k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
@@ -2197,30 +2194,10 @@ func TestGraphBuilder_CELTypeChecking(t *testing.T) {
 }
 
 func TestNewBuilder(t *testing.T) {
-	tests := []struct {
-		name    string
-		config  *rest.Config
-		client  *http.Client
-		wantErr string
-	}{
-		{name: "success", config: &rest.Config{}, client: &http.Client{}},
-		{name: "schema resolver creation failure", config: &rest.Config{Host: "://bad"}, client: &http.Client{}, wantErr: "failed to create schema resolver"},
-		{name: "rest mapper creation failure", config: &rest.Config{}, client: nil, wantErr: "failed to create dynamic REST mapper"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			builder, err := NewBuilder(tt.config, tt.client)
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.NotNil(t, builder)
-		})
-	}
+	fakeResolver, fakeDiscovery := k8s.NewFakeResolver()
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory2.NewMemCacheClient(fakeDiscovery))
+	builder := NewBuilder(fakeResolver, restMapper)
+	assert.NotNil(t, builder)
 }
 
 func TestGraphBuilder_StructuralTypeCompatibility(t *testing.T) {

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -15,6 +15,7 @@
 package graph
 
 import (
+	"os"
 	"testing"
 
 	"github.com/google/cel-go/cel"

--- a/pkg/graph/schema/resolver/crd_resolver.go
+++ b/pkg/graph/schema/resolver/crd_resolver.go
@@ -17,7 +17,9 @@ package resolver
 import (
 	"fmt"
 	"sync"
+	"time"
 
+	"golang.org/x/sync/singleflight"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
@@ -27,6 +29,8 @@ import (
 	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	kroschema "github.com/kubernetes-sigs/kro/pkg/graph/schema"
 )
 
 const (
@@ -45,6 +49,7 @@ type CRDSchemaResolver struct {
 	mu      sync.RWMutex
 	schemas map[schema.GroupVersionKind]*spec.Schema
 	indexer cache.Indexer
+	sf      singleflight.Group
 }
 
 // NewCRDSchemaResolver creates a resolver from a CRD informer. It adds a
@@ -52,11 +57,11 @@ type CRDSchemaResolver struct {
 // handlers for cache eviction. The caller is responsible for starting the
 // informer (e.g. via the informer factory registered with the controller
 // manager).
-func NewCRDSchemaResolver(crdInformer crdinformers.CustomResourceDefinitionInformer) *CRDSchemaResolver {
+func NewCRDSchemaResolver(crdInformer crdinformers.CustomResourceDefinitionInformer) (*CRDSchemaResolver, error) {
 	informer := crdInformer.Informer()
 
 	// Add a custom indexer that maps GVK strings to CRD objects.
-	informer.AddIndexers(cache.Indexers{
+	if err := informer.AddIndexers(cache.Indexers{
 		gvkIndexName: func(obj any) ([]string, error) {
 			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
 			if !ok {
@@ -64,60 +69,91 @@ func NewCRDSchemaResolver(crdInformer crdinformers.CustomResourceDefinitionInfor
 			}
 			return gvkIndexKeys(crd), nil
 		},
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("adding GVK indexer: %w", err)
+	}
 
 	r := &CRDSchemaResolver{
 		schemas: make(map[schema.GroupVersionKind]*spec.Schema),
 		indexer: informer.GetIndexer(),
 	}
 
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: r.onUpdate,
 		DeleteFunc: r.onDelete,
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("adding event handler: %w", err)
+	}
 
-	return r
+	return r, nil
 }
 
 // ResolveSchema returns the OpenAPI schema for the given GVK.
 //
-// On cache hit the schema is returned immediately. On miss the resolver
-// queries the informer's GVK index to find the CRD, extracts the schema for
-// the requested version, caches it, and returns it.
+// On cache hit the schema is returned immediately. On miss, singleflight
+// deduplicates concurrent extractions for the same GVK: only one goroutine
+// queries the informer index, extracts the schema, and populates the cache.
 func (r *CRDSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
 	// Fast path: cached schema.
 	r.mu.RLock()
 	if s, ok := r.schemas[gvk]; ok {
 		r.mu.RUnlock()
+		crdCacheHitsTotal.Inc()
 		return s, nil
 	}
 	r.mu.RUnlock()
 
-	// Look up the CRD from the informer's GVK index.
+	crdCacheMissesTotal.Inc()
+
 	key := gvkIndexKey(gvk)
-	items, err := r.indexer.ByIndex(gvkIndexName, key)
-	if err != nil || len(items) == 0 {
-		return nil, openapiresolver.ErrSchemaNotFound
-	}
+	result, err, shared := r.sf.Do(key, func() (any, error) {
+		// Double-check: another goroutine may have populated the cache.
+		r.mu.RLock()
+		if s, ok := r.schemas[gvk]; ok {
+			r.mu.RUnlock()
+			return s, nil
+		}
+		r.mu.RUnlock()
 
-	crd, ok := items[0].(*apiextensionsv1.CustomResourceDefinition)
-	if !ok {
-		return nil, openapiresolver.ErrSchemaNotFound
-	}
+		// Look up the CRD from the informer's GVK index.
+		items, err := r.indexer.ByIndex(gvkIndexName, key)
+		if err != nil || len(items) == 0 {
+			return nil, openapiresolver.ErrSchemaNotFound
+		}
 
-	// Extract the schema for the requested version.
-	s, err := extractVersionSchema(crd, gvk.Version)
+		crd, ok := items[0].(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			return nil, openapiresolver.ErrSchemaNotFound
+		}
+
+		// Extract the schema for the requested version and inject ObjectMeta.
+		start := time.Now()
+		s, err := extractVersionSchema(crd, gvk.Version)
+		if err != nil {
+			crdExtractionErrorsTotal.Inc()
+			return nil, fmt.Errorf("extracting schema for %v: %w", gvk, err)
+		}
+		if s == nil {
+			return nil, openapiresolver.ErrSchemaNotFound
+		}
+		injectKubeEnvelope(s, crd.Spec.Scope == apiextensionsv1.NamespaceScoped)
+		crdExtractionDuration.Observe(time.Since(start).Seconds())
+
+		r.mu.Lock()
+		r.schemas[gvk] = s
+		r.mu.Unlock()
+
+		crdCacheSize.Set(float64(len(r.schemas)))
+		return s, nil
+	})
+
+	if shared {
+		crdSingleflightDeduplicatedTotal.Inc()
+	}
 	if err != nil {
-		return nil, fmt.Errorf("extracting schema for %v: %w", gvk, err)
+		return nil, err
 	}
-	if s == nil {
-		return nil, openapiresolver.ErrSchemaNotFound
-	}
-
-	r.mu.Lock()
-	r.schemas[gvk] = s
-	r.mu.Unlock()
-	return s, nil
+	return result.(*spec.Schema), nil
 }
 
 // gvkIndexKey returns the index key for a GVK.
@@ -157,10 +193,14 @@ func allGVKs(crd *apiextensionsv1.CustomResourceDefinition) []schema.GroupVersio
 
 func (r *CRDSchemaResolver) evictGVKs(gvks []schema.GroupVersionKind) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	for _, gvk := range gvks {
-		delete(r.schemas, gvk)
+		if _, ok := r.schemas[gvk]; ok {
+			delete(r.schemas, gvk)
+			crdCacheEvictionsTotal.Inc()
+		}
 	}
+	crdCacheSize.Set(float64(len(r.schemas)))
+	r.mu.Unlock()
 }
 
 func (r *CRDSchemaResolver) onUpdate(oldObj, newObj any) {
@@ -189,6 +229,30 @@ func (r *CRDSchemaResolver) onDelete(obj any) {
 		return
 	}
 	r.evictGVKs(allGVKs(crd))
+}
+
+// injectKubeEnvelope adds the standard Kubernetes envelope fields (metadata,
+// apiVersion, kind) to a CRD schema. CRD specs only contain spec/status —
+// the API server injects the rest when serving aggregated OpenAPI.
+func injectKubeEnvelope(s *spec.Schema, namespaced bool) {
+	if s.Properties == nil {
+		s.Properties = make(map[string]spec.Schema)
+	}
+	// Replace metadata if absent or if it's a bare "type: object" stub
+	// (common in CRDs generated by controller-gen).
+	if meta, ok := s.Properties["metadata"]; !ok || len(meta.Properties) == 0 {
+		if namespaced {
+			s.Properties["metadata"] = kroschema.ObjectMetaSchema
+		} else {
+			s.Properties["metadata"] = kroschema.NamespacelessObjectMetaSchema
+		}
+	}
+	if _, ok := s.Properties["apiVersion"]; !ok {
+		s.Properties["apiVersion"] = kroschema.StringSchema
+	}
+	if _, ok := s.Properties["kind"]; !ok {
+		s.Properties["kind"] = kroschema.StringSchema
+	}
 }
 
 // extractVersionSchema extracts the OpenAPI schema for a specific version from a CRD.

--- a/pkg/graph/schema/resolver/crd_resolver.go
+++ b/pkg/graph/schema/resolver/crd_resolver.go
@@ -15,6 +15,7 @@
 package resolver
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -23,76 +24,145 @@ import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
-	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/cel/environment"
 	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kroschema "github.com/kubernetes-sigs/kro/pkg/graph/schema"
 )
 
 const (
-	// gvkIndexName is the name of the custom indexer that maps GVK strings
-	// to CRD objects.
-	gvkIndexName = "byGVK"
+	// CRDGVKIndexField is the field index name used by controller-runtime's
+	// cache to map GVK strings to CRD objects.
+	CRDGVKIndexField = ".metadata.gvkIndex"
 )
 
-// CRDSchemaResolver resolves schemas from CRD OpenAPI definitions using a CRD
-// informer with a custom GVK indexer for lookups and lazy schema extraction.
+// CRDSchemaResolver resolves schemas from CRD OpenAPI definitions using the
+// controller-runtime cache with a custom GVK field index for lookups and lazy
+// schema extraction.
 //
 // Schemas are only parsed when ResolveSchema is called (lazy) and cached until
-// the CRD is updated or deleted. Event handlers evict cached schemas so the
-// next resolve re-extracts from the updated CRD.
+// the CRD is updated or deleted. A controller watches CRD changes and evicts
+// cached schemas so the next resolve re-extracts from the updated CRD.
 type CRDSchemaResolver struct {
 	mu      sync.RWMutex
 	schemas map[schema.GroupVersionKind]*spec.Schema
-	indexer cache.Indexer
+	// crdGVKs is a reverse index: CRD name → GVKs tracked for that CRD.
+	// Used to evict schemas when a CRD is deleted (the object is already
+	// gone from the cache by the time the reconciler runs).
+	crdGVKs map[string][]schema.GroupVersionKind
+	cache   cache.Cache
 	sf      singleflight.Group
 }
 
-// NewCRDSchemaResolver creates a resolver from a CRD informer. It adds a
-// custom GVK indexer to the informer for O(1) lookups and registers event
-// handlers for cache eviction. The caller is responsible for starting the
-// informer (e.g. via the informer factory registered with the controller
-// manager).
-func NewCRDSchemaResolver(crdInformer crdinformers.CustomResourceDefinitionInformer) (*CRDSchemaResolver, error) {
-	informer := crdInformer.Informer()
+// NewCRDSchemaResolver creates a resolver backed by the controller-runtime
+// cache. Call SetupWithManager to register the field index and eviction
+// controller before starting the manager.
+func NewCRDSchemaResolver(c cache.Cache) *CRDSchemaResolver {
+	return &CRDSchemaResolver{
+		schemas: make(map[schema.GroupVersionKind]*spec.Schema),
+		crdGVKs: make(map[string][]schema.GroupVersionKind),
+		cache:   c,
+	}
+}
 
-	// Add a custom indexer that maps GVK strings to CRD objects.
-	if err := informer.AddIndexers(cache.Indexers{
-		gvkIndexName: func(obj any) ([]string, error) {
+// SetupWithManager registers a GVK field index on the cache and a controller
+// that watches CRD updates/deletes to evict stale cached schemas. Must be
+// called before the manager is started.
+func (r *CRDSchemaResolver) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetCache().IndexField(
+		context.Background(),
+		&apiextensionsv1.CustomResourceDefinition{},
+		CRDGVKIndexField,
+		func(obj client.Object) []string {
 			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
 			if !ok {
-				return nil, nil
+				return nil
 			}
-			return gvkIndexKeys(crd), nil
+			return gvkIndexKeys(crd)
 		},
-	}); err != nil {
-		return nil, fmt.Errorf("adding GVK indexer: %w", err)
+	); err != nil {
+		return fmt.Errorf("adding GVK field index: %w", err)
 	}
 
-	r := &CRDSchemaResolver{
-		schemas: make(map[schema.GroupVersionKind]*spec.Schema),
-		indexer: informer.GetIndexer(),
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("crd-schema-resolver").
+		Watches(
+			&apiextensionsv1.CustomResourceDefinition{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(event.CreateEvent) bool { return false },
+				UpdateFunc: func(event.UpdateEvent) bool { return true },
+				DeleteFunc: func(event.DeleteEvent) bool { return true },
+			}),
+		).
+		Complete(r)
+}
+
+// Reconcile evicts cached schemas when a CRD is updated or deleted.
+func (r *CRDSchemaResolver) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.cache.Get(ctx, client.ObjectKey{Name: req.Name}, crd); err != nil {
+		if apierrors.IsNotFound(err) {
+			// CRD deleted — evict using the reverse index.
+			r.mu.Lock()
+			if gvks, ok := r.crdGVKs[req.Name]; ok {
+				for _, gvk := range gvks {
+					if _, exists := r.schemas[gvk]; exists {
+						delete(r.schemas, gvk)
+						crdCacheEvictionsTotal.Inc()
+					}
+				}
+				delete(r.crdGVKs, req.Name)
+				crdCacheSize.Set(float64(len(r.schemas)))
+			}
+			r.mu.Unlock()
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
 	}
 
-	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: r.onUpdate,
-		DeleteFunc: r.onDelete,
-	}); err != nil {
-		return nil, fmt.Errorf("adding event handler: %w", err)
+	// CRD updated — evict all tracked GVKs (old + new versions).
+	gvks := allGVKs(crd)
+	r.mu.Lock()
+	// Evict previously tracked GVKs (handles removed versions).
+	if old, ok := r.crdGVKs[req.Name]; ok {
+		for _, gvk := range old {
+			if _, exists := r.schemas[gvk]; exists {
+				delete(r.schemas, gvk)
+				crdCacheEvictionsTotal.Inc()
+			}
+		}
 	}
+	// Evict current GVKs and update the reverse index.
+	for _, gvk := range gvks {
+		if _, exists := r.schemas[gvk]; exists {
+			delete(r.schemas, gvk)
+			crdCacheEvictionsTotal.Inc()
+		}
+	}
+	r.crdGVKs[req.Name] = gvks
+	crdCacheSize.Set(float64(len(r.schemas)))
+	r.mu.Unlock()
 
-	return r, nil
+	return reconcile.Result{}, nil
 }
 
 // ResolveSchema returns the OpenAPI schema for the given GVK.
 //
 // On cache hit the schema is returned immediately. On miss, singleflight
 // deduplicates concurrent extractions for the same GVK: only one goroutine
-// queries the informer index, extracts the schema, and populates the cache.
+// queries the cache index, extracts the schema, and populates the local cache.
 func (r *CRDSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
 	// Fast path: cached schema.
 	r.mu.RLock()
@@ -115,16 +185,18 @@ func (r *CRDSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Sc
 		}
 		r.mu.RUnlock()
 
-		// Look up the CRD from the informer's GVK index.
-		items, err := r.indexer.ByIndex(gvkIndexName, key)
-		if err != nil || len(items) == 0 {
+		// Look up the CRD from the cache's GVK field index.
+		var crdList apiextensionsv1.CustomResourceDefinitionList
+		if err := r.cache.List(context.Background(), &crdList,
+			client.MatchingFields{CRDGVKIndexField: key},
+		); err != nil {
+			return nil, fmt.Errorf("listing CRDs by GVK index: %w", err)
+		}
+		if len(crdList.Items) == 0 {
 			return nil, openapiresolver.ErrSchemaNotFound
 		}
 
-		crd, ok := items[0].(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			return nil, openapiresolver.ErrSchemaNotFound
-		}
+		crd := &crdList.Items[0]
 
 		// Extract the schema for the requested version and inject ObjectMeta.
 		start := time.Now()
@@ -141,6 +213,8 @@ func (r *CRDSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Sc
 
 		r.mu.Lock()
 		r.schemas[gvk] = s
+		// Track this CRD in the reverse index for delete eviction.
+		r.crdGVKs[crd.Name] = allGVKs(crd)
 		r.mu.Unlock()
 
 		crdCacheSize.Set(float64(len(r.schemas)))
@@ -189,46 +263,6 @@ func allGVKs(crd *apiextensionsv1.CustomResourceDefinition) []schema.GroupVersio
 		})
 	}
 	return gvks
-}
-
-func (r *CRDSchemaResolver) evictGVKs(gvks []schema.GroupVersionKind) {
-	r.mu.Lock()
-	for _, gvk := range gvks {
-		if _, ok := r.schemas[gvk]; ok {
-			delete(r.schemas, gvk)
-			crdCacheEvictionsTotal.Inc()
-		}
-	}
-	crdCacheSize.Set(float64(len(r.schemas)))
-	r.mu.Unlock()
-}
-
-func (r *CRDSchemaResolver) onUpdate(oldObj, newObj any) {
-	// Evict GVKs from both old and new CRD to handle served-version changes.
-	if oldCRD, ok := oldObj.(*apiextensionsv1.CustomResourceDefinition); ok && oldCRD != nil {
-		r.evictGVKs(allGVKs(oldCRD))
-	}
-	if newCRD, ok := newObj.(*apiextensionsv1.CustomResourceDefinition); ok && newCRD != nil {
-		r.evictGVKs(allGVKs(newCRD))
-	}
-}
-
-func (r *CRDSchemaResolver) onDelete(obj any) {
-	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return
-		}
-		crd, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			return
-		}
-	}
-	if crd == nil {
-		return
-	}
-	r.evictGVKs(allGVKs(crd))
 }
 
 // injectKubeEnvelope adds the standard Kubernetes envelope fields (metadata,

--- a/pkg/graph/schema/resolver/crd_resolver.go
+++ b/pkg/graph/schema/resolver/crd_resolver.go
@@ -1,0 +1,224 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"fmt"
+	"sync"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/cel/environment"
+	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+const (
+	// gvkIndexName is the name of the custom indexer that maps GVK strings
+	// to CRD objects.
+	gvkIndexName = "byGVK"
+)
+
+// CRDSchemaResolver resolves schemas from CRD OpenAPI definitions using a CRD
+// informer with a custom GVK indexer for lookups and lazy schema extraction.
+//
+// Schemas are only parsed when ResolveSchema is called (lazy) and cached until
+// the CRD is updated or deleted. Event handlers evict cached schemas so the
+// next resolve re-extracts from the updated CRD.
+type CRDSchemaResolver struct {
+	mu      sync.RWMutex
+	schemas map[schema.GroupVersionKind]*spec.Schema
+	indexer cache.Indexer
+}
+
+// NewCRDSchemaResolver creates a resolver from a CRD informer. It adds a
+// custom GVK indexer to the informer for O(1) lookups and registers event
+// handlers for cache eviction. The caller is responsible for starting the
+// informer (e.g. via the informer factory registered with the controller
+// manager).
+func NewCRDSchemaResolver(crdInformer crdinformers.CustomResourceDefinitionInformer) *CRDSchemaResolver {
+	informer := crdInformer.Informer()
+
+	// Add a custom indexer that maps GVK strings to CRD objects.
+	informer.AddIndexers(cache.Indexers{
+		gvkIndexName: func(obj any) ([]string, error) {
+			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok {
+				return nil, nil
+			}
+			return gvkIndexKeys(crd), nil
+		},
+	})
+
+	r := &CRDSchemaResolver{
+		schemas: make(map[schema.GroupVersionKind]*spec.Schema),
+		indexer: informer.GetIndexer(),
+	}
+
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: r.onUpdate,
+		DeleteFunc: r.onDelete,
+	})
+
+	return r
+}
+
+// ResolveSchema returns the OpenAPI schema for the given GVK.
+//
+// On cache hit the schema is returned immediately. On miss the resolver
+// queries the informer's GVK index to find the CRD, extracts the schema for
+// the requested version, caches it, and returns it.
+func (r *CRDSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	// Fast path: cached schema.
+	r.mu.RLock()
+	if s, ok := r.schemas[gvk]; ok {
+		r.mu.RUnlock()
+		return s, nil
+	}
+	r.mu.RUnlock()
+
+	// Look up the CRD from the informer's GVK index.
+	key := gvkIndexKey(gvk)
+	items, err := r.indexer.ByIndex(gvkIndexName, key)
+	if err != nil || len(items) == 0 {
+		return nil, openapiresolver.ErrSchemaNotFound
+	}
+
+	crd, ok := items[0].(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return nil, openapiresolver.ErrSchemaNotFound
+	}
+
+	// Extract the schema for the requested version.
+	s, err := extractVersionSchema(crd, gvk.Version)
+	if err != nil {
+		return nil, fmt.Errorf("extracting schema for %v: %w", gvk, err)
+	}
+	if s == nil {
+		return nil, openapiresolver.ErrSchemaNotFound
+	}
+
+	r.mu.Lock()
+	r.schemas[gvk] = s
+	r.mu.Unlock()
+	return s, nil
+}
+
+// gvkIndexKey returns the index key for a GVK.
+func gvkIndexKey(gvk schema.GroupVersionKind) string {
+	return gvk.Group + "/" + gvk.Version + "/" + gvk.Kind
+}
+
+// gvkIndexKeys returns all index keys for served versions of a CRD.
+func gvkIndexKeys(crd *apiextensionsv1.CustomResourceDefinition) []string {
+	keys := make([]string, 0, len(crd.Spec.Versions))
+	for _, v := range crd.Spec.Versions {
+		if !v.Served {
+			continue
+		}
+		keys = append(keys, gvkIndexKey(schema.GroupVersionKind{
+			Group:   crd.Spec.Group,
+			Version: v.Name,
+			Kind:    crd.Spec.Names.Kind,
+		}))
+	}
+	return keys
+}
+
+// allGVKs returns GVKs for all versions of a CRD (served or not), used for
+// eviction to ensure stale entries for removed versions are cleaned up.
+func allGVKs(crd *apiextensionsv1.CustomResourceDefinition) []schema.GroupVersionKind {
+	gvks := make([]schema.GroupVersionKind, 0, len(crd.Spec.Versions))
+	for _, v := range crd.Spec.Versions {
+		gvks = append(gvks, schema.GroupVersionKind{
+			Group:   crd.Spec.Group,
+			Version: v.Name,
+			Kind:    crd.Spec.Names.Kind,
+		})
+	}
+	return gvks
+}
+
+func (r *CRDSchemaResolver) evictGVKs(gvks []schema.GroupVersionKind) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, gvk := range gvks {
+		delete(r.schemas, gvk)
+	}
+}
+
+func (r *CRDSchemaResolver) onUpdate(oldObj, newObj any) {
+	// Evict GVKs from both old and new CRD to handle served-version changes.
+	if oldCRD, ok := oldObj.(*apiextensionsv1.CustomResourceDefinition); ok && oldCRD != nil {
+		r.evictGVKs(allGVKs(oldCRD))
+	}
+	if newCRD, ok := newObj.(*apiextensionsv1.CustomResourceDefinition); ok && newCRD != nil {
+		r.evictGVKs(allGVKs(newCRD))
+	}
+}
+
+func (r *CRDSchemaResolver) onDelete(obj any) {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		crd, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			return
+		}
+	}
+	if crd == nil {
+		return
+	}
+	r.evictGVKs(allGVKs(crd))
+}
+
+// extractVersionSchema extracts the OpenAPI schema for a specific version from a CRD.
+func extractVersionSchema(crd *apiextensionsv1.CustomResourceDefinition, version string) (*spec.Schema, error) {
+	for _, v := range crd.Spec.Versions {
+		if v.Name != version {
+			continue
+		}
+		if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
+			return nil, nil
+		}
+		return convertCRDSchema(v.Schema.OpenAPIV3Schema)
+	}
+	return nil, nil
+}
+
+// convertCRDSchema converts a CRD JSONSchemaProps to a kube-openapi spec.Schema.
+func convertCRDSchema(jsonSchema *apiextensionsv1.JSONSchemaProps) (*spec.Schema, error) {
+	internalSchema := &apiextensions.JSONSchemaProps{}
+	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(
+		jsonSchema, internalSchema, nil,
+	); err != nil {
+		return nil, fmt.Errorf("converting CRD schema to internal: %w", err)
+	}
+
+	openapiSchema := &spec.Schema{}
+	postProcess := validation.StripUnsupportedFormatsPostProcessorForVersion(environment.DefaultCompatibilityVersion())
+	if err := validation.ConvertJSONSchemaPropsWithPostProcess(internalSchema, openapiSchema, postProcess); err != nil {
+		return nil, fmt.Errorf("converting to openapi schema: %w", err)
+	}
+
+	return openapiSchema, nil
+}

--- a/pkg/graph/schema/resolver/crd_resolver_test.go
+++ b/pkg/graph/schema/resolver/crd_resolver_test.go
@@ -31,13 +31,11 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
-var testGVK = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
-
-func newTestCRD(name, group, kind string, versions ...string) *apiextensionsv1.CustomResourceDefinition {
+func newTestCRD(name, kind string, versions ...string) *apiextensionsv1.CustomResourceDefinition {
 	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: group,
+			Group: "example.com",
 			Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: kind},
 		},
 	}
@@ -58,7 +56,6 @@ func newTestCRD(name, group, kind string, versions ...string) *apiextensionsv1.C
 	return crd
 }
 
-// startResolver creates a CRDSchemaResolver with a running informer.
 func startResolver(t *testing.T, crds ...*apiextensionsv1.CustomResourceDefinition) (*CRDSchemaResolver, *fake.Clientset) {
 	t.Helper()
 	objs := make([]k8sruntime.Object, len(crds))
@@ -67,7 +64,10 @@ func startResolver(t *testing.T, crds ...*apiextensionsv1.CustomResourceDefiniti
 	}
 	fakeClient := fake.NewSimpleClientset(objs...)
 	factory := apiextensionsinformers.NewSharedInformerFactory(fakeClient, 0)
-	r := NewCRDSchemaResolver(factory.Apiextensions().V1().CustomResourceDefinitions())
+	r, err := NewCRDSchemaResolver(factory.Apiextensions().V1().CustomResourceDefinitions())
+	if err != nil {
+		t.Fatalf("NewCRDSchemaResolver: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -78,7 +78,6 @@ func startResolver(t *testing.T, crds ...*apiextensionsv1.CustomResourceDefiniti
 	return r, fakeClient
 }
 
-// eventually polls condition until it returns true or timeout.
 func eventually(t *testing.T, condition func() bool, timeout, interval time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -91,57 +90,54 @@ func eventually(t *testing.T, condition func() bool, timeout, interval time.Dura
 	t.Fatal("condition not met within timeout")
 }
 
-// --- extractVersionSchema ---
-
 func TestExtractVersionSchema(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1", "v2")
+	crd := newTestCRD("foos.example.com", "Foo", "v1", "v2")
 
-	s, err := extractVersionSchema(crd, "v1")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name    string
+		version string
+		wantNil bool
+	}{
+		{"existing v1", "v1", false},
+		{"existing v2", "v2", false},
+		{"nonexistent version", "v999", true},
 	}
-	if s == nil {
-		t.Fatal("expected non-nil schema for v1")
-	}
-
-	s, err = extractVersionSchema(crd, "v2")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if s == nil {
-		t.Fatal("expected non-nil schema for v2")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := extractVersionSchema(crd, tt.version)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if (s == nil) != tt.wantNil {
+				t.Fatalf("schema nil: got %v, want %v", s == nil, tt.wantNil)
+			}
+		})
 	}
 }
 
-func TestExtractVersionSchema_VersionNotFound(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
-	s, err := extractVersionSchema(crd, "v999")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestExtractVersionSchema_NilFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		versions []apiextensionsv1.CustomResourceDefinitionVersion
+	}{
+		{"nil Schema", []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1", Schema: nil}}},
+		{"nil OpenAPIV3Schema", []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1", Schema: &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: nil}}}},
 	}
-	if s != nil {
-		t.Fatal("expected nil schema for nonexistent version")
-	}
-}
-
-func TestExtractVersionSchema_NilSchema(t *testing.T) {
-	crd := &apiextensionsv1.CustomResourceDefinition{
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-				{Name: "v1", Schema: nil},
-			},
-		},
-	}
-	s, err := extractVersionSchema(crd, "v1")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if s != nil {
-		t.Fatal("expected nil schema when Schema is nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{Versions: tt.versions},
+			}
+			s, err := extractVersionSchema(crd, "v1")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if s != nil {
+				t.Fatal("expected nil schema")
+			}
+		})
 	}
 }
-
-// --- convertCRDSchema ---
 
 func TestConvertCRDSchema(t *testing.T) {
 	jsonSchema := &apiextensionsv1.JSONSchemaProps{
@@ -160,53 +156,85 @@ func TestConvertCRDSchema(t *testing.T) {
 	}
 }
 
-// --- gvkIndexKeys ---
-
 func TestGvkIndexKeys(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1", "v2beta1")
-	keys := gvkIndexKeys(crd)
-	if len(keys) != 2 {
-		t.Fatalf("expected 2 keys, got %d", len(keys))
+	tests := []struct {
+		name     string
+		crd      *apiextensionsv1.CustomResourceDefinition
+		wantKeys []string
+	}{
+		{
+			name:     "multiple served versions",
+			crd:      newTestCRD("foos.example.com", "Foo", "v1", "v2beta1"),
+			wantKeys: []string{"example.com/v1/Foo", "example.com/v2beta1/Foo"},
+		},
+		{
+			name: "filters unserved versions",
+			crd: func() *apiextensionsv1.CustomResourceDefinition {
+				crd := newTestCRD("foos.example.com", "Foo", "v1")
+				crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+					Name: "v2", Served: false,
+				})
+				return crd
+			}(),
+			wantKeys: []string{"example.com/v1/Foo"},
+		},
 	}
-	if keys[0] != "example.com/v1/Foo" {
-		t.Errorf("unexpected key: %s", keys[0])
-	}
-	if keys[1] != "example.com/v2beta1/Foo" {
-		t.Errorf("unexpected key: %s", keys[1])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys := gvkIndexKeys(tt.crd)
+			if len(keys) != len(tt.wantKeys) {
+				t.Fatalf("keys: got %d, want %d", len(keys), len(tt.wantKeys))
+			}
+			for i, want := range tt.wantKeys {
+				if keys[i] != want {
+					t.Errorf("key[%d]: got %s, want %s", i, keys[i], want)
+				}
+			}
+		})
 	}
 }
-
-func TestGvkIndexKeys_FiltersUnserved(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
-	// Add an unserved version.
-	crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
-		Name:   "v2",
-		Served: false,
-	})
-	keys := gvkIndexKeys(crd)
-	if len(keys) != 1 {
-		t.Fatalf("expected 1 key (unserved filtered), got %d", len(keys))
-	}
-}
-
-// --- ResolveSchema ---
 
 func TestResolveSchema(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
-	r, _ := startResolver(t, crd)
-
-	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
-	s, err := r.ResolveSchema(gvk)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name    string
+		crds    []*apiextensionsv1.CustomResourceDefinition
+		gvk     schema.GroupVersionKind
+		wantErr bool
+		wantNil bool
+	}{
+		{
+			name: "resolves existing CRD",
+			crds: []*apiextensionsv1.CustomResourceDefinition{newTestCRD("foos.example.com", "Foo", "v1")},
+			gvk:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		},
+		{
+			name:    "not found for unknown GVK",
+			gvk:     schema.GroupVersionKind{Group: "unknown.com", Version: "v1", Kind: "Unknown"},
+			wantErr: true,
+		},
 	}
-	if s == nil {
-		t.Fatal("expected non-nil schema")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := startResolver(t, tt.crds...)
+			s, err := r.ResolveSchema(tt.gvk)
+			if tt.wantErr {
+				if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
+					t.Fatalf("expected ErrSchemaNotFound, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if s == nil {
+				t.Fatal("expected non-nil schema")
+			}
+		})
 	}
 }
 
 func TestResolveSchema_CacheHit(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	crd := newTestCRD("foos.example.com", "Foo", "v1")
 	r, _ := startResolver(t, crd)
 
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
@@ -217,18 +245,8 @@ func TestResolveSchema_CacheHit(t *testing.T) {
 	}
 }
 
-func TestResolveSchema_NotFound(t *testing.T) {
-	r, _ := startResolver(t)
-
-	gvk := schema.GroupVersionKind{Group: "unknown.com", Version: "v1", Kind: "Unknown"}
-	_, err := r.ResolveSchema(gvk)
-	if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
-		t.Fatalf("expected ErrSchemaNotFound, got %v", err)
-	}
-}
-
 func TestResolveSchema_MultipleVersions(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1", "v2", "v1beta1")
+	crd := newTestCRD("foos.example.com", "Foo", "v1", "v2", "v1beta1")
 	r, _ := startResolver(t, crd)
 
 	for _, version := range []string{"v1", "v2", "v1beta1"} {
@@ -243,10 +261,8 @@ func TestResolveSchema_MultipleVersions(t *testing.T) {
 	}
 }
 
-// --- Event-driven eviction ---
-
 func TestResolveSchema_EvictOnUpdate(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	crd := newTestCRD("foos.example.com", "Foo", "v1")
 	r, fakeClient := startResolver(t, crd)
 
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
@@ -255,7 +271,6 @@ func TestResolveSchema_EvictOnUpdate(t *testing.T) {
 		t.Fatal("expected non-nil schema")
 	}
 
-	// Update the CRD.
 	crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"] = apiextensionsv1.JSONSchemaProps{Type: "object"}
 	_, err := fakeClient.ApiextensionsV1().CustomResourceDefinitions().Update(
 		context.Background(), crd, metav1.UpdateOptions{},
@@ -264,7 +279,6 @@ func TestResolveSchema_EvictOnUpdate(t *testing.T) {
 		t.Fatalf("failed to update CRD: %v", err)
 	}
 
-	// Wait for eviction + re-index.
 	eventually(t, func() bool {
 		s2, err := r.ResolveSchema(gvk)
 		return err == nil && s2 != s1
@@ -272,7 +286,7 @@ func TestResolveSchema_EvictOnUpdate(t *testing.T) {
 }
 
 func TestResolveSchema_EvictOnDelete(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	crd := newTestCRD("foos.example.com", "Foo", "v1")
 	r, fakeClient := startResolver(t, crd)
 
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
@@ -281,7 +295,6 @@ func TestResolveSchema_EvictOnDelete(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Delete the CRD.
 	err = fakeClient.ApiextensionsV1().CustomResourceDefinitions().Delete(
 		context.Background(), "foos.example.com", metav1.DeleteOptions{},
 	)
@@ -298,7 +311,7 @@ func TestResolveSchema_EvictOnDelete(t *testing.T) {
 func TestResolveSchema_DynamicAdd(t *testing.T) {
 	r, fakeClient := startResolver(t)
 
-	barCRD := newTestCRD("bars.example.com", "example.com", "Bar", "v1")
+	barCRD := newTestCRD("bars.example.com", "Bar", "v1")
 	_, err := fakeClient.ApiextensionsV1().CustomResourceDefinitions().Create(
 		context.Background(), barCRD, metav1.CreateOptions{},
 	)
@@ -313,20 +326,34 @@ func TestResolveSchema_DynamicAdd(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 }
 
-// --- onDelete tombstone handling ---
+func TestOnDelete_InvalidObject(t *testing.T) {
+	r, _ := startResolver(t)
+	tests := []struct {
+		name string
+		obj  any
+	}{
+		{"nil", nil},
+		{"string", "not-a-crd"},
+		{"tombstone with string", cache.DeletedFinalStateUnknown{Obj: "not-a-crd"}},
+		{"tombstone with nil CRD", cache.DeletedFinalStateUnknown{Obj: (*apiextensionsv1.CustomResourceDefinition)(nil)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r.onDelete(tt.obj) // should not panic
+		})
+	}
+}
 
 func TestOnDelete_Tombstone(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	crd := newTestCRD("foos.example.com", "Foo", "v1")
 	r, _ := startResolver(t, crd)
 
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
-	_, _ = r.ResolveSchema(gvk) // populate cache
+	_, _ = r.ResolveSchema(gvk)
 
-	// Simulate tombstone delete.
 	tombstone := cache.DeletedFinalStateUnknown{Key: "foos.example.com", Obj: crd}
 	r.onDelete(tombstone)
 
-	// Cache should be evicted.
 	r.mu.RLock()
 	_, ok := r.schemas[gvk]
 	r.mu.RUnlock()
@@ -335,100 +362,136 @@ func TestOnDelete_Tombstone(t *testing.T) {
 	}
 }
 
-func TestOnDelete_InvalidObject(t *testing.T) {
-	r, _ := startResolver(t)
-	// Should not panic.
-	r.onDelete(nil)
-	r.onDelete("not-a-crd")
-	r.onDelete(cache.DeletedFinalStateUnknown{Obj: "not-a-crd"})
-	r.onDelete(cache.DeletedFinalStateUnknown{Obj: (*apiextensionsv1.CustomResourceDefinition)(nil)})
-}
-
-// --- TTL cached resolver error path ---
-
-type failingResolver struct{}
-
-func (f *failingResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
-	return nil, errors.New("connection refused")
-}
-
-func TestTTLCachedSchemaResolver_DelegateError(t *testing.T) {
-	cached := NewTTLCachedSchemaResolver(&failingResolver{}, 100, time.Hour)
-	_, err := cached.ResolveSchema(testGVK)
-	if err == nil || err.Error() != "connection refused" {
-		t.Fatalf("expected delegate error, got %v", err)
+func TestInjectKubeEnvelope(t *testing.T) {
+	tests := []struct {
+		name          string
+		schema        *spec.Schema
+		namespaced    bool
+		wantNamespace bool
+		wantPreserve  bool
+	}{
+		{
+			name: "namespaced",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type:       []string{"object"},
+				Properties: map[string]spec.Schema{"spec": {}},
+			}},
+			namespaced:    true,
+			wantNamespace: true,
+		},
+		{
+			name: "cluster-scoped",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type:       []string{"object"},
+				Properties: map[string]spec.Schema{"spec": {}},
+			}},
+			namespaced:    false,
+			wantNamespace: false,
+		},
+		{
+			name:          "nil properties",
+			schema:        &spec.Schema{},
+			namespaced:    true,
+			wantNamespace: true,
+		},
+		{
+			name: "overwrites bare metadata stub",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"metadata": {SchemaProps: spec.SchemaProps{Type: []string{"object"}}},
+				},
+			}},
+			namespaced:    true,
+			wantNamespace: true,
+		},
+		{
+			name: "preserves metadata with properties",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"metadata": {SchemaProps: spec.SchemaProps{
+						Type: []string{"custom"},
+						Properties: map[string]spec.Schema{
+							"name": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+						},
+					}},
+				},
+			}},
+			namespaced:   true,
+			wantPreserve: true,
+		},
 	}
-	_, err = cached.ResolveSchema(testGVK)
-	if err == nil {
-		t.Fatal("expected error on second call")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			injectKubeEnvelope(tt.schema, tt.namespaced)
+
+			if _, ok := tt.schema.Properties["metadata"]; !ok {
+				t.Fatal("expected metadata")
+			}
+			if _, ok := tt.schema.Properties["apiVersion"]; !ok {
+				t.Fatal("expected apiVersion")
+			}
+			if _, ok := tt.schema.Properties["kind"]; !ok {
+				t.Fatal("expected kind")
+			}
+
+			if tt.wantPreserve {
+				if got := tt.schema.Properties["metadata"].Type[0]; got != "custom" {
+					t.Fatalf("metadata type: got %s, want custom", got)
+				}
+				return
+			}
+
+			meta := tt.schema.Properties["metadata"]
+			if _, ok := meta.Properties["name"]; !ok {
+				t.Fatal("expected metadata.name")
+			}
+			_, hasNS := meta.Properties["namespace"]
+			if hasNS != tt.wantNamespace {
+				t.Fatalf("metadata.namespace: got %v, want %v", hasNS, tt.wantNamespace)
+			}
+		})
 	}
 }
 
-// --- ChainedResolver ---
-
-func dummySchema(typ string) *spec.Schema {
-	return &spec.Schema{
-		SchemaProps: spec.SchemaProps{Type: []string{typ}},
+func TestInjectKubeEnvelope_EndToEnd(t *testing.T) {
+	tests := []struct {
+		name          string
+		scope         apiextensionsv1.ResourceScope
+		wantNamespace bool
+	}{
+		{"namespaced CRD", apiextensionsv1.NamespaceScoped, true},
+		{"cluster-scoped CRD", apiextensionsv1.ClusterScoped, false},
 	}
-}
 
-type staticResolver struct{ schema *spec.Schema }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crd := newTestCRD("foos.example.com", "Foo", "v1")
+			crd.Spec.Scope = tt.scope
+			r, _ := startResolver(t, crd)
 
-func (r *staticResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
-	return r.schema, nil
-}
-
-type notFoundResolver struct{}
-
-func (r *notFoundResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
-	return nil, openapiresolver.ErrSchemaNotFound
-}
-
-type errorResolver struct{ err error }
-
-func (r *errorResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
-	return nil, r.err
-}
-
-func TestChainedResolver_FirstResolverWins(t *testing.T) {
-	s := dummySchema("first")
-	r := NewChainedResolver(&staticResolver{schema: s}, &staticResolver{schema: dummySchema("second")})
-	got, err := r.ResolveSchema(testGVK)
-	if err != nil || got != s {
-		t.Fatalf("expected first resolver's schema, got err=%v", err)
-	}
-}
-
-func TestChainedResolver_FallsThroughOnNotFound(t *testing.T) {
-	s := dummySchema("second")
-	r := NewChainedResolver(&notFoundResolver{}, &staticResolver{schema: s})
-	got, err := r.ResolveSchema(testGVK)
-	if err != nil || got != s {
-		t.Fatalf("expected fallthrough to second resolver, got err=%v", err)
-	}
-}
-
-func TestChainedResolver_AllNotFound(t *testing.T) {
-	r := NewChainedResolver(&notFoundResolver{}, &notFoundResolver{})
-	_, err := r.ResolveSchema(testGVK)
-	if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
-		t.Fatalf("expected ErrSchemaNotFound, got %v", err)
-	}
-}
-
-func TestChainedResolver_StopsOnRealError(t *testing.T) {
-	realErr := errors.New("connection refused")
-	r := NewChainedResolver(&errorResolver{err: realErr}, &staticResolver{schema: dummySchema("x")})
-	_, err := r.ResolveSchema(testGVK)
-	if !errors.Is(err, realErr) {
-		t.Fatalf("expected real error, got %v", err)
-	}
-}
-
-func TestChainedResolver_EmptyChain(t *testing.T) {
-	r := NewChainedResolver()
-	_, err := r.ResolveSchema(testGVK)
-	if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
-		t.Fatalf("expected ErrSchemaNotFound, got %v", err)
+			gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+			s, err := r.ResolveSchema(gvk)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if _, ok := s.Properties["metadata"]; !ok {
+				t.Fatal("expected metadata")
+			}
+			if _, ok := s.Properties["apiVersion"]; !ok {
+				t.Fatal("expected apiVersion")
+			}
+			if _, ok := s.Properties["kind"]; !ok {
+				t.Fatal("expected kind")
+			}
+			meta := s.Properties["metadata"]
+			if _, ok := meta.Properties["name"]; !ok {
+				t.Fatal("expected metadata.name")
+			}
+			_, hasNS := meta.Properties["namespace"]
+			if hasNS != tt.wantNamespace {
+				t.Fatalf("metadata.namespace: got %v, want %v", hasNS, tt.wantNamespace)
+			}
+		})
 	}
 }

--- a/pkg/graph/schema/resolver/crd_resolver_test.go
+++ b/pkg/graph/schema/resolver/crd_resolver_test.go
@@ -1,0 +1,434 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+var testGVK = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+
+func newTestCRD(name, group, kind string, versions ...string) *apiextensionsv1.CustomResourceDefinition {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: kind},
+		},
+	}
+	for _, v := range versions {
+		crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+			Name:   v,
+			Served: true,
+			Schema: &apiextensionsv1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"spec": {Type: "object"},
+					},
+				},
+			},
+		})
+	}
+	return crd
+}
+
+// startResolver creates a CRDSchemaResolver with a running informer.
+func startResolver(t *testing.T, crds ...*apiextensionsv1.CustomResourceDefinition) (*CRDSchemaResolver, *fake.Clientset) {
+	t.Helper()
+	objs := make([]k8sruntime.Object, len(crds))
+	for i := range crds {
+		objs[i] = crds[i]
+	}
+	fakeClient := fake.NewSimpleClientset(objs...)
+	factory := apiextensionsinformers.NewSharedInformerFactory(fakeClient, 0)
+	r := NewCRDSchemaResolver(factory.Apiextensions().V1().CustomResourceDefinitions())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+
+	return r, fakeClient
+}
+
+// eventually polls condition until it returns true or timeout.
+func eventually(t *testing.T, condition func() bool, timeout, interval time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(interval)
+	}
+	t.Fatal("condition not met within timeout")
+}
+
+// --- extractVersionSchema ---
+
+func TestExtractVersionSchema(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1", "v2")
+
+	s, err := extractVersionSchema(crd, "v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil schema for v1")
+	}
+
+	s, err = extractVersionSchema(crd, "v2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil schema for v2")
+	}
+}
+
+func TestExtractVersionSchema_VersionNotFound(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	s, err := extractVersionSchema(crd, "v999")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s != nil {
+		t.Fatal("expected nil schema for nonexistent version")
+	}
+}
+
+func TestExtractVersionSchema_NilSchema(t *testing.T) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1", Schema: nil},
+			},
+		},
+	}
+	s, err := extractVersionSchema(crd, "v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s != nil {
+		t.Fatal("expected nil schema when Schema is nil")
+	}
+}
+
+// --- convertCRDSchema ---
+
+func TestConvertCRDSchema(t *testing.T) {
+	jsonSchema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"name": {Type: "string"},
+			"age":  {Type: "integer"},
+		},
+	}
+	s, err := convertCRDSchema(jsonSchema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s == nil || len(s.Properties) != 2 {
+		t.Fatalf("expected 2 properties, got %v", s)
+	}
+}
+
+// --- gvkIndexKeys ---
+
+func TestGvkIndexKeys(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1", "v2beta1")
+	keys := gvkIndexKeys(crd)
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	if keys[0] != "example.com/v1/Foo" {
+		t.Errorf("unexpected key: %s", keys[0])
+	}
+	if keys[1] != "example.com/v2beta1/Foo" {
+		t.Errorf("unexpected key: %s", keys[1])
+	}
+}
+
+func TestGvkIndexKeys_FiltersUnserved(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	// Add an unserved version.
+	crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+		Name:   "v2",
+		Served: false,
+	})
+	keys := gvkIndexKeys(crd)
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key (unserved filtered), got %d", len(keys))
+	}
+}
+
+// --- ResolveSchema ---
+
+func TestResolveSchema(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	r, _ := startResolver(t, crd)
+
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+	s, err := r.ResolveSchema(gvk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil schema")
+	}
+}
+
+func TestResolveSchema_CacheHit(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	r, _ := startResolver(t, crd)
+
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+	s1, _ := r.ResolveSchema(gvk)
+	s2, _ := r.ResolveSchema(gvk)
+	if s1 != s2 {
+		t.Fatal("expected same pointer on cache hit")
+	}
+}
+
+func TestResolveSchema_NotFound(t *testing.T) {
+	r, _ := startResolver(t)
+
+	gvk := schema.GroupVersionKind{Group: "unknown.com", Version: "v1", Kind: "Unknown"}
+	_, err := r.ResolveSchema(gvk)
+	if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
+		t.Fatalf("expected ErrSchemaNotFound, got %v", err)
+	}
+}
+
+func TestResolveSchema_MultipleVersions(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1", "v2", "v1beta1")
+	r, _ := startResolver(t, crd)
+
+	for _, version := range []string{"v1", "v2", "v1beta1"} {
+		gvk := schema.GroupVersionKind{Group: "example.com", Version: version, Kind: "Foo"}
+		s, err := r.ResolveSchema(gvk)
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", version, err)
+		}
+		if s == nil {
+			t.Fatalf("expected non-nil schema for %s", version)
+		}
+	}
+}
+
+// --- Event-driven eviction ---
+
+func TestResolveSchema_EvictOnUpdate(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	r, fakeClient := startResolver(t, crd)
+
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+	s1, _ := r.ResolveSchema(gvk)
+	if s1 == nil {
+		t.Fatal("expected non-nil schema")
+	}
+
+	// Update the CRD.
+	crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"] = apiextensionsv1.JSONSchemaProps{Type: "object"}
+	_, err := fakeClient.ApiextensionsV1().CustomResourceDefinitions().Update(
+		context.Background(), crd, metav1.UpdateOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to update CRD: %v", err)
+	}
+
+	// Wait for eviction + re-index.
+	eventually(t, func() bool {
+		s2, err := r.ResolveSchema(gvk)
+		return err == nil && s2 != s1
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestResolveSchema_EvictOnDelete(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	r, fakeClient := startResolver(t, crd)
+
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+	_, err := r.ResolveSchema(gvk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Delete the CRD.
+	err = fakeClient.ApiextensionsV1().CustomResourceDefinitions().Delete(
+		context.Background(), "foos.example.com", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to delete CRD: %v", err)
+	}
+
+	eventually(t, func() bool {
+		_, err := r.ResolveSchema(gvk)
+		return errors.Is(err, openapiresolver.ErrSchemaNotFound)
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestResolveSchema_DynamicAdd(t *testing.T) {
+	r, fakeClient := startResolver(t)
+
+	barCRD := newTestCRD("bars.example.com", "example.com", "Bar", "v1")
+	_, err := fakeClient.ApiextensionsV1().CustomResourceDefinitions().Create(
+		context.Background(), barCRD, metav1.CreateOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to create CRD: %v", err)
+	}
+
+	barGVK := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bar"}
+	eventually(t, func() bool {
+		s, err := r.ResolveSchema(barGVK)
+		return err == nil && s != nil
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+// --- onDelete tombstone handling ---
+
+func TestOnDelete_Tombstone(t *testing.T) {
+	crd := newTestCRD("foos.example.com", "example.com", "Foo", "v1")
+	r, _ := startResolver(t, crd)
+
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+	_, _ = r.ResolveSchema(gvk) // populate cache
+
+	// Simulate tombstone delete.
+	tombstone := cache.DeletedFinalStateUnknown{Key: "foos.example.com", Obj: crd}
+	r.onDelete(tombstone)
+
+	// Cache should be evicted.
+	r.mu.RLock()
+	_, ok := r.schemas[gvk]
+	r.mu.RUnlock()
+	if ok {
+		t.Fatal("expected cache eviction after tombstone delete")
+	}
+}
+
+func TestOnDelete_InvalidObject(t *testing.T) {
+	r, _ := startResolver(t)
+	// Should not panic.
+	r.onDelete(nil)
+	r.onDelete("not-a-crd")
+	r.onDelete(cache.DeletedFinalStateUnknown{Obj: "not-a-crd"})
+	r.onDelete(cache.DeletedFinalStateUnknown{Obj: (*apiextensionsv1.CustomResourceDefinition)(nil)})
+}
+
+// --- TTL cached resolver error path ---
+
+type failingResolver struct{}
+
+func (f *failingResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return nil, errors.New("connection refused")
+}
+
+func TestTTLCachedSchemaResolver_DelegateError(t *testing.T) {
+	cached := NewTTLCachedSchemaResolver(&failingResolver{}, 100, time.Hour)
+	_, err := cached.ResolveSchema(testGVK)
+	if err == nil || err.Error() != "connection refused" {
+		t.Fatalf("expected delegate error, got %v", err)
+	}
+	_, err = cached.ResolveSchema(testGVK)
+	if err == nil {
+		t.Fatal("expected error on second call")
+	}
+}
+
+// --- ChainedResolver ---
+
+func dummySchema(typ string) *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{Type: []string{typ}},
+	}
+}
+
+type staticResolver struct{ schema *spec.Schema }
+
+func (r *staticResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return r.schema, nil
+}
+
+type notFoundResolver struct{}
+
+func (r *notFoundResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return nil, openapiresolver.ErrSchemaNotFound
+}
+
+type errorResolver struct{ err error }
+
+func (r *errorResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return nil, r.err
+}
+
+func TestChainedResolver_FirstResolverWins(t *testing.T) {
+	s := dummySchema("first")
+	r := NewChainedResolver(&staticResolver{schema: s}, &staticResolver{schema: dummySchema("second")})
+	got, err := r.ResolveSchema(testGVK)
+	if err != nil || got != s {
+		t.Fatalf("expected first resolver's schema, got err=%v", err)
+	}
+}
+
+func TestChainedResolver_FallsThroughOnNotFound(t *testing.T) {
+	s := dummySchema("second")
+	r := NewChainedResolver(&notFoundResolver{}, &staticResolver{schema: s})
+	got, err := r.ResolveSchema(testGVK)
+	if err != nil || got != s {
+		t.Fatalf("expected fallthrough to second resolver, got err=%v", err)
+	}
+}
+
+func TestChainedResolver_AllNotFound(t *testing.T) {
+	r := NewChainedResolver(&notFoundResolver{}, &notFoundResolver{})
+	_, err := r.ResolveSchema(testGVK)
+	if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
+		t.Fatalf("expected ErrSchemaNotFound, got %v", err)
+	}
+}
+
+func TestChainedResolver_StopsOnRealError(t *testing.T) {
+	realErr := errors.New("connection refused")
+	r := NewChainedResolver(&errorResolver{err: realErr}, &staticResolver{schema: dummySchema("x")})
+	_, err := r.ResolveSchema(testGVK)
+	if !errors.Is(err, realErr) {
+		t.Fatalf("expected real error, got %v", err)
+	}
+}
+
+func TestChainedResolver_EmptyChain(t *testing.T) {
+	r := NewChainedResolver()
+	_, err := r.ResolveSchema(testGVK)
+	if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
+		t.Fatalf("expected ErrSchemaNotFound, got %v", err)
+	}
+}

--- a/pkg/graph/schema/resolver/crd_resolver_test.go
+++ b/pkg/graph/schema/resolver/crd_resolver_test.go
@@ -17,19 +17,130 @@ package resolver
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
-	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// testCache is a minimal cache.Cache implementation for unit testing the
+// CRDSchemaResolver. It supports List with MatchingFields and Get.
+type testCache struct {
+	cache.Cache
+	mu        sync.RWMutex
+	objects   []*apiextensionsv1.CustomResourceDefinition
+	indexFn   client.IndexerFunc
+	indexName string
+}
+
+func newTestCache(crds ...*apiextensionsv1.CustomResourceDefinition) *testCache {
+	return &testCache{
+		objects: crds,
+	}
+}
+
+func (c *testCache) IndexField(_ context.Context, _ client.Object, field string, extractValue client.IndexerFunc) error {
+	c.indexName = field
+	c.indexFn = extractValue
+	return nil
+}
+
+func (c *testCache) GetInformer(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+	// Not used by Reconcile-based eviction, but needed to satisfy the interface
+	// if NewCRDSchemaResolver ever calls it during setup in tests.
+	return nil, nil
+}
+
+func (c *testCache) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, crd := range c.objects {
+		if crd.Name == key.Name {
+			*obj.(*apiextensionsv1.CustomResourceDefinition) = *crd
+			return nil
+		}
+	}
+	return apierrors.NewNotFound(schema.GroupResource{
+		Group:    "apiextensions.k8s.io",
+		Resource: "customresourcedefinitions",
+	}, key.Name)
+}
+
+func (c *testCache) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	crdList, ok := list.(*apiextensionsv1.CustomResourceDefinitionList)
+	if !ok {
+		return errors.New("unsupported list type")
+	}
+
+	listOpts := &client.ListOptions{}
+	for _, o := range opts {
+		o.ApplyToList(listOpts)
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// If there's a MatchingFields selector, filter using the index function.
+	if listOpts.FieldSelector != nil {
+		reqs := listOpts.FieldSelector.Requirements()
+		for _, req := range reqs {
+			if req.Field == c.indexName {
+				wantValue := req.Value
+				for _, crd := range c.objects {
+					keys := c.indexFn(crd)
+					for _, key := range keys {
+						if key == wantValue {
+							crdList.Items = append(crdList.Items, *crd)
+						}
+					}
+				}
+				return nil
+			}
+		}
+	}
+
+	// No filter — return all.
+	for _, crd := range c.objects {
+		crdList.Items = append(crdList.Items, *crd)
+	}
+	return nil
+}
+
+func (c *testCache) addCRD(crd *apiextensionsv1.CustomResourceDefinition) {
+	c.mu.Lock()
+	c.objects = append(c.objects, crd)
+	c.mu.Unlock()
+}
+
+func (c *testCache) updateCRD(name string, crd *apiextensionsv1.CustomResourceDefinition) {
+	c.mu.Lock()
+	for i, existing := range c.objects {
+		if existing.Name == name {
+			c.objects[i] = crd
+			break
+		}
+	}
+	c.mu.Unlock()
+}
+
+func (c *testCache) removeCRD(name string) {
+	c.mu.Lock()
+	for i, existing := range c.objects {
+		if existing.Name == name {
+			c.objects = append(c.objects[:i], c.objects[i+1:]...)
+			break
+		}
+	}
+	c.mu.Unlock()
+}
 
 func newTestCRD(name, kind string, versions ...string) *apiextensionsv1.CustomResourceDefinition {
 	crd := &apiextensionsv1.CustomResourceDefinition{
@@ -56,38 +167,22 @@ func newTestCRD(name, kind string, versions ...string) *apiextensionsv1.CustomRe
 	return crd
 }
 
-func startResolver(t *testing.T, crds ...*apiextensionsv1.CustomResourceDefinition) (*CRDSchemaResolver, *fake.Clientset) {
+func startResolver(t *testing.T, crds ...*apiextensionsv1.CustomResourceDefinition) (*CRDSchemaResolver, *testCache) {
 	t.Helper()
-	objs := make([]k8sruntime.Object, len(crds))
-	for i := range crds {
-		objs[i] = crds[i]
-	}
-	fakeClient := fake.NewSimpleClientset(objs...)
-	factory := apiextensionsinformers.NewSharedInformerFactory(fakeClient, 0)
-	r, err := NewCRDSchemaResolver(factory.Apiextensions().V1().CustomResourceDefinitions())
-	if err != nil {
-		t.Fatalf("NewCRDSchemaResolver: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	factory.Start(ctx.Done())
-	factory.WaitForCacheSync(ctx.Done())
-
-	return r, fakeClient
+	tc := newTestCache(crds...)
+	r := NewCRDSchemaResolver(tc)
+	return r, tc
 }
 
-func eventually(t *testing.T, condition func() bool, timeout, interval time.Duration) {
+// reconcileCRD is a test helper that triggers a Reconcile for the given CRD name.
+func reconcileCRD(t *testing.T, r *CRDSchemaResolver, name string) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if condition() {
-			return
-		}
-		time.Sleep(interval)
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile(%s): %v", name, err)
 	}
-	t.Fatal("condition not met within timeout")
 }
 
 func TestExtractVersionSchema(t *testing.T) {
@@ -200,7 +295,6 @@ func TestResolveSchema(t *testing.T) {
 		crds    []*apiextensionsv1.CustomResourceDefinition
 		gvk     schema.GroupVersionKind
 		wantErr bool
-		wantNil bool
 	}{
 		{
 			name: "resolves existing CRD",
@@ -261,9 +355,9 @@ func TestResolveSchema_MultipleVersions(t *testing.T) {
 	}
 }
 
-func TestResolveSchema_EvictOnUpdate(t *testing.T) {
+func TestReconcile_EvictOnUpdate(t *testing.T) {
 	crd := newTestCRD("foos.example.com", "Foo", "v1")
-	r, fakeClient := startResolver(t, crd)
+	r, tc := startResolver(t, crd)
 
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
 	s1, _ := r.ResolveSchema(gvk)
@@ -271,23 +365,25 @@ func TestResolveSchema_EvictOnUpdate(t *testing.T) {
 		t.Fatal("expected non-nil schema")
 	}
 
-	crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"] = apiextensionsv1.JSONSchemaProps{Type: "object"}
-	_, err := fakeClient.ApiextensionsV1().CustomResourceDefinitions().Update(
-		context.Background(), crd, metav1.UpdateOptions{},
-	)
-	if err != nil {
-		t.Fatalf("failed to update CRD: %v", err)
-	}
+	// Update the CRD in the fake cache and reconcile.
+	updatedCRD := crd.DeepCopy()
+	updatedCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"] = apiextensionsv1.JSONSchemaProps{Type: "object"}
+	tc.updateCRD("foos.example.com", updatedCRD)
+	reconcileCRD(t, r, "foos.example.com")
 
-	eventually(t, func() bool {
-		s2, err := r.ResolveSchema(gvk)
-		return err == nil && s2 != s1
-	}, 5*time.Second, 50*time.Millisecond)
+	// After eviction, the next resolve should return a different schema pointer.
+	s2, err := r.ResolveSchema(gvk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s2 == s1 {
+		t.Fatal("expected different schema pointer after eviction")
+	}
 }
 
-func TestResolveSchema_EvictOnDelete(t *testing.T) {
+func TestReconcile_EvictOnDelete(t *testing.T) {
 	crd := newTestCRD("foos.example.com", "Foo", "v1")
-	r, fakeClient := startResolver(t, crd)
+	r, tc := startResolver(t, crd)
 
 	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
 	_, err := r.ResolveSchema(gvk)
@@ -295,70 +391,35 @@ func TestResolveSchema_EvictOnDelete(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	err = fakeClient.ApiextensionsV1().CustomResourceDefinitions().Delete(
-		context.Background(), "foos.example.com", metav1.DeleteOptions{},
-	)
-	if err != nil {
-		t.Fatalf("failed to delete CRD: %v", err)
-	}
+	// Remove CRD from cache and reconcile (simulates delete).
+	tc.removeCRD("foos.example.com")
+	reconcileCRD(t, r, "foos.example.com")
 
-	eventually(t, func() bool {
-		_, err := r.ResolveSchema(gvk)
-		return errors.Is(err, openapiresolver.ErrSchemaNotFound)
-	}, 5*time.Second, 50*time.Millisecond)
+	_, err = r.ResolveSchema(gvk)
+	if !errors.Is(err, openapiresolver.ErrSchemaNotFound) {
+		t.Fatalf("expected ErrSchemaNotFound after delete, got %v", err)
+	}
+}
+
+func TestReconcile_DeleteUnknownCRD(t *testing.T) {
+	// Reconciling a CRD name that was never resolved should be a no-op.
+	r, _ := startResolver(t)
+	reconcileCRD(t, r, "unknown.example.com")
 }
 
 func TestResolveSchema_DynamicAdd(t *testing.T) {
-	r, fakeClient := startResolver(t)
+	r, tc := startResolver(t)
 
 	barCRD := newTestCRD("bars.example.com", "Bar", "v1")
-	_, err := fakeClient.ApiextensionsV1().CustomResourceDefinitions().Create(
-		context.Background(), barCRD, metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Fatalf("failed to create CRD: %v", err)
-	}
+	tc.addCRD(barCRD)
 
 	barGVK := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bar"}
-	eventually(t, func() bool {
-		s, err := r.ResolveSchema(barGVK)
-		return err == nil && s != nil
-	}, 5*time.Second, 50*time.Millisecond)
-}
-
-func TestOnDelete_InvalidObject(t *testing.T) {
-	r, _ := startResolver(t)
-	tests := []struct {
-		name string
-		obj  any
-	}{
-		{"nil", nil},
-		{"string", "not-a-crd"},
-		{"tombstone with string", cache.DeletedFinalStateUnknown{Obj: "not-a-crd"}},
-		{"tombstone with nil CRD", cache.DeletedFinalStateUnknown{Obj: (*apiextensionsv1.CustomResourceDefinition)(nil)}},
+	s, err := r.ResolveSchema(barGVK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r.onDelete(tt.obj) // should not panic
-		})
-	}
-}
-
-func TestOnDelete_Tombstone(t *testing.T) {
-	crd := newTestCRD("foos.example.com", "Foo", "v1")
-	r, _ := startResolver(t, crd)
-
-	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
-	_, _ = r.ResolveSchema(gvk)
-
-	tombstone := cache.DeletedFinalStateUnknown{Key: "foos.example.com", Obj: crd}
-	r.onDelete(tombstone)
-
-	r.mu.RLock()
-	_, ok := r.schemas[gvk]
-	r.mu.RUnlock()
-	if ok {
-		t.Fatal("expected cache eviction after tombstone delete")
+	if s == nil {
+		t.Fatal("expected non-nil schema")
 	}
 }
 

--- a/pkg/graph/schema/resolver/doc.go
+++ b/pkg/graph/schema/resolver/doc.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resolver provides OpenAPI schema resolution for kro's graph builder.
+//
+// The package provides three resolver implementations and a ChainedResolver to
+// compose them. The recommended resolution order is:
+//
+//   - Core (DefaultCoreResolver): compiled-in OpenAPI definitions for built-in
+//     Kubernetes types. Always available, zero cost.
+//
+//   - CRD (DefaultCRDResolver): event-driven informer for CRD schemas. Lazy
+//     extraction — only CRDs that kro references pay the parsing cost. The
+//     caller must register it with the controller manager (mgr.Add).
+//
+//   - Fallback (DefaultFallbackResolver): TTL-cached discovery client for
+//     everything else — aggregated API types (metrics-server, custom API
+//     servers) and a warm-up fallback while the CRD informer cache is cold.
+//
+// The CRD informer starts asynchronously via the controller manager. On the
+// first ResolveSchema call the informer cache may not yet be synced; misses
+// fall through to the fallback resolver by design.
+package resolver

--- a/pkg/graph/schema/resolver/metrics.go
+++ b/pkg/graph/schema/resolver/metrics.go
@@ -20,6 +20,7 @@ import (
 )
 
 var (
+	// TTL-cached (fallback) resolver metrics.
 	cacheHitsTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "schema_resolver_cache_hits_total",
 		Help: "Total number of schema resolver cache hits",
@@ -54,11 +55,43 @@ var (
 		Name: "schema_resolver_errors_total",
 		Help: "Total number of schema resolution errors",
 	})
+
+	// CRD informer-backed resolver metrics.
+	crdCacheHitsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "schema_resolver_crd_cache_hits_total",
+		Help: "Total number of CRD schema resolver cache hits",
+	})
+	crdCacheMissesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "schema_resolver_crd_cache_misses_total",
+		Help: "Total number of CRD schema resolver cache misses",
+	})
+	crdCacheSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "schema_resolver_crd_cache_size",
+		Help: "Current number of entries in the CRD schema resolver cache",
+	})
+	crdCacheEvictionsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "schema_resolver_crd_cache_evictions_total",
+		Help: "Total number of entries evicted from the CRD schema resolver cache",
+	})
+	crdExtractionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "schema_resolver_crd_extraction_duration_seconds",
+		Help:    "Duration of CRD schema extraction from informer cache",
+		Buckets: prometheus.ExponentialBuckets(0.0001, 2, 12), // 0.1ms to ~0.4s
+	})
+	crdExtractionErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "schema_resolver_crd_extraction_errors_total",
+		Help: "Total number of CRD schema extraction errors",
+	})
+	crdSingleflightDeduplicatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "schema_resolver_crd_singleflight_deduplicated_total",
+		Help: "Total number of CRD resolver requests deduplicated by singleflight",
+	})
 )
 
 // MustRegister registers the metrics with the given Prometheus registry
 func MustRegister(registry prometheus.Registerer) {
 	registry.MustRegister(
+		// TTL-cached (fallback) resolver.
 		cacheHitsTotal,
 		cacheMissesTotal,
 		cacheSize,
@@ -66,6 +99,14 @@ func MustRegister(registry prometheus.Registerer) {
 		apiCallDuration,
 		singleflightDeduplicatedTotal,
 		schemaResolutionErrorsTotal,
+		// CRD informer-backed resolver.
+		crdCacheHitsTotal,
+		crdCacheMissesTotal,
+		crdCacheSize,
+		crdCacheEvictionsTotal,
+		crdExtractionDuration,
+		crdExtractionErrorsTotal,
+		crdSingleflightDeduplicatedTotal,
 	)
 }
 

--- a/pkg/graph/schema/resolver/resolver.go
+++ b/pkg/graph/schema/resolver/resolver.go
@@ -15,45 +15,74 @@
 package resolver
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
-	"k8s.io/apiextensions-apiserver/pkg/generated/openapi"
-	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	generatedopenapi "k8s.io/apiextensions-apiserver/pkg/generated/openapi"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
-// NewCombinedResolver creates a new schema resolver that can resolve both core and client types.
-func NewCombinedResolver(clientConfig *rest.Config, httpClient *http.Client) (resolver.SchemaResolver, error) {
-	// Create a regular discovery client first
+// ChainedResolver tries a sequence of SchemaResolvers in order, falling
+// through on ErrSchemaNotFound.
+type ChainedResolver struct {
+	resolvers []openapiresolver.SchemaResolver
+}
+
+// NewChainedResolver creates a ChainedResolver that tries the given resolvers
+// in order. The caller decides the resolution order.
+func NewChainedResolver(resolvers ...openapiresolver.SchemaResolver) *ChainedResolver {
+	return &ChainedResolver{resolvers: resolvers}
+}
+
+// ResolveSchema tries each resolver in order, falling back only on ErrSchemaNotFound.
+func (r *ChainedResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	for _, res := range r.resolvers {
+		s, err := res.ResolveSchema(gvk)
+		if err == nil {
+			return s, nil
+		}
+		if errors.Is(err, openapiresolver.ErrSchemaNotFound) {
+			continue
+		}
+		return nil, err
+	}
+	return nil, openapiresolver.ErrSchemaNotFound
+}
+
+// DefaultCoreResolver creates a resolver for built-in Kubernetes types (Pods,
+// Services, Deployments, etc.) using compiled-in OpenAPI definitions.
+func DefaultCoreResolver() openapiresolver.SchemaResolver {
+	return openapiresolver.NewDefinitionsSchemaResolver(
+		generatedopenapi.GetOpenAPIDefinitions,
+		scheme.Scheme,
+	)
+}
+
+const (
+	// DefaultFallbackMaxSize is the default LRU cache size for the fallback resolver.
+	DefaultFallbackMaxSize = 500
+	// DefaultFallbackTTL is the default TTL for cached schemas in the fallback resolver.
+	DefaultFallbackTTL = 5 * time.Minute
+)
+
+// DefaultFallbackResolver creates a TTL-cached discovery resolver that serves
+// as a fallback for schemas not resolved by the core or CRD resolvers. This
+// covers aggregated API types (e.g. metrics-server, custom API servers) and
+// also acts as a warm-up fallback while the CRD informer cache is cold.
+func DefaultFallbackResolver(clientConfig *rest.Config, httpClient *http.Client) (*TTLCachedSchemaResolver, error) {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(clientConfig, httpClient)
 	if err != nil {
 		return nil, err
 	}
-
-	// ClientResolver is a resolver that uses the discovery client to resolve
-	// client types. It is used to resolve types that are not known at compile
-	// time a.k.a present in:
-	// https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/generated/openapi/zz_generated.openapi.go
-	clientResolver := &resolver.ClientDiscoveryResolver{
-		Discovery: discoveryClient,
-	}
-
-	cachedResolver := NewTTLCachedSchemaResolver(
-		clientResolver,
-		500,           // maxSize: enough for 200 CRDs × 2-3 versions
-		5*time.Minute, // TTL: balance between freshness and performance
-	)
-
-	// CoreResolver is a resolver that uses the OpenAPI definitions to resolve
-	// core types. It is used to resolve types that are known at compile time.
-	coreResolver := resolver.NewDefinitionsSchemaResolver(
-		openapi.GetOpenAPIDefinitions,
-		scheme.Scheme,
-	)
-
-	combinedResolver := coreResolver.Combine(cachedResolver)
-	return combinedResolver, nil
+	return NewTTLCachedSchemaResolver(
+		&openapiresolver.ClientDiscoveryResolver{Discovery: discoveryClient},
+		DefaultFallbackMaxSize,
+		DefaultFallbackTTL,
+	), nil
 }

--- a/pkg/graph/schema/resolver/resolver_test.go
+++ b/pkg/graph/schema/resolver/resolver_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+var testGVK = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+
+func dummySchema(typ string) *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{Type: []string{typ}},
+	}
+}
+
+type staticResolver struct{ schema *spec.Schema }
+
+func (r *staticResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return r.schema, nil
+}
+
+type notFoundResolver struct{}
+
+func (r *notFoundResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return nil, openapiresolver.ErrSchemaNotFound
+}
+
+type errorResolver struct{ err error }
+
+func (r *errorResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return nil, r.err
+}
+
+func TestChainedResolver(t *testing.T) {
+	first := dummySchema("first")
+	second := dummySchema("second")
+	realErr := errors.New("connection refused")
+
+	tests := []struct {
+		name      string
+		resolvers []openapiresolver.SchemaResolver
+		want      *spec.Schema
+		wantErr   error
+	}{
+		{
+			name:      "first resolver wins",
+			resolvers: []openapiresolver.SchemaResolver{&staticResolver{schema: first}, &staticResolver{schema: second}},
+			want:      first,
+		},
+		{
+			name:      "falls through on not found",
+			resolvers: []openapiresolver.SchemaResolver{&notFoundResolver{}, &staticResolver{schema: second}},
+			want:      second,
+		},
+		{
+			name:      "all not found",
+			resolvers: []openapiresolver.SchemaResolver{&notFoundResolver{}, &notFoundResolver{}},
+			wantErr:   openapiresolver.ErrSchemaNotFound,
+		},
+		{
+			name:      "stops on real error",
+			resolvers: []openapiresolver.SchemaResolver{&errorResolver{err: realErr}, &staticResolver{schema: second}},
+			wantErr:   realErr,
+		},
+		{
+			name:      "empty chain",
+			resolvers: nil,
+			wantErr:   openapiresolver.ErrSchemaNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewChainedResolver(tt.resolvers...)
+			got, err := r.ResolveSchema(testGVK)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err: got %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatal("unexpected schema pointer")
+			}
+		})
+	}
+}

--- a/pkg/graph/schema/resolver/ttl_cached_test.go
+++ b/pkg/graph/schema/resolver/ttl_cached_test.go
@@ -15,6 +15,7 @@
 package resolver
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -169,6 +170,25 @@ func TestTTLCachedSchemaResolver_LRUEviction(t *testing.T) {
 
 	if calls := mock.getCallCount(); calls != 0 {
 		t.Errorf("expected 0 calls for cache hit, got %d", calls)
+	}
+}
+
+type failingResolver struct{}
+
+func (f *failingResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	return nil, errors.New("connection refused")
+}
+
+func TestTTLCachedSchemaResolver_DelegateError(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+	cached := NewTTLCachedSchemaResolver(&failingResolver{}, 100, time.Hour)
+	_, err := cached.ResolveSchema(gvk)
+	if err == nil || err.Error() != "connection refused" {
+		t.Fatalf("expected delegate error, got %v", err)
+	}
+	_, err = cached.ResolveSchema(gvk)
+	if err == nil {
+		t.Fatal("expected error on second call")
 	}
 }
 

--- a/pkg/graph/schema/schema.go
+++ b/pkg/graph/schema/schema.go
@@ -23,6 +23,11 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
+// StringSchema is a simple string type schema.
+var StringSchema = spec.Schema{
+	SchemaProps: spec.SchemaProps{Type: []string{"string"}},
+}
+
 // ObjectMeta holds the k8s ObjectMeta schema, populated once at startup.
 var ObjectMetaSchema spec.Schema
 

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -31,10 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
 	ctrlinstance "github.com/kubernetes-sigs/kro/pkg/controller/instance"
@@ -157,31 +153,14 @@ func (e *Environment) setupController() error {
 
 	restConfig := e.ClientSet.RESTConfig()
 
-	// Shared CRD informer for schema resolution and RGD controller.
-	apiextensionsClientset, err := apiextensionsclient.NewForConfigAndClient(restConfig, e.ClientSet.HTTPClient())
-	if err != nil {
-		return fmt.Errorf("creating apiextensions clientset: %w", err)
-	}
-	crdInformerFactory := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClientset, 0)
-	crdInformer := crdInformerFactory.Apiextensions().V1().CustomResourceDefinitions()
-
-	// Schema resolution: core -> CRD informer -> fallback discovery.
-	crdResolver, err := schemaresolver.NewCRDSchemaResolver(crdInformer)
-	if err != nil {
-		return fmt.Errorf("creating CRD schema resolver: %w", err)
+	// Schema resolution: core -> CRD informer (via manager cache) -> fallback discovery.
+	crdResolver := schemaresolver.NewCRDSchemaResolver(e.CtrlManager.GetCache())
+	if err := crdResolver.SetupWithManager(e.CtrlManager); err != nil {
+		return fmt.Errorf("setting up CRD schema resolver: %w", err)
 	}
 	fallbackResolver, err := schemaresolver.DefaultFallbackResolver(restConfig, e.ClientSet.HTTPClient())
 	if err != nil {
 		return fmt.Errorf("creating fallback resolver: %w", err)
-	}
-	if err := e.CtrlManager.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		crdInformerFactory.Start(ctx.Done())
-		crdInformerFactory.WaitForCacheSync(ctx.Done())
-		<-ctx.Done()
-		crdInformerFactory.Shutdown()
-		return nil
-	})); err != nil {
-		return fmt.Errorf("registering CRD informer factory: %w", err)
 	}
 
 	e.GraphBuilder = graph.NewBuilder(
@@ -208,7 +187,6 @@ func (e *Environment) setupController() error {
 		dc,
 		e.GraphBuilder,
 		e.ControllerConfig.ReconcileConfig.DefaultRequeueDuration,
-		crdInformer.Informer(),
 		40,
 		graph.RGDConfig{
 			MaxCollectionSize:          1000,

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -31,12 +31,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
 	ctrlinstance "github.com/kubernetes-sigs/kro/pkg/controller/instance"
 	ctrlresourcegraphdefinition "github.com/kubernetes-sigs/kro/pkg/controller/resourcegraphdefinition"
 	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
+	schemaresolver "github.com/kubernetes-sigs/kro/pkg/graph/schema/resolver"
 )
 
 type Environment struct {
@@ -132,12 +137,6 @@ func (e *Environment) initializeClients() error {
 
 	e.CRDManager = e.ClientSet.CRD(kroclient.CRDWrapperConfig{})
 
-	restConfig := e.ClientSet.RESTConfig()
-	e.GraphBuilder, err = graph.NewBuilder(restConfig, e.ClientSet.HTTPClient())
-	if err != nil {
-		return fmt.Errorf("creating graph builder: %w", err)
-	}
-
 	return nil
 }
 
@@ -155,6 +154,40 @@ func (e *Environment) setupController() error {
 		return fmt.Errorf("creating manager: %w", err)
 	}
 	e.ClientSet.SetRESTMapper(e.CtrlManager.GetRESTMapper())
+
+	restConfig := e.ClientSet.RESTConfig()
+
+	// Shared CRD informer for schema resolution and RGD controller.
+	apiextensionsClientset, err := apiextensionsclient.NewForConfigAndClient(restConfig, e.ClientSet.HTTPClient())
+	if err != nil {
+		return fmt.Errorf("creating apiextensions clientset: %w", err)
+	}
+	crdInformerFactory := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClientset, 0)
+	crdInformer := crdInformerFactory.Apiextensions().V1().CustomResourceDefinitions()
+
+	// Schema resolution: core -> CRD informer -> fallback discovery.
+	crdResolver, err := schemaresolver.NewCRDSchemaResolver(crdInformer)
+	if err != nil {
+		return fmt.Errorf("creating CRD schema resolver: %w", err)
+	}
+	fallbackResolver, err := schemaresolver.DefaultFallbackResolver(restConfig, e.ClientSet.HTTPClient())
+	if err != nil {
+		return fmt.Errorf("creating fallback resolver: %w", err)
+	}
+	if err := e.CtrlManager.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		crdInformerFactory.Start(ctx.Done())
+		crdInformerFactory.WaitForCacheSync(ctx.Done())
+		<-ctx.Done()
+		crdInformerFactory.Shutdown()
+		return nil
+	})); err != nil {
+		return fmt.Errorf("registering CRD informer factory: %w", err)
+	}
+
+	e.GraphBuilder = graph.NewBuilder(
+		schemaresolver.NewChainedResolver(schemaresolver.DefaultCoreResolver(), crdResolver, fallbackResolver),
+		e.CtrlManager.GetRESTMapper(),
+	)
 
 	dc := dynamiccontroller.NewDynamicController(
 		zap.New(zap.WriteTo(e.ControllerConfig.LogWriter), zap.UseDevMode(true)),
@@ -175,6 +208,7 @@ func (e *Environment) setupController() error {
 		dc,
 		e.GraphBuilder,
 		e.ControllerConfig.ReconcileConfig.DefaultRequeueDuration,
+		crdInformer.Informer(),
 		40,
 		graph.RGDConfig{
 			MaxCollectionSize:          1000,


### PR DESCRIPTION
Replace the TTL-only schema resolution with a three-layer chained resolver:
core (compiled-in) -> CRD (informer-backed) -> fallback (TTL-cached discovery)

The CRD resolver uses a custom GVK indexer on the CRD informer for O(1)
lookups and lazily extracts `OpenAPI` schemas on first access, caching them
until the CRD is updated or deleted. This gives event driven invalidation
without paying the memory cost of converting schemas for every CRD in the
cluster -- only CRDs that kro actually references are materialized.

Builder is a pure consumer that takes a `SchemaResolver` interface with no
lifecycle concerns. Resolver wiring, ordering, and lifecycle are owned by
`cmd/controller/main.go`. The CRD resolver takes a
`CustomResourceDefinitionInformer` directly rather than a `clientset`, and the
informer factory is registered with the controller manager for lifecycle
management.