### PR TITLE
Modify tracking-id annotation for ArgoCD

### DIFF
--- a/website/docs/docs/faq.md
+++ b/website/docs/docs/faq.md
@@ -80,7 +80,7 @@ sidebar_position: 100
            blockOwnerDeletion: true
            controller: false
       annotations:
-        argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"]}
+        argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
    ```
 
    This annotation allows ArgoCD to properly track and manage the resources


### PR DESCRIPTION
Updated tracking-id annotation to use `.orValue("")` for default, as it is now needed with latest versions.

The `?` optional access operator is kept because `annotations` may be absent on the resource — without it, resources with no annotations would fail reconciliation. The `?` + `.orValue("")` pattern is the canonical kro approach (see docs and test examples throughout the repo).

Supersedes #962 (rebased on latest main, cleaned up merge commit).