### PR TITLE
fix: Support ordered deletion without desired-state projection, CEL evaluation, GraphRevision resolution or external observation

### DIFF
--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -1,0 +1,263 @@
+# CEL-independent ordered instance deletion
+
+## Problem statement
+
+Instance deletion currently reconstructs managed-resource identities from the
+compiled graph. That makes cleanup depend on the same desired-state and CEL
+evaluation pipeline used during normal reconciliation.
+
+[Issue #1316](https://github.com/kubernetes-sigs/kro/issues/1316) demonstrates
+why that dependency is unsafe. An instance creates a managed child whose
+identity or desired state references an external object. The child remains
+alive behind a finalizer owned by another controller. The external reference is
+then deleted, followed by the root instance. During deletion, kro can no longer
+evaluate the child's CEL expressions because the external data is unavailable.
+The child is not deleted and the kro finalizer on the root instance is stuck.
+
+This is one example of a broader lifecycle invariant: deleting an instance must
+remain possible when desired-state projection, identity CEL, readiness CEL, or
+external observation is unavailable. Cleanup needs durable identities and
+ordering information from the resources that normal reconciliation already
+created.
+
+## Proposal
+
+Persist each managed child's apply order and use the instance's ApplySet
+inventory as the authority for deletion. Instance deletion lists that inventory
+without resolving desired objects, validates every member's persisted order,
+and deletes only the highest remaining order. It waits for that entire wave to
+disappear before advancing.
+
+External references remain read-only inputs. They are not finalized, mutated,
+or deleted by kro.
+
+#### Overview
+
+The lifecycle is governed by these invariants:
+
+- Managed-resource identity during deletion comes from persisted ApplySet
+  inventory, not from reconstructed desired objects or current graph nodes.
+- Every managed child carries `internal.kro.run/apply-order`. Its value is the
+  child's one-based position in the complete runtime DAG's total topological
+  order.
+- External nodes occupy positions in that total order but are not applied, so
+  managed-resource order values may have gaps.
+- Deletion processes only the highest order still present in inventory.
+- A wave remains active until all of its objects are absent, including objects
+  that already have a deletion timestamp.
+- The instance finalizer is removed only after the inventory is empty.
+- Missing or invalid order metadata is a visible migration error. The root
+  finalizer remains, and deletion never silently changes to unordered cleanup.
+
+#### Normal reconciliation
+
+`processNodes` enumerates every runtime node in topological order. Regular
+managed resources receive the node ID and the one-based apply order as
+controller-owned labels. Every expanded member of a `forEach` collection
+receives the same order because the collection is one graph node. External
+references and external collections are observed but never applied and receive
+no apply-order label.
+
+The existing server-side apply path writes the label alongside the desired
+resource. This also backfills an unchanged child: SSA still submits controller
+metadata even when the resource spec has not changed. A later successful
+reconcile against a new GraphRevision can update an object's order. An object
+removed from the graph keeps its last persisted order until normal pruning
+deletes it.
+
+Both `kro.run/` and `internal.kro.run/` are reserved label prefixes in resource
+templates. RGD authors therefore cannot override the node identity or deletion
+order owned by the controller.
+
+#### Deletion inventory
+
+The instance is already the ApplySet parent. Its annotations persist the union
+of group-kinds and additional namespaces that can contain members. Deletion
+creates the same ApplySet, calls `Project(nil)` to reconstruct that scope from
+the parent annotations, and calls `ListOrphans` with an empty keep-UID set. All
+ApplySet members are consequently deletion candidates.
+
+This inventory has two important properties. First, external references are
+absent because kro never applies them and they are not ApplySet members. Second,
+resources retained from an older GraphRevision remain discoverable even if
+their group-kind, namespace, or node ID is absent from the current graph.
+
+The deletion path does not call `IsIgnored`, `GetDesired`,
+`GetDesiredIdentity`, `DeleteTargets`, readiness evaluation, or external
+observation. Deletion is handled before compiled GraphRevision resolution.
+This is intentional: resolving the current revision can itself require
+unavailable dependencies or invalid CEL, which is exactly the failure mode in
+#1316. The early path only needs the parent object, persisted ApplySet
+annotations, and dynamic REST mappings. The tradeoff is that deletion status
+cannot describe current graph nodes when no revision can be resolved; the
+controller still reports the instance-level deleting condition and preserves
+the finalizer on inventory or ordering failures. Keeping deletion after graph
+resolution would preserve richer node status, but would leave the root
+finalizer stuck whenever resolution fails.
+
+#### Ordered deletion waves
+
+Before issuing any DELETE, the controller parses every candidate's
+`internal.kro.run/apply-order`. Only positive base-10 integers are accepted.
+Missing, malformed, zero, or negative values fail the reconciliation before any
+cluster mutation. The error identifies the resource's GVK, namespace, and name.
+When the candidate has a current `kro.run/node-id`, that node is marked Error.
+There is no inference from node ID, graph shape, collection index, or LIST
+order.
+
+After validation, the controller finds the highest remaining order and selects
+only candidates at that order. It skips a DELETE for a candidate that already
+has a deletion timestamp, but that candidate remains in the active wave and
+blocks every lower order until it is actually absent. Other active-wave
+candidates are passed to `ApplySet.DeleteOrphan`. Its UID precondition prevents
+a LIST/DELETE race from deleting a different object recreated with the same
+name.
+
+DELETE calls within a wave are sequential. All candidates remain visible on
+the next LIST, so every reconciliation with non-empty inventory returns a
+delayed requeue. A UID conflict also requeues and does not permit a lower wave
+to advance. Only a later reconciliation that observes no higher-order members
+can begin the next order. Empty inventory is the sole condition for removing
+the root finalizer and cleaning up coordinator watches.
+
+Node status during deletion is derived without CEL:
+
+- External nodes are Skipped.
+- Current managed nodes represented by any live candidate are Deleting,
+  including lower-order nodes that have not received DELETE yet.
+- Current managed nodes with no candidates are Deleted.
+- A DELETE or ordering error marks the relevant current node Error when its
+  node ID is available.
+
+#### Rollout behavior
+
+When an instance controller registers a GVR at startup, it explicitly enqueues
+the instances already present in its cache. Healthy, unsuspended instances
+therefore run normal reconciliation and acquire the order label through SSA,
+even when their child specs are unchanged. This proposal adds neither a
+separate migration job nor a forced restart loop.
+
+Some instances can miss that backfill. An instance already deleting when the
+new version starts bypasses normal child apply. Suspended instances, instances
+whose desired resources cannot resolve, and instances deleted before startup
+reconciliation completes can also retain unlabeled children. These cases fail
+safely during deletion: the ordering error is reported and the root finalizer
+is retained.
+
+Operators have two break-glass choices:
+
+1. Determine the correct historical order and manually assign valid
+   `internal.kro.run/apply-order` labels before allowing deletion to continue.
+2. Remove the root finalizer and manually clean up all remaining managed
+   children.
+
+This is an accepted upgrade limitation, not an unordered compatibility mode.
+The controller must not guess an order for an unlabeled resource.
+
+#### Failure behavior
+
+ApplySet LIST failures and RESTMapping failures retain the root finalizer and
+retry through normal reconciliation error handling. Malformed ordering metadata
+is reported before any DELETE. DELETE errors retain the finalizer, mark the
+associated node Error when possible, and propagate. A UID precondition conflict
+causes a delayed requeue with the active wave unchanged.
+
+A child with a deletion timestamp is expected progress rather than an error.
+It remains Deleting and continues to block lower orders until the API server no
+longer lists it. No error path is allowed to issue deletion for a lower-order
+resource while a higher-order member remains.
+
+## Other solutions considered
+
+#### Finalize external references
+
+Rejected. External references are read-only, can be shared by unrelated
+instances, and can be managed by another authority. Giving kro a finalizer on
+them would change that ownership contract and could block their deletion.
+
+#### Unordered label-based deletion
+
+Rejected. Finding children by an ownership label avoids CEL but deletes all
+resources together. That is a breaking change to kro's dependent-before-
+dependency lifecycle and can remove resources while their dependents are still
+terminating.
+
+#### Reconstruct identity from CEL and current desired state
+
+Rejected. This is the failure mode in #1316. Deletion must survive missing
+dependencies, invalid expressions, unavailable observation, and desired state
+that no longer describes resources created by an older revision.
+
+#### Infer missing order from current node IDs
+
+Rejected for this rollout. It complicates migration and can be wrong when the
+current GraphRevision differs from the revision that created an older resource.
+Failing visibly preserves ordering rather than hiding uncertainty.
+
+## Scoping
+
+#### What is in scope for this proposal?
+
+- Persisting total topological apply positions on regular and collection
+  resources.
+- Reserving the public and internal kro label prefixes in RGD templates.
+- ApplySet-inventory discovery for instance deletion.
+- Strict, UID-preconditioned, highest-order deletion waves.
+- Startup-reconcile backfill and documented manual remediation for missed
+  migration.
+- Unit and focused integration coverage for the lifecycle.
+
+#### What is not in scope?
+
+A future level-aware reconciliation engine may replace total positions with
+dependency levels, as discussed in
+[PR #1215](https://github.com/kubernetes-sigs/kro/pull/1215#discussion_r3164471497).
+The durable-inventory and wait-for-wave semantics remain applicable: store the
+level on each member, delete the highest remaining level, and wait for absence
+before advancing.
+
+This proposal does not add an upgrade migration controller or infer metadata for missed
+backfills, or change normal orphan-pruning order.
+
+## Testing strategy
+
+#### Requirements
+
+Fake-client deletion fixtures carry a stable UID, the computed
+`applyset.kubernetes.io/part-of` value, `kro.run/node-id`, and
+`internal.kro.run/apply-order`. Their parent instance carries the ApplySet
+group-kind and namespace annotations. Integration tests use synthetic child
+finalizers to make ordering observable rather than timing-dependent.
+
+#### Test plan
+
+Unit tests verify regular-resource order, shared collection order, external
+exclusion, SSA label application to existing objects, and validation of both
+reserved prefixes. ApplySet tests cover namespaced and cluster-scoped discovery
+from parent annotations, including older resources no longer represented by the
+current graph.
+
+Deletion unit tests verify that only the highest remaining order receives
+DELETE, a terminating highest-order resource blocks lower orders, the next wave
+starts only after the higher wave disappears, and all resources at one order
+are handled together. They also cover empty-inventory finalizer removal;
+missing, malformed, zero, and negative labels before any DELETE; DELETE error
+state; UID-conflict requeue; and deletion with an absent external reference.
+
+The core integration suite reproduces #1316 by creating an external ConfigMap
+and a managed child derived from it, asserting the child's persisted order,
+holding the child with a synthetic finalizer, deleting both the external object
+and root, and observing that the child receives a deletion timestamp. Removing
+the child finalizer must allow both child and root to disappear.
+
+A second integration scenario creates `A -> B`, holds B with a synthetic
+finalizer, and deletes the root. B must become terminating while A has no
+deletion timestamp. Only after B disappears may A and then the root disappear.
+
+## Discussion and notes
+
+The persisted order is a total topological position starting at one, not a
+dependency depth. Gaps caused by external nodes are intentional and harmless.
+The central contract is not that orders are contiguous; it is that deletion
+uses only persisted inventory and never advances below the highest remaining
+value.

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -24,9 +24,10 @@ created.
 
 Persist each managed child's apply order and use the instance's ApplySet
 inventory as the authority for deletion. Instance deletion lists that inventory
-without resolving desired objects, validates every member's persisted order,
-and deletes only the highest remaining order. It waits for that entire wave to
-disappear before advancing.
+without resolving desired objects, groups members by persisted order, and
+deletes only the highest remaining order. It waits for that entire wave to
+disappear before advancing. Members without a usable persisted order share a
+fallback wave that runs after every valid order.
 
 External references remain read-only inputs. They are not finalized, mutated,
 or deleted by kro.
@@ -37,17 +38,17 @@ The lifecycle is governed by these invariants:
 
 - Managed-resource identity during deletion comes from persisted ApplySet
   inventory, not from reconstructed desired objects or current graph nodes.
-- Every managed child carries `internal.kro.run/apply-order`. Its value is the
-  child's one-based position in the complete runtime DAG's total topological
-  order.
+- Normal reconciliation gives every managed child
+  `internal.kro.run/apply-order`. Its value is the child's one-based position
+  in the complete runtime DAG's total topological order.
 - External nodes occupy positions in that total order but are not applied, so
   managed-resource order values may have gaps.
 - Deletion processes only the highest order still present in inventory.
 - A wave remains active until all of its objects are absent, including objects
   that already have a deletion timestamp.
+- Members with missing or invalid order metadata share one fallback wave. That
+  wave runs last and has no ordering guarantee within it.
 - The instance finalizer is removed only after the inventory is empty.
-- Missing or invalid order metadata is a visible migration error. The root
-  finalizer remains, and deletion never silently changes to unordered cleanup.
 
 #### Normal reconciliation
 
@@ -91,19 +92,19 @@ unavailable dependencies or invalid CEL, which is exactly the failure mode in
 annotations, and dynamic REST mappings. The tradeoff is that deletion status
 cannot describe current graph nodes when no revision can be resolved; the
 controller still reports the instance-level deleting condition and preserves
-the finalizer on inventory or ordering failures. Keeping deletion after graph
+the finalizer on inventory or deletion failures. Keeping deletion after graph
 resolution would preserve richer node status, but would leave the root
 finalizer stuck whenever resolution fails.
 
 #### Ordered deletion waves
 
-Before issuing any DELETE, the controller parses every candidate's
-`internal.kro.run/apply-order`. Only positive base-10 integers are accepted.
-Missing, malformed, zero, or negative values fail the reconciliation before any
-cluster mutation. The error identifies the resource's GVK, namespace, and name.
-When the candidate has a current `kro.run/node-id`, that node is marked Error.
-There is no inference from node ID, graph shape, collection index, or LIST
-order.
+The controller parses every candidate's `internal.kro.run/apply-order`.
+Positive base-10 integers retain their persisted order. Missing, malformed,
+zero, or negative values are assigned internal order zero, which is lower than
+every valid order. All such candidates therefore share a fallback wave that is
+selected only after every valid ordered wave is absent. There is no inference
+from node ID, graph shape, collection index, or LIST order, and no
+reverse-order guarantee among members of the fallback wave.
 
 After validation, the controller finds the highest remaining order and selects
 only candidates at that order. It skips a DELETE for a candidate that already
@@ -126,8 +127,8 @@ Node status during deletion is derived without CEL:
 - Current managed nodes represented by any live candidate are Deleting,
   including lower-order nodes that have not received DELETE yet.
 - Current managed nodes with no candidates are Deleted.
-- A DELETE or ordering error marks the relevant current node Error when its
-  node ID is available.
+- A DELETE error marks the relevant current node Error when its node ID is
+  available.
 
 #### Rollout behavior
 
@@ -140,27 +141,22 @@ separate migration job nor a forced restart loop.
 Some instances can miss that backfill. An instance already deleting when the
 new version starts bypasses normal child apply. Suspended instances, instances
 whose desired resources cannot resolve, and instances deleted before startup
-reconciliation completes can also retain unlabeled children. These cases fail
-safely during deletion: the ordering error is reported and the root finalizer
-is retained.
+reconciliation completes can also retain unlabeled children. Deletion still
+processes every labeled wave in reverse order, then deletes all remaining
+unlabeled or invalidly labeled children in the shared fallback wave.
 
-Operators have two break-glass choices:
-
-1. Determine the correct historical order and manually assign valid
-   `internal.kro.run/apply-order` labels before allowing deletion to continue.
-2. Remove the root finalizer and manually clean up all remaining managed
-   children.
-
-This is an accepted upgrade limitation, not an unordered compatibility mode.
-The controller must not guess an order for an unlabeled resource.
+This compatibility behavior deliberately prioritizes deletion liveness over
+reverse-order guarantees for resources whose historical order was never
+persisted. It avoids leaving an instance and its children indefinitely stuck in
+deletion during rollout while preserving strict ordering wherever the metadata
+is available.
 
 #### Failure behavior
 
 ApplySet LIST failures and RESTMapping failures retain the root finalizer and
-retry through normal reconciliation error handling. Malformed ordering metadata
-is reported before any DELETE. DELETE errors retain the finalizer, mark the
-associated node Error when possible, and propagate. A UID precondition conflict
-causes a delayed requeue with the active wave unchanged.
+retry through normal reconciliation error handling. DELETE errors retain the
+finalizer, mark the associated node Error when possible, and propagate. A UID
+precondition conflict causes a delayed requeue with the active wave unchanged.
 
 A child with a deletion timestamp is expected progress rather than an error.
 It remains Deleting and continues to block lower orders until the API server no
@@ -175,12 +171,12 @@ Rejected. External references are read-only, can be shared by unrelated
 instances, and can be managed by another authority. Giving kro a finalizer on
 them would change that ownership contract and could block their deletion.
 
-#### Unordered label-based deletion
+#### Fully unordered label-based deletion
 
-Rejected. Finding children by an ownership label avoids CEL but deletes all
-resources together. That is a breaking change to kro's dependent-before-
-dependency lifecycle and can remove resources while their dependents are still
-terminating.
+Rejected as the general deletion strategy. Finding children by an ownership
+label avoids CEL but deleting all resources together discards usable persisted
+ordering. The compatibility fallback limits unordered deletion to members that
+have no usable order and runs it only after every ordered member is absent.
 
 #### Reconstruct identity from CEL and current desired state
 
@@ -192,7 +188,8 @@ that no longer describes resources created by an older revision.
 
 Rejected for this rollout. It complicates migration and can be wrong when the
 current GraphRevision differs from the revision that created an older resource.
-Failing visibly preserves ordering rather than hiding uncertainty.
+The fallback wave represents that uncertainty explicitly without inventing an
+order that may be wrong.
 
 ## Scoping
 
@@ -203,8 +200,7 @@ Failing visibly preserves ordering rather than hiding uncertainty.
 - Reserving the public and internal kro label prefixes in RGD templates.
 - ApplySet-inventory discovery for instance deletion.
 - Strict, UID-preconditioned, highest-order deletion waves.
-- Startup-reconcile backfill and documented manual remediation for missed
-  migration.
+- A final compatibility wave for resources that missed order-label backfill.
 - Unit and focused integration coverage for the lifecycle.
 
 #### What is not in scope?
@@ -216,8 +212,8 @@ The durable-inventory and wait-for-wave semantics remain applicable: store the
 level on each member, delete the highest remaining level, and wait for absence
 before advancing.
 
-This proposal does not add an upgrade migration controller or infer metadata for missed
-backfills, or change normal orphan-pruning order.
+This proposal does not add an upgrade migration controller, infer metadata for
+missed backfills, or change normal orphan-pruning order.
 
 ## Testing strategy
 
@@ -241,8 +237,9 @@ Deletion unit tests verify that only the highest remaining order receives
 DELETE, a terminating highest-order resource blocks lower orders, the next wave
 starts only after the higher wave disappears, and all resources at one order
 are handled together. They also cover empty-inventory finalizer removal;
-missing, malformed, zero, and negative labels before any DELETE; DELETE error
-state; UID-conflict requeue; and deletion with an absent external reference.
+missing, malformed, zero, and negative labels in a shared final wave; DELETE
+error state; UID-conflict requeue; and deletion with an absent external
+reference.
 
 The core integration suite reproduces #1316 by creating an external ConfigMap
 and a managed child derived from it, asserting the child's persisted order,
@@ -260,4 +257,5 @@ The persisted order is a total topological position starting at one, not a
 dependency depth. Gaps caused by external nodes are intentional and harmless.
 The central contract is not that orders are contiguous; it is that deletion
 uses only persisted inventory and never advances below the highest remaining
-value.
+valid value. The fallback order zero is selected only when no valid ordered
+members remain.

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -70,6 +70,14 @@ Both `kro.run/` and `internal.kro.run/` are reserved label prefixes in resource
 templates. RGD authors therefore cannot override the node identity or deletion
 order owned by the controller.
 
+The write that first installs the instance finalizer also creates a valid empty
+ApplySet inventory when none exists. If the instance already has valid
+inventory, that write preserves it; partial or malformed inventory prevents
+finalizer installation rather than being replaced with an empty scope. An
+automatic replacement could hide previously managed children and orphan them
+during deletion. Recovery therefore requires repairing the metadata, or
+removing it only after confirming that no managed members remain.
+
 #### Deletion inventory
 
 The instance is already the ApplySet parent. Its annotations persist the union

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -39,9 +39,10 @@ The lifecycle is governed by these invariants:
 - Managed-resource identity during deletion comes from persisted ApplySet
   inventory, not from reconstructed desired objects or current graph nodes.
 - Normal reconciliation gives every managed child
-  `internal.kro.run/apply-order`. Its value is the child's one-based position
-  in the complete runtime DAG's total topological order.
-- External nodes occupy positions in that total order but are not applied, so
+  `internal.kro.run/apply-order`. Its value is the child's one-based reverse
+  topological deletion wave. Dependents have higher values than their
+  dependencies, while nodes that can be deleted together share a value.
+- External nodes participate in the graph layers but are not applied, so
   managed-resource order values may have gaps.
 - Deletion processes only the highest order still present in inventory.
 - A wave remains active until all of its objects are absent, including objects
@@ -52,12 +53,13 @@ The lifecycle is governed by these invariants:
 
 #### Normal reconciliation
 
-`processNodes` enumerates every runtime node in topological order. Regular
-managed resources receive the node ID and the one-based apply order as
-controller-owned labels. Every expanded member of a `forEach` collection
-receives the same order because the collection is one graph node. External
-references and external collections are observed but never applied and receive
-no apply-order label.
+Before processing nodes, the controller groups the compiled DAG into reverse
+topological layers. Regular managed resources receive the node ID and the
+layer's one-based apply order as controller-owned labels. Every expanded member
+of a `forEach` collection receives the same order because the collection is one
+graph node. External references and external collections participate in layer
+calculation but are observed rather than applied and receive no apply-order
+label.
 
 The existing server-side apply path writes the label alongside the desired
 resource. This also backfills an unchanged child: SSA still submits controller
@@ -214,7 +216,7 @@ order that may be wrong.
 
 #### What is in scope for this proposal?
 
-- Persisting total topological apply positions on regular and collection
+- Persisting reverse topological deletion waves on regular and collection
   resources.
 - Reserving the public and internal kro label prefixes in RGD templates.
 - ApplySet-inventory discovery for instance deletion.
@@ -225,15 +227,10 @@ order that may be wrong.
 
 #### What is not in scope?
 
-A future level-aware reconciliation engine may replace total positions with
-dependency levels, as discussed in
-[PR #1215](https://github.com/kubernetes-sigs/kro/pull/1215#discussion_r3164471497).
-The durable-inventory and wait-for-wave semantics remain applicable: store the
-level on each member, delete the highest remaining level, and wait for absence
-before advancing.
-
-This proposal does not add an upgrade migration controller, infer metadata for
-missed backfills, or change normal orphan-pruning order.
+The deletion-wave calculation does not change normal reconciliation to apply
+resources concurrently. This proposal also does not add an upgrade migration
+controller, infer metadata for missed backfills, or change normal
+orphan-pruning order.
 
 ## Testing strategy
 
@@ -274,9 +271,10 @@ deletion timestamp. Only after B disappears may A and then the root disappear.
 
 ## Discussion and notes
 
-The persisted order is a total topological position starting at one, not a
-dependency depth. Gaps caused by external nodes are intentional and harmless.
-The central contract is not that orders are contiguous; it is that deletion
-uses only persisted inventory and never advances below the highest remaining
-valid value. The fallback order zero is selected only when no valid ordered
-members remain.
+The persisted order is a reverse topological layer starting at one. Sink nodes
+receive the highest value, and removing that layer exposes the next set of
+nodes whose dependents are gone. Gaps caused by external-only layers are
+intentional and harmless. The central contract is not that orders are
+contiguous; it is that deletion uses only persisted inventory and never
+advances below the highest remaining valid value. The fallback order zero is
+selected only when no valid ordered members remain.

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -132,6 +132,11 @@ Deletion status is intentionally instance-level. The runtime-free path cannot
 derive meaningful current-graph node states, and those transient states were
 never persisted independently. `ResourcesReady=Unknown` with reason
 `UnderDeletion` reports progress or the error currently blocking deletion.
+When an RGD defines author conditions, deletion preserves their last persisted
+values and overlays this kro-owned lifecycle condition because author
+conditions cannot be reevaluated without a runtime. If the author defines a
+condition with the same type, the deletion condition temporarily takes
+precedence so cleanup failures remain observable.
 
 #### Rollout behavior
 

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -158,6 +158,15 @@ retry through normal reconciliation error handling. DELETE errors retain the
 finalizer, mark the associated node Error when possible, and propagate. A UID
 precondition conflict causes a delayed requeue with the active wave unchanged.
 
+Deletion validates the ApplySet parent ID, kro tooling ownership, and the
+presence and syntax of the persisted group-kind and namespace annotations
+before listing members. Normal reconciliation also writes a checksum over that
+inventory; when present, deletion verifies it to detect accidental partial
+mutation. Invalid inventory retains the root finalizer and reports an
+actionable reconciliation error rather than treating the inventory as empty
+and orphaning children. Parents created by older kro versions may omit the
+checksum, but must still carry the standard ApplySet inventory annotations.
+
 A child with a deletion timestamp is expected progress rather than an error.
 It remains Deleting and continues to block lower orders until the API server no
 longer lists it. No error path is allowed to issue deletion for a lower-order

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -10,9 +10,10 @@ evaluation pipeline used during normal reconciliation.
 why that dependency is unsafe. An instance creates a managed child whose
 identity or desired state references an external object. The child remains
 alive behind a finalizer owned by another controller. The external reference is
-then deleted, followed by the root instance. During deletion, kro can no longer
-evaluate the child's CEL expressions because the external data is unavailable.
-The child is not deleted and the kro finalizer on the root instance is stuck.
+then deleted, followed by (or at the same time as) the root instance. During
+deletion, kro can no longer evaluate the child's CEL expressions because the
+external data is unavailable. The child is not deleted and the kro finalizer on
+the root instance is stuck.
 
 This is one example of a broader lifecycle invariant: deleting an instance must
 remain possible when desired-state projection, identity CEL, readiness CEL, or
@@ -22,123 +23,107 @@ created.
 
 ## Proposal
 
-Persist each managed child's apply order and use the instance's ApplySet
+Persist each managed child's _apply order_ and use the instance's `ApplySet`
 inventory as the authority for deletion. Instance deletion lists that inventory
 without resolving desired objects, groups members by persisted order, and
 deletes only the highest remaining order. It waits for that entire wave to
 disappear before advancing. Members without a usable persisted order share a
 fallback wave that runs after every valid order.
 
-External references remain read-only inputs. They are not finalized, mutated,
-or deleted by kro.
-
 #### Overview
 
 The lifecycle is governed by these invariants:
 
-- Managed-resource identity during deletion comes from persisted ApplySet
+- Managed-resource identity during deletion comes from persisted `ApplySet`
   inventory, not from reconstructed desired objects or current graph nodes.
-- Normal reconciliation gives every managed child
+- Normal reconciliation gives every managed child an annotation
   `internal.kro.run/apply-order`. Its value is the child's one-based reverse
-  topological deletion wave. Dependents have higher values than their
-  dependencies, while nodes that can be deleted together share a value.
-- External nodes participate in the graph layers but are not applied, so
-  managed-resource order values may have gaps.
-- Deletion processes only the highest order still present in inventory.
-- A wave remains active until all of its objects are absent, including objects
-  that already have a deletion timestamp.
+  topological "layer". Dependents have higher values than their dependencies,
+  while nodes that can be deleted together share a value. In other words,
+  children sharing the same value belong to the same _deletion wave_.
+- Deletion is processed in waves, actuating deletion only for the highest order
+  still present in inventory.
+- A wave remains active until all of its objects are absent; having a deletion
+  timestamp is not enough, but the child must be fully garbage collected.
 - Members with missing or invalid order metadata share one fallback wave. That
-  wave runs last and has no ordering guarantee within it.
-- The instance finalizer is removed only after the inventory is empty.
+  wave runs last and has no ordering guarantee within it. This is also the
+  behavior that will apply to deletions triggered concurrently with rolling this
+  change out; effectively, every graph not reconciled at least once with this
+  change, has all its children with the fallback apply order (`0`).
+- The instance finalizer is removed only after the inventory is empty, i.e. when
+  all children have been successfully deleted and garbage collected.
+- Progress is made observable with a condition on the root instance.
 
-#### Normal reconciliation
+#### Normal reconciliation writes metadata
 
-Before processing nodes, the controller groups the compiled DAG into reverse
-topological layers. Regular managed resources receive a node ID label and the
-layer's one-based apply order as a controller-owned annotation. Every expanded
-member of a `forEach` collection receives the same order because the collection
-is one graph node. External references and external collections participate in
-layer calculation but are observed rather than applied and receive no
-apply-order annotation.
+Resources with no deletion timestamp, processes and stores metadata as follows:
 
-The existing server-side apply path writes the annotation alongside the
-desired resource. This also backfills an unchanged child: SSA still submits
-controller metadata even when the resource spec has not changed. A later
-successful reconcile against a new GraphRevision can update an object's order.
-An object removed from the graph keeps its last persisted order until normal
-pruning deletes it.
+Each child node gets
+- a label with a node id referencing the root instance (current behavior)
+- an annotation with an apply order, indicating its topological layer in the DAG
+  (this is new for this proposal)
 
-Both `kro.run/` and `internal.kro.run/` are reserved label and annotation
-prefixes in resource templates. RGD authors therefore cannot override the node
+Additionally, the root instance itself gets
+- an annotation indicating all GVKs and namespaces where to find children; this
+  is the `ApplySet` inventory already managed by the current behavior
+- an annotation with a checksum of the inventory, guarding against partial
+  mutation that might result in incorrect deletion behavior
+
+The current implementation already ensures that the `ApplySet` inventory
+includes all GKVs/namespaces in use, even in the case of transient failures, so
+relying on it for finding children is valid even when the RGD has recently been
+updated and there are children present in the cluster that are not referenced in
+the graph.
+
+#### ⚠️ Label/annotation domain guards
+
+As [previously proposed][krep-label-migration], `internal.kro.run/` is used as a
+prefix for new metadata. Additionally, both `kro.run/` and `internal.kro.run/`
+are now reserved label and annotation prefixes in resource templates; defining
+either manually on an RGD child instance is now an error. RGD authors therefore cannot override the node
 identity or deletion order owned by the controller.
 
-The write that first installs the instance finalizer also creates a valid empty
-ApplySet inventory when none exists. If the instance already has valid
-inventory, that write preserves it; partial or malformed inventory prevents
-finalizer installation rather than being replaced with an empty scope. An
-automatic replacement could hide previously managed children and orphan them
-during deletion. Recovery therefore requires repairing the metadata, or
-removing it only after confirming that no managed members remain.
-
-#### Deletion inventory
-
-The instance is already the ApplySet parent. Its annotations persist the union
-of group-kinds and additional namespaces that can contain members. Deletion
-creates the same ApplySet, calls `Project(nil)` to reconstruct that scope from
-the parent annotations, and calls `ListOrphans` with an empty keep-UID set. All
-ApplySet members are consequently deletion candidates.
-
-This inventory has two important properties. First, external references are
-absent because kro never applies them and they are not ApplySet members. Second,
-resources retained from an older GraphRevision remain discoverable even if
-their group-kind, namespace, or node ID is absent from the current graph.
-
-The deletion path does not call `IsIgnored`, `GetDesired`,
-`GetDesiredIdentity`, `DeleteTargets`, readiness evaluation, or external
-observation. Deletion is handled before compiled GraphRevision resolution.
-This is intentional: resolving the current revision can itself require
-unavailable dependencies or invalid CEL, which is exactly the failure mode in
-#1316. The early path uses a dedicated runtime-free context containing only the
-parent object, persisted ApplySet annotations, dynamic client, and REST
-mappings. Deletion intentionally reports only instance-level status; it does
-not synthesize per-node states that cannot be persisted without a resolved
-runtime. Keeping deletion after graph resolution would preserve richer node
-status, but would leave the root finalizer stuck whenever resolution fails.
+[krep-label-migration]: https://github.com/kubernetes-sigs/kro/blob/main/docs/design/proposals/label-migration.md
 
 #### Ordered deletion waves
 
-The controller parses every candidate's `internal.kro.run/apply-order`.
-Positive base-10 integers retain their persisted order. Missing, malformed,
-zero, or negative values are assigned internal order zero, which is lower than
-every valid order. All such candidates therefore share a fallback wave that is
-selected only after every valid ordered wave is absent. There is no inference
-from node ID, graph shape, collection index, or LIST order, and no
-reverse-order guarantee among members of the fallback wave.
+When deletion of the root instance is requested (its deletion timestamp is non-
+nil), the reconciler _does not_ process the entire RGD to resolve identities,
+CEL expressions, etc.
+
+Instead, it inspects the root instance's `ApplySet` inventory annotation, and
+issues `LIST` calls for each GVK/namespace, filtered by the node-id label.
+
+Resources are collected into _waves_ based on the persisted apply order.
+Missing, malformed, zero, or negative values are assigned internal order zero,
+which is lower than every valid order; all such candidates therefore share a
+fallback wave that is selected only after every valid ordered wave is absent.
+There is no ordering guarantee within a wave; this _might_ violate previous
+reverse-order guarantees in the fallback wave, but the ordering of the waves
+themselves should guarantee reverse-order deletion for all valid resources.
 
 After validation, the controller finds the highest remaining order and selects
-only candidates at that order. It skips a DELETE for a candidate that already
+only candidates at that order. It skips a `DELETE` for a candidate that already
 has a deletion timestamp, but that candidate remains in the active wave and
 blocks every lower order until it is actually absent. Other active-wave
-candidates are passed to `ApplySet.DeleteOrphan`. Its UID precondition prevents
+candidates are passed to `ApplySet.DeleteOrphan`; its UID precondition prevents
 a LIST/DELETE race from deleting a different object recreated with the same
 name.
 
-DELETE calls within a wave are sequential. All candidates remain visible on
+`DELETE` calls within a wave are sequential. All candidates remain visible on
 the next LIST, so every reconciliation with non-empty inventory returns a
 delayed requeue. A UID conflict also requeues and does not permit a lower wave
 to advance. Only a later reconciliation that observes no higher-order members
 can begin the next order. Empty inventory is the sole condition for removing
 the root finalizer and cleaning up coordinator watches.
 
-Deletion status is intentionally instance-level. The runtime-free path cannot
-derive meaningful current-graph node states, and those transient states were
-never persisted independently. `ResourcesReady=Unknown` with reason
-`UnderDeletion` reports progress or the error currently blocking deletion.
-When an RGD defines author conditions, deletion preserves their last persisted
-values and overlays this kro-owned lifecycle condition because author
-conditions cannot be reevaluated without a runtime. If the author defines a
-condition with the same type, the deletion condition temporarily takes
-precedence so cleanup failures remain observable.
+Deletion status is reported on the root instance, using `ResourcesReady=Unknown`
+with reason `UnderDeletion`. When an RGD defines author conditions, deletion
+preserves their last persisted values and overlays this kro-owned lifecycle
+condition because author conditions cannot be reevaluated without processing the
+full graph including CEL resolution etc. If the author defines a condition with
+the same type, the deletion condition temporarily takes precedence so cleanup
+failures remain observable.
 
 #### Rollout behavior
 
@@ -164,12 +149,12 @@ is available.
 
 #### Failure behavior
 
-ApplySet LIST failures and RESTMapping failures retain the root finalizer and
-retry through normal reconciliation error handling. DELETE errors retain the
-finalizer and propagate through the instance-level status. Inventory, LIST,
-DELETE, and UID-conflict errors replace the generic deletion-progress message
-with an actionable `ResourcesReady` condition message. A UID precondition
-conflict causes a delayed requeue with the active wave unchanged.
+ApplySet `LIST` failures and `RESTMapping` failures retain the root finalizer
+and retry through normal reconciliation error handling. `DELETE` errors retain
+the finalizer and propagate through the instance-level status. Inventory,
+`LIST`, `DELETE`, and UID-conflict errors replace the generic deletion-progress
+message with an actionable `ResourcesReady` condition message. A UID
+precondition conflict causes a delayed requeue with the active wave unchanged.
 
 Deletion validates the ApplySet parent ID, kro tooling ownership, and the
 presence and syntax of the persisted group-kind and namespace annotations
@@ -189,95 +174,28 @@ resource while a higher-order member remains.
 
 #### Finalize external references
 
-Rejected. External references are read-only, can be shared by unrelated
+**Rejected.** External references are read-only, can be shared by unrelated
 instances, and can be managed by another authority. Giving kro a finalizer on
 them would change that ownership contract and could block their deletion.
 
 #### Fully unordered label-based deletion
 
-Rejected as the general deletion strategy. Finding children by an ownership
+**Rejected.** as the general deletion strategy. Finding children by an ownership
 label avoids CEL but deleting all resources together discards usable persisted
 ordering. The compatibility fallback limits unordered deletion to members that
-have no usable order and runs it only after every ordered member is absent.
+have no usable order and runs it only after every ordered member is absent, but
+under normal operations we should be able to guarantee that dependencies are
+deleted before their dependents.
 
 #### Reconstruct identity from CEL and current desired state
 
-Rejected. This is the failure mode in #1316. Deletion must survive missing
+**Rejected.** This is the failure mode in #1316. Deletion must survive missing
 dependencies, invalid expressions, unavailable observation, and desired state
 that no longer describes resources created by an older revision.
 
 #### Infer missing order from current node IDs
 
-Rejected for this rollout. It complicates migration and can be wrong when the
-current GraphRevision differs from the revision that created an older resource.
-The fallback wave represents that uncertainty explicitly without inventing an
-order that may be wrong.
-
-## Scoping
-
-#### What is in scope for this proposal?
-
-- Persisting reverse topological deletion waves on regular and collection
-  resources.
-- Reserving the public and internal kro label and annotation prefixes in RGD
-  templates.
-- ApplySet-inventory discovery for instance deletion.
-- Validation and checksumming of persisted ApplySet deletion inventory.
-- Strict, UID-preconditioned, highest-order deletion waves.
-- A final compatibility wave for resources that missed order-annotation
-  backfill.
-- Unit and focused integration coverage for the lifecycle.
-
-#### What is not in scope?
-
-The deletion-wave calculation does not change normal reconciliation to apply
-resources concurrently. This proposal also does not add an upgrade migration
-controller, infer metadata for missed backfills, or change normal
-orphan-pruning order.
-
-## Testing strategy
-
-#### Requirements
-
-Fake-client deletion fixtures carry a stable UID, the computed
-`applyset.kubernetes.io/part-of` value, `kro.run/node-id`, and
-`internal.kro.run/apply-order`. Their parent instance carries the ApplySet
-parent ID, tooling, group-kind, and namespace metadata. Integration tests use
-synthetic child finalizers to make ordering observable rather than
-timing-dependent.
-
-#### Test plan
-
-Unit tests verify regular-resource order, shared collection order, external
-exclusion, SSA annotation application to existing objects, and validation of
-both reserved prefixes. ApplySet tests cover namespaced and cluster-scoped
-discovery from parent annotations, including older resources no longer
-represented by the current graph.
-
-Deletion unit tests verify that only the highest remaining order receives
-DELETE, a terminating highest-order resource blocks lower orders, the next wave
-starts only after the higher wave disappears, and all resources at one order
-are handled together. They also cover empty-inventory finalizer removal;
-missing, malformed, zero, and negative annotations in a shared final wave; DELETE
-error visibility; invalid-inventory finalizer retention; UID-conflict requeue;
-and deletion with an absent external reference.
-
-The core integration suite reproduces #1316 by creating an external ConfigMap
-and a managed child derived from it, asserting the child's persisted order,
-holding the child with a synthetic finalizer, deleting both the external object
-and root, and observing that the child receives a deletion timestamp. Removing
-the child finalizer must allow both child and root to disappear.
-
-A second integration scenario creates `A -> B`, holds B with a synthetic
-finalizer, and deletes the root. B must become terminating while A has no
-deletion timestamp. Only after B disappears may A and then the root disappear.
-
-## Discussion and notes
-
-The persisted order is a reverse topological layer starting at one. Sink nodes
-receive the highest value, and removing that layer exposes the next set of
-nodes whose dependents are gone. Gaps caused by external-only layers are
-intentional and harmless. The central contract is not that orders are
-contiguous; it is that deletion uses only persisted inventory and never
-advances below the highest remaining valid value. The fallback order zero is
-selected only when no valid ordered members remain.
+**Rejected.** for this rollout. It complicates migration and can be wrong when
+the current GraphRevision differs from the revision that created an older
+resource. The fallback wave represents that uncertainty explicitly without
+inventing an order that may be wrong.

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -54,23 +54,23 @@ The lifecycle is governed by these invariants:
 #### Normal reconciliation
 
 Before processing nodes, the controller groups the compiled DAG into reverse
-topological layers. Regular managed resources receive the node ID and the
-layer's one-based apply order as controller-owned labels. Every expanded member
-of a `forEach` collection receives the same order because the collection is one
-graph node. External references and external collections participate in layer
-calculation but are observed rather than applied and receive no apply-order
-label.
+topological layers. Regular managed resources receive a node ID label and the
+layer's one-based apply order as a controller-owned annotation. Every expanded
+member of a `forEach` collection receives the same order because the collection
+is one graph node. External references and external collections participate in
+layer calculation but are observed rather than applied and receive no
+apply-order annotation.
 
-The existing server-side apply path writes the label alongside the desired
-resource. This also backfills an unchanged child: SSA still submits controller
-metadata even when the resource spec has not changed. A later successful
-reconcile against a new GraphRevision can update an object's order. An object
-removed from the graph keeps its last persisted order until normal pruning
-deletes it.
+The existing server-side apply path writes the annotation alongside the
+desired resource. This also backfills an unchanged child: SSA still submits
+controller metadata even when the resource spec has not changed. A later
+successful reconcile against a new GraphRevision can update an object's order.
+An object removed from the graph keeps its last persisted order until normal
+pruning deletes it.
 
-Both `kro.run/` and `internal.kro.run/` are reserved label prefixes in resource
-templates. RGD authors therefore cannot override the node identity or deletion
-order owned by the controller.
+Both `kro.run/` and `internal.kro.run/` are reserved label and annotation
+prefixes in resource templates. RGD authors therefore cannot override the node
+identity or deletion order owned by the controller.
 
 The write that first installs the instance finalizer also creates a valid empty
 ApplySet inventory when none exists. If the instance already has valid
@@ -144,16 +144,17 @@ precedence so cleanup failures remain observable.
 
 When an instance controller registers a GVR at startup, it explicitly enqueues
 the instances already present in its cache. Healthy, unsuspended instances
-therefore run normal reconciliation and acquire the order label through SSA,
+therefore run normal reconciliation and acquire the order annotation through SSA,
 even when their child specs are unchanged. This proposal adds neither a
 separate migration job nor a forced restart loop.
 
 Some instances can miss that backfill. An instance already deleting when the
 new version starts bypasses normal child apply. Suspended instances, instances
 whose desired resources cannot resolve, and instances deleted before startup
-reconciliation completes can also retain unlabeled children. Deletion still
-processes every labeled wave in reverse order, then deletes all remaining
-unlabeled or invalidly labeled children in the shared fallback wave.
+reconciliation completes can also retain children without the annotation.
+Deletion still processes every annotated wave in reverse order, then deletes
+all remaining children with missing or invalid annotations in the shared
+fallback wave.
 
 This compatibility behavior deliberately prioritizes deletion liveness over
 reverse-order guarantees for resources whose historical order was never
@@ -218,11 +219,13 @@ order that may be wrong.
 
 - Persisting reverse topological deletion waves on regular and collection
   resources.
-- Reserving the public and internal kro label prefixes in RGD templates.
+- Reserving the public and internal kro label and annotation prefixes in RGD
+  templates.
 - ApplySet-inventory discovery for instance deletion.
 - Validation and checksumming of persisted ApplySet deletion inventory.
 - Strict, UID-preconditioned, highest-order deletion waves.
-- A final compatibility wave for resources that missed order-label backfill.
+- A final compatibility wave for resources that missed order-annotation
+  backfill.
 - Unit and focused integration coverage for the lifecycle.
 
 #### What is not in scope?
@@ -246,16 +249,16 @@ timing-dependent.
 #### Test plan
 
 Unit tests verify regular-resource order, shared collection order, external
-exclusion, SSA label application to existing objects, and validation of both
-reserved prefixes. ApplySet tests cover namespaced and cluster-scoped discovery
-from parent annotations, including older resources no longer represented by the
-current graph.
+exclusion, SSA annotation application to existing objects, and validation of
+both reserved prefixes. ApplySet tests cover namespaced and cluster-scoped
+discovery from parent annotations, including older resources no longer
+represented by the current graph.
 
 Deletion unit tests verify that only the highest remaining order receives
 DELETE, a terminating highest-order resource blocks lower orders, the next wave
 starts only after the higher wave disappears, and all resources at one order
 are handled together. They also cover empty-inventory finalizer removal;
-missing, malformed, zero, and negative labels in a shared final wave; DELETE
+missing, malformed, zero, and negative annotations in a shared final wave; DELETE
 error visibility; invalid-inventory finalizer retention; UID-conflict requeue;
 and deletion with an absent external reference.
 

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -120,14 +120,10 @@ to advance. Only a later reconciliation that observes no higher-order members
 can begin the next order. Empty inventory is the sole condition for removing
 the root finalizer and cleaning up coordinator watches.
 
-Node status during deletion is derived without CEL:
-
-- External nodes are Skipped.
-- Current managed nodes represented by any live candidate are Deleting,
-  including lower-order nodes that have not received DELETE yet.
-- Current managed nodes with no candidates are Deleted.
-- A DELETE error marks the relevant current node Error when its node ID is
-  available.
+Deletion status is intentionally instance-level. The runtime-free path cannot
+derive meaningful current-graph node states, and those transient states were
+never persisted independently. `ResourcesReady=Unknown` with reason
+`UnderDeletion` reports progress or the error currently blocking deletion.
 
 #### Rollout behavior
 
@@ -154,7 +150,9 @@ is available.
 
 ApplySet LIST failures and RESTMapping failures retain the root finalizer and
 retry through normal reconciliation error handling. DELETE errors retain the
-finalizer and propagate through the instance-level status. A UID precondition
+finalizer and propagate through the instance-level status. Inventory, LIST,
+DELETE, and UID-conflict errors replace the generic deletion-progress message
+with an actionable `ResourcesReady` condition message. A UID precondition
 conflict causes a delayed requeue with the active wave unchanged.
 
 Deletion validates the ApplySet parent ID, kro tooling ownership, and the
@@ -207,6 +205,7 @@ order that may be wrong.
   resources.
 - Reserving the public and internal kro label prefixes in RGD templates.
 - ApplySet-inventory discovery for instance deletion.
+- Validation and checksumming of persisted ApplySet deletion inventory.
 - Strict, UID-preconditioned, highest-order deletion waves.
 - A final compatibility wave for resources that missed order-label backfill.
 - Unit and focused integration coverage for the lifecycle.
@@ -230,8 +229,9 @@ missed backfills, or change normal orphan-pruning order.
 Fake-client deletion fixtures carry a stable UID, the computed
 `applyset.kubernetes.io/part-of` value, `kro.run/node-id`, and
 `internal.kro.run/apply-order`. Their parent instance carries the ApplySet
-group-kind and namespace annotations. Integration tests use synthetic child
-finalizers to make ordering observable rather than timing-dependent.
+parent ID, tooling, group-kind, and namespace metadata. Integration tests use
+synthetic child finalizers to make ordering observable rather than
+timing-dependent.
 
 #### Test plan
 
@@ -246,8 +246,8 @@ DELETE, a terminating highest-order resource blocks lower orders, the next wave
 starts only after the higher wave disappears, and all resources at one order
 are handled together. They also cover empty-inventory finalizer removal;
 missing, malformed, zero, and negative labels in a shared final wave; DELETE
-error state; UID-conflict requeue; and deletion with an absent external
-reference.
+error visibility; invalid-inventory finalizer retention; UID-conflict requeue;
+and deletion with an absent external reference.
 
 The core integration suite reproduces #1316 by creating an external ConfigMap
 and a managed child derived from it, asserting the child's persisted order,

--- a/docs/design/proposals/ordered-instance-deletion.md
+++ b/docs/design/proposals/ordered-instance-deletion.md
@@ -88,13 +88,12 @@ The deletion path does not call `IsIgnored`, `GetDesired`,
 observation. Deletion is handled before compiled GraphRevision resolution.
 This is intentional: resolving the current revision can itself require
 unavailable dependencies or invalid CEL, which is exactly the failure mode in
-#1316. The early path only needs the parent object, persisted ApplySet
-annotations, and dynamic REST mappings. The tradeoff is that deletion status
-cannot describe current graph nodes when no revision can be resolved; the
-controller still reports the instance-level deleting condition and preserves
-the finalizer on inventory or deletion failures. Keeping deletion after graph
-resolution would preserve richer node status, but would leave the root
-finalizer stuck whenever resolution fails.
+#1316. The early path uses a dedicated runtime-free context containing only the
+parent object, persisted ApplySet annotations, dynamic client, and REST
+mappings. Deletion intentionally reports only instance-level status; it does
+not synthesize per-node states that cannot be persisted without a resolved
+runtime. Keeping deletion after graph resolution would preserve richer node
+status, but would leave the root finalizer stuck whenever resolution fails.
 
 #### Ordered deletion waves
 
@@ -155,8 +154,8 @@ is available.
 
 ApplySet LIST failures and RESTMapping failures retain the root finalizer and
 retry through normal reconciliation error handling. DELETE errors retain the
-finalizer, mark the associated node Error when possible, and propagate. A UID
-precondition conflict causes a delayed requeue with the active wave unchanged.
+finalizer and propagate through the instance-level status. A UID precondition
+conflict causes a delayed requeue with the active wave unchanged.
 
 Deletion validates the ApplySet parent ID, kro tooling ownership, and the
 presence and syntax of the persisted group-kind and namespace annotations

--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -150,6 +150,7 @@ func (m Metadata) Annotations() map[string]string {
 		ApplySetToolingAnnotation:              m.Tooling,
 		ApplySetGKsAnnotation:                  m.GroupKindsString(),
 		ApplySetAdditionalNamespacesAnnotation: m.NamespacesString(),
+		ApplySetInventoryHashAnnotation:        inventoryHash(m.ID, m.GroupKinds, m.AdditionalNamespaces),
 	}
 }
 

--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -245,7 +245,10 @@ func (a *ApplySet) Project(resources []Resource) (Metadata, error) {
 	}
 
 	// Union with parent annotations (memory from previous reconciles)
-	parentGKs, parentNamespaces := a.parentAnnotationSets()
+	parentGKs, parentNamespaces, err := a.parentAnnotationSets()
+	if err != nil {
+		return Metadata{}, err
+	}
 	for gk := range parentGKs {
 		gks.Insert(gk)
 	}
@@ -572,43 +575,8 @@ func (a *ApplySet) listOrphans(
 	return candidates, nil
 }
 
-func (a *ApplySet) parentAnnotationSets() (sets.Set[schema.GroupKind], sets.Set[string]) {
-	gks := sets.New[schema.GroupKind]()
-	namespaces := sets.New[string]()
-
-	if len(a.parentAnnotations) == 0 {
-		return gks, namespaces
-	}
-
-	// Parse GKs from standard KEP annotation
-	if raw := a.parentAnnotations[ApplySetGKsAnnotation]; raw != "" {
-		for _, entry := range strings.Split(raw, ",") {
-			entry = strings.TrimSpace(entry)
-			if entry == "" {
-				continue
-			}
-			parts := strings.SplitN(entry, ".", 2)
-			gk := schema.GroupKind{Kind: parts[0]}
-			if len(parts) == 2 {
-				gk.Group = parts[1]
-			}
-			if gk.Kind != "" {
-				gks.Insert(gk)
-			}
-		}
-	}
-
-	if raw := a.parentAnnotations[ApplySetAdditionalNamespacesAnnotation]; raw != "" {
-		for _, entry := range strings.Split(raw, ",") {
-			entry = strings.TrimSpace(entry)
-			if entry == "" {
-				continue
-			}
-			namespaces.Insert(entry)
-		}
-	}
-
-	return gks, namespaces
+func (a *ApplySet) parentAnnotationSets() (sets.Set[schema.GroupKind], sets.Set[string], error) {
+	return parseParentAnnotationSets(a.parentAnnotations)
 }
 
 func (a *ApplySet) buildMetadata(

--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -457,14 +457,41 @@ func (a *ApplySet) ListOrphans(ctx context.Context, opts PruneOptions) ([]Orphan
 
 	mappings := make([]*meta.RESTMapping, 0, len(scopeGKs))
 	for gk := range scopeGKs {
-		mapping, err := a.restMapper.RESTMapping(gk)
+		mapping, err := a.restMappingForPrune(gk)
 		if err != nil {
 			return nil, fmt.Errorf("RESTMapping failed for %v: %w", gk, err)
+		}
+		if mapping == nil {
+			continue
 		}
 		mappings = append(mappings, mapping)
 	}
 
 	return a.listOrphans(ctx, mappings, scopeNamespaces, opts.KeepUIDs)
+}
+
+// restMappingForPrune refreshes stale discovery once before concluding that a
+// resource type no longer exists. A persistently missing type cannot have live
+// objects to list, so it no longer belongs in the prune search space. Other
+// mapping failures remain fatal because they do not establish that absence.
+func (a *ApplySet) restMappingForPrune(gk schema.GroupKind) (*meta.RESTMapping, error) {
+	mapping, err := a.restMapper.RESTMapping(gk)
+	if err == nil {
+		return mapping, nil
+	} else if !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+
+	meta.MaybeResetRESTMapper(a.restMapper)
+	mapping, err = a.restMapper.RESTMapping(gk)
+	if meta.IsNoMatchError(err) {
+		a.log.V(2).Info("skipping prune for missing resource type", "groupKind", gk)
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return mapping, nil
 }
 
 // DeleteOrphan deletes a single orphan candidate using a UID precondition

--- a/pkg/controller/instance/applyset/applyset_test.go
+++ b/pkg/controller/instance/applyset/applyset_test.go
@@ -1445,8 +1445,8 @@ func TestMetadata_Annotations(t *testing.T) {
 
 	annotations := m.Annotations()
 
-	if len(annotations) != 3 {
-		t.Errorf("Annotations() returned %d annotations, want 3", len(annotations))
+	if len(annotations) != 4 {
+		t.Errorf("Annotations() returned %d annotations, want 4", len(annotations))
 	}
 
 	if got := annotations[ApplySetToolingAnnotation]; got != "kro/v1.0.0" {
@@ -1459,6 +1459,9 @@ func TestMetadata_Annotations(t *testing.T) {
 
 	if got := annotations[ApplySetAdditionalNamespacesAnnotation]; got != "default" {
 		t.Errorf("Annotations()[%s] = %q, want %q", ApplySetAdditionalNamespacesAnnotation, got, "default")
+	}
+	if got := annotations[ApplySetInventoryHashAnnotation]; got == "" {
+		t.Errorf("Annotations()[%s] is empty", ApplySetInventoryHashAnnotation)
 	}
 }
 

--- a/pkg/controller/instance/applyset/applyset_test.go
+++ b/pkg/controller/instance/applyset/applyset_test.go
@@ -97,6 +97,23 @@ func newTestRESTMapper() meta.RESTMapper {
 	return mapper
 }
 
+type resettableTestRESTMapper struct {
+	meta.RESTMapper
+	restMapping func(schema.GroupKind, ...string) (*meta.RESTMapping, error)
+	resetCount  int
+}
+
+func (m *resettableTestRESTMapper) RESTMapping(
+	gk schema.GroupKind,
+	versions ...string,
+) (*meta.RESTMapping, error) {
+	return m.restMapping(gk, versions...)
+}
+
+func (m *resettableTestRESTMapper) Reset() {
+	m.resetCount++
+}
+
 func newConfigMap(name, namespace string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -611,6 +628,115 @@ func TestPrune(t *testing.T) {
 				t.Errorf("Prune() pruned %d resources, want %d", len(pruned), tt.wantPruned)
 			}
 		})
+	}
+}
+
+func TestListOrphansRefreshesNoMatchErrors(t *testing.T) {
+	gk := schema.GroupKind{Kind: "ConfigMap"}
+	delegate := newTestRESTMapper()
+	mapper := &resettableTestRESTMapper{RESTMapper: delegate}
+	mapper.restMapping = func(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+		if mapper.resetCount == 0 {
+			return nil, &meta.NoKindMatchError{GroupKind: gk}
+		}
+		return delegate.RESTMapping(gk, versions...)
+	}
+
+	applier := New(Config{
+		Client:          newFakeDynamicClient(),
+		RESTMapper:      mapper,
+		Log:             logr.Discard(),
+		ParentNamespace: "default",
+	}, newTestParent(schema.GroupVersionKind{
+		Group: "kro.run", Version: "v1alpha1", Kind: "TestKind",
+	}))
+
+	candidates, err := applier.ListOrphans(t.Context(), PruneOptions{
+		KeepUIDs: sets.New[types.UID](),
+		Scope: &PruneScope{
+			GroupKinds: sets.New(gk),
+			Namespaces: sets.New("default"),
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("ListOrphans() error = %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("ListOrphans() returned %d candidates, want 0", len(candidates))
+	}
+	if mapper.resetCount != 1 {
+		t.Fatalf("REST mapper reset %d times, want 1", mapper.resetCount)
+	}
+}
+
+func TestListOrphansSkipsPersistentlyMissingTypes(t *testing.T) {
+	parent := newTestParent(schema.GroupVersionKind{
+		Group: "kro.run", Version: "v1alpha1", Kind: "TestKind",
+	})
+	orphan := newConfigMap("orphan", "default")
+	orphan.SetLabels(map[string]string{ApplysetPartOfLabel: ID(parent)})
+
+	delegate := newTestRESTMapper()
+	mapper := &resettableTestRESTMapper{RESTMapper: delegate}
+	mapper.restMapping = delegate.RESTMapping
+	applier := New(Config{
+		Client:          newFakeDynamicClient(orphan),
+		RESTMapper:      mapper,
+		Log:             logr.Discard(),
+		ParentNamespace: "default",
+	}, parent)
+
+	candidates, err := applier.ListOrphans(t.Context(), PruneOptions{
+		KeepUIDs: sets.New[types.UID](),
+		Scope: &PruneScope{
+			GroupKinds: sets.New(
+				schema.GroupKind{Kind: "ConfigMap"},
+				schema.GroupKind{Group: "example.com", Kind: "RemovedKind"},
+			),
+			Namespaces: sets.New("default"),
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("ListOrphans() error = %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Object.GetName() != "orphan" {
+		t.Fatalf("ListOrphans() candidates = %#v, want orphan ConfigMap", candidates)
+	}
+	if mapper.resetCount != 1 {
+		t.Fatalf("REST mapper reset %d times, want 1", mapper.resetCount)
+	}
+}
+
+func TestListOrphansReturnsOtherMappingErrors(t *testing.T) {
+	wantErr := errors.New("discovery unavailable")
+	mapper := &resettableTestRESTMapper{RESTMapper: newTestRESTMapper()}
+	mapper.restMapping = func(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+		return nil, wantErr
+	}
+	applier := New(Config{
+		Client:          newFakeDynamicClient(),
+		RESTMapper:      mapper,
+		Log:             logr.Discard(),
+		ParentNamespace: "default",
+	}, newTestParent(schema.GroupVersionKind{
+		Group: "kro.run", Version: "v1alpha1", Kind: "TestKind",
+	}))
+
+	_, err := applier.ListOrphans(t.Context(), PruneOptions{
+		KeepUIDs: sets.New[types.UID](),
+		Scope: &PruneScope{
+			GroupKinds: sets.New(schema.GroupKind{Kind: "ConfigMap"}),
+			Namespaces: sets.New("default"),
+		},
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ListOrphans() error = %v, want %v", err, wantErr)
+	}
+	if mapper.resetCount != 0 {
+		t.Fatalf("REST mapper reset %d times, want 0", mapper.resetCount)
 	}
 }
 

--- a/pkg/controller/instance/applyset/const.go
+++ b/pkg/controller/instance/applyset/const.go
@@ -84,6 +84,10 @@ const (
 	// Example value: "ConfigMap,Deployment.apps,Service"
 	ApplySetGKsAnnotation = "applyset.kubernetes.io/contains-group-kinds"
 
+	// ApplySetInventoryHashAnnotation detects accidental mutation of the
+	// persisted group-kind and namespace inventory used during deletion.
+	ApplySetInventoryHashAnnotation = "internal.kro.run/applyset-inventory-hash"
+
 	// ApplySetParentIDLabel is the key of the label that makes object an ApplySet parent object.
 	// Its value MUST use the format specified in V1ApplySetIdFormat below.
 	ApplySetParentIDLabel = "applyset.kubernetes.io/id"

--- a/pkg/controller/instance/applyset/inventory.go
+++ b/pkg/controller/instance/applyset/inventory.go
@@ -1,0 +1,139 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applyset
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+type parentObject interface {
+	metav1.Object
+	schema.ObjectKind
+}
+
+// ValidateParentInventory checks the persisted ApplySet metadata that is the
+// authoritative resource-discovery scope during deletion. An empty inventory
+// is valid, but its annotation keys must still be present.
+func ValidateParentInventory(parent parentObject) error {
+	expectedID := ID(parent)
+	if actual := parent.GetLabels()[ApplySetParentIDLabel]; actual != expectedID {
+		return fmt.Errorf("invalid %s label: got %q, want %q", ApplySetParentIDLabel, actual, expectedID)
+	}
+
+	annotations := parent.GetAnnotations()
+	tooling, exists := annotations[ApplySetToolingAnnotation]
+	if !exists || !strings.HasPrefix(tooling, "kro/") {
+		return fmt.Errorf("invalid %s annotation: %q is not owned by kro", ApplySetToolingAnnotation, tooling)
+	}
+
+	rawGroupKinds, exists := annotations[ApplySetGKsAnnotation]
+	if !exists {
+		return fmt.Errorf("missing required %s annotation", ApplySetGKsAnnotation)
+	}
+	groupKinds, err := parseGroupKinds(rawGroupKinds)
+	if err != nil {
+		return fmt.Errorf("invalid %s annotation: %w", ApplySetGKsAnnotation, err)
+	}
+
+	rawNamespaces, exists := annotations[ApplySetAdditionalNamespacesAnnotation]
+	if !exists {
+		return fmt.Errorf("missing required %s annotation", ApplySetAdditionalNamespacesAnnotation)
+	}
+	namespaces, err := parseNamespaces(rawNamespaces)
+	if err != nil {
+		return fmt.Errorf("invalid %s annotation: %w", ApplySetAdditionalNamespacesAnnotation, err)
+	}
+
+	// The hash is optional for ApplySet parents created by earlier kro
+	// versions. Normal reconciliation backfills it before applying children.
+	if actual, exists := annotations[ApplySetInventoryHashAnnotation]; exists {
+		expected := inventoryHash(expectedID, groupKinds, namespaces)
+		if actual != expected {
+			return fmt.Errorf("invalid %s annotation: got %q, want %q", ApplySetInventoryHashAnnotation, actual, expected)
+		}
+	}
+	return nil
+}
+
+func parseGroupKinds(raw string) (sets.Set[schema.GroupKind], error) {
+	result := sets.New[schema.GroupKind]()
+	if raw == "" {
+		return result, nil
+	}
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			return nil, fmt.Errorf("contains an empty group-kind")
+		}
+		parts := strings.SplitN(entry, ".", 2)
+		if parts[0] == "" || strings.ContainsAny(parts[0], " \t\r\n") {
+			return nil, fmt.Errorf("invalid kind %q", parts[0])
+		}
+		gk := schema.GroupKind{Kind: parts[0]}
+		if len(parts) == 2 {
+			if problems := validation.IsDNS1123Subdomain(parts[1]); len(problems) > 0 {
+				return nil, fmt.Errorf("invalid group %q: %s", parts[1], strings.Join(problems, ", "))
+			}
+			gk.Group = parts[1]
+		}
+		result.Insert(gk)
+	}
+	return result, nil
+}
+
+func parseNamespaces(raw string) (sets.Set[string], error) {
+	result := sets.New[string]()
+	if raw == "" {
+		return result, nil
+	}
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if problems := validation.IsDNS1123Label(entry); len(problems) > 0 {
+			return nil, fmt.Errorf("invalid namespace %q: %s", entry, strings.Join(problems, ", "))
+		}
+		result.Insert(entry)
+	}
+	return result, nil
+}
+
+func inventoryHash(
+	id string,
+	groupKinds sets.Set[schema.GroupKind],
+	namespaces sets.Set[string],
+) string {
+	gkStrings := make([]string, 0, groupKinds.Len())
+	for gk := range groupKinds {
+		value := gk.Kind
+		if gk.Group != "" {
+			value += "." + gk.Group
+		}
+		gkStrings = append(gkStrings, value)
+	}
+	sort.Strings(gkStrings)
+	nsStrings := namespaces.UnsortedList()
+	sort.Strings(nsStrings)
+	payload := strings.Join([]string{id, strings.Join(gkStrings, ","), strings.Join(nsStrings, ",")}, "\x00")
+	sum := sha256.Sum256([]byte(payload))
+	return "sha256:" + base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/pkg/controller/instance/applyset/inventory.go
+++ b/pkg/controller/instance/applyset/inventory.go
@@ -47,22 +47,16 @@ func ValidateParentInventory(parent parentObject) error {
 		return fmt.Errorf("invalid %s annotation: %q is not owned by kro", ApplySetToolingAnnotation, tooling)
 	}
 
-	rawGroupKinds, exists := annotations[ApplySetGKsAnnotation]
-	if !exists {
+	if _, exists := annotations[ApplySetGKsAnnotation]; !exists {
 		return fmt.Errorf("missing required %s annotation", ApplySetGKsAnnotation)
 	}
-	groupKinds, err := parseGroupKinds(rawGroupKinds)
-	if err != nil {
-		return fmt.Errorf("invalid %s annotation: %w", ApplySetGKsAnnotation, err)
-	}
-
-	rawNamespaces, exists := annotations[ApplySetAdditionalNamespacesAnnotation]
-	if !exists {
+	if _, exists := annotations[ApplySetAdditionalNamespacesAnnotation]; !exists {
 		return fmt.Errorf("missing required %s annotation", ApplySetAdditionalNamespacesAnnotation)
 	}
-	namespaces, err := parseNamespaces(rawNamespaces)
+
+	groupKinds, namespaces, err := parseParentAnnotationSets(annotations)
 	if err != nil {
-		return fmt.Errorf("invalid %s annotation: %w", ApplySetAdditionalNamespacesAnnotation, err)
+		return err
 	}
 
 	// The hash is optional for ApplySet parents created by earlier kro
@@ -74,6 +68,22 @@ func ValidateParentInventory(parent parentObject) error {
 		}
 	}
 	return nil
+}
+
+// parseParentAnnotationSets is the single parser for the persisted ApplySet
+// discovery scope used by both normal projection and deletion validation.
+func parseParentAnnotationSets(
+	annotations map[string]string,
+) (sets.Set[schema.GroupKind], sets.Set[string], error) {
+	groupKinds, err := parseGroupKinds(annotations[ApplySetGKsAnnotation])
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid %s annotation: %w", ApplySetGKsAnnotation, err)
+	}
+	namespaces, err := parseNamespaces(annotations[ApplySetAdditionalNamespacesAnnotation])
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid %s annotation: %w", ApplySetAdditionalNamespacesAnnotation, err)
+	}
+	return groupKinds, namespaces, nil
 }
 
 func parseGroupKinds(raw string) (sets.Set[schema.GroupKind], error) {

--- a/pkg/controller/instance/applyset/inventory_test.go
+++ b/pkg/controller/instance/applyset/inventory_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applyset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func validInventoryParent() *testParent {
+	parent := newTestParent(schema.GroupVersionKind{
+		Group: "kro.run", Version: "v1alpha1", Kind: "TestKind",
+	})
+	metadata := Metadata{
+		ID:                   ID(parent),
+		Tooling:              "kro/v1.0.0",
+		GroupKinds:           sets.New(schema.GroupKind{Kind: "ConfigMap"}),
+		AdditionalNamespaces: sets.New("other-ns"),
+	}
+	parent.SetLabels(metadata.Labels())
+	parent.SetAnnotations(metadata.Annotations())
+	return parent
+}
+
+func TestValidateParentInventory(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*testParent)
+		wantError string
+	}{
+		{name: "valid"},
+		{
+			name: "legacy parent without hash",
+			mutate: func(parent *testParent) {
+				delete(parent.Annotations, ApplySetInventoryHashAnnotation)
+			},
+		},
+		{
+			name: "wrong parent ID",
+			mutate: func(parent *testParent) {
+				parent.Labels[ApplySetParentIDLabel] = "applyset-wrong-v1"
+			},
+			wantError: ApplySetParentIDLabel,
+		},
+		{
+			name: "foreign tooling",
+			mutate: func(parent *testParent) {
+				parent.Annotations[ApplySetToolingAnnotation] = "other/v1"
+			},
+			wantError: ApplySetToolingAnnotation,
+		},
+		{
+			name: "missing group kinds",
+			mutate: func(parent *testParent) {
+				delete(parent.Annotations, ApplySetGKsAnnotation)
+			},
+			wantError: ApplySetGKsAnnotation,
+		},
+		{
+			name: "missing namespaces",
+			mutate: func(parent *testParent) {
+				delete(parent.Annotations, ApplySetAdditionalNamespacesAnnotation)
+			},
+			wantError: ApplySetAdditionalNamespacesAnnotation,
+		},
+		{
+			name: "malformed group kinds",
+			mutate: func(parent *testParent) {
+				parent.Annotations[ApplySetGKsAnnotation] = "ConfigMap,"
+			},
+			wantError: ApplySetGKsAnnotation,
+		},
+		{
+			name: "malformed namespace",
+			mutate: func(parent *testParent) {
+				parent.Annotations[ApplySetAdditionalNamespacesAnnotation] = "NOT_A_NAMESPACE"
+			},
+			wantError: ApplySetAdditionalNamespacesAnnotation,
+		},
+		{
+			name: "inventory hash mismatch",
+			mutate: func(parent *testParent) {
+				parent.Annotations[ApplySetGKsAnnotation] = "ConfigMap,Secret"
+			},
+			wantError: ApplySetInventoryHashAnnotation,
+		},
+		{
+			name: "explicit empty inventory",
+			mutate: func(parent *testParent) {
+				metadata := Metadata{ID: ID(parent), Tooling: "kro/v1.0.0"}
+				parent.SetLabels(metadata.Labels())
+				parent.SetAnnotations(metadata.Annotations())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := validInventoryParent()
+			if tt.mutate != nil {
+				tt.mutate(parent)
+			}
+			err := ValidateParentInventory(parent)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+}

--- a/pkg/controller/instance/applyset/inventory_test.go
+++ b/pkg/controller/instance/applyset/inventory_test.go
@@ -17,6 +17,7 @@ package applyset
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,6 +37,21 @@ func validInventoryParent() *testParent {
 	parent.SetLabels(metadata.Labels())
 	parent.SetAnnotations(metadata.Annotations())
 	return parent
+}
+
+func TestProjectRejectsMalformedParentInventory(t *testing.T) {
+	parent := validInventoryParent()
+	parent.Annotations[ApplySetGKsAnnotation] = "ConfigMap,"
+	applier := New(Config{
+		Client:          newFakeDynamicClient(),
+		RESTMapper:      newTestRESTMapper(),
+		Log:             logr.Discard(),
+		ParentNamespace: "default",
+	}, parent)
+
+	_, err := applier.Project(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ApplySetGKsAnnotation)
 }
 
 func TestValidateParentInventory(t *testing.T) {

--- a/pkg/controller/instance/context.go
+++ b/pkg/controller/instance/context.go
@@ -99,9 +99,6 @@ func NewReconcileContext(
 	config ReconcileConfig,
 	instance *unstructured.Unstructured,
 ) *ReconcileContext {
-	if rt == nil {
-		panic("NewReconcileContext requires a runtime; use NewDeletionContext for deletion")
-	}
 	return &ReconcileContext{
 		Ctx:        ctx,
 		Log:        log,

--- a/pkg/controller/instance/context.go
+++ b/pkg/controller/instance/context.go
@@ -57,6 +57,28 @@ type ReconcileContext struct {
 	Watcher dynamiccontroller.InstanceWatcher
 }
 
+// DeletionContext contains only the dependencies available to the early
+// deletion path. In particular, it has no runtime: deletion must remain
+// independent of GraphRevision resolution and CEL evaluation.
+type DeletionContext struct {
+	Ctx context.Context
+	Log logr.Logger
+
+	GVR        schema.GroupVersionResource
+	Namespaced bool
+	Client     dynamic.Interface
+	RestMapper meta.RESTMapper
+
+	Instance *unstructured.Unstructured
+	Config   ReconcileConfig
+
+	WireStatus map[string]interface{}
+
+	Mark         *ConditionsMarker
+	StateManager *StateManager
+	Watcher      dynamiccontroller.InstanceWatcher
+}
+
 // NewReconcileContext constructs a ReconcileContext for a single reconciliation cycle.
 // It bundles all dependencies needed to reconcile an instance's resources:
 //   - client/restMapper: for Kubernetes API operations
@@ -78,6 +100,9 @@ func NewReconcileContext(
 	config ReconcileConfig,
 	instance *unstructured.Unstructured,
 ) *ReconcileContext {
+	if rt == nil {
+		panic("NewReconcileContext requires a runtime; use NewDeletionContext for deletion")
+	}
 	return &ReconcileContext{
 		Ctx:        ctx,
 		Log:        log,
@@ -97,6 +122,33 @@ func NewReconcileContext(
 	}
 }
 
+// NewDeletionContext constructs the runtime-free context used before graph
+// resolution when an instance has a deletion timestamp.
+func NewDeletionContext(
+	ctx context.Context,
+	log logr.Logger,
+	gvr schema.GroupVersionResource,
+	namespaced bool,
+	client dynamic.Interface,
+	restMapper meta.RESTMapper,
+	config ReconcileConfig,
+	instance *unstructured.Unstructured,
+) *DeletionContext {
+	return &DeletionContext{
+		Ctx:          ctx,
+		Log:          log,
+		GVR:          gvr,
+		Namespaced:   namespaced,
+		Client:       client,
+		RestMapper:   restMapper,
+		Instance:     instance,
+		Config:       config,
+		WireStatus:   captureWireStatus(instance),
+		Mark:         NewConditionsMarkerFor(instance),
+		StateManager: newStateManager(),
+	}
+}
+
 // rebindInstance replaces rcx.Instance with a fresh server response (e.g.
 // after an SSA patch), re-capturing the wire status before the condition
 // marker mutates the new object.
@@ -104,6 +156,12 @@ func (rcx *ReconcileContext) rebindInstance(instance *unstructured.Unstructured)
 	rcx.Instance = instance
 	rcx.WireStatus = captureWireStatus(instance)
 	rcx.Mark = NewConditionsMarkerFor(instance)
+}
+
+func (dcx *DeletionContext) rebindInstance(instance *unstructured.Unstructured) {
+	dcx.Instance = instance
+	dcx.WireStatus = captureWireStatus(instance)
+	dcx.Mark = NewConditionsMarkerFor(instance)
 }
 
 // captureWireStatus deep-copies the instance's .status subtree.
@@ -119,10 +177,25 @@ func (rcx *ReconcileContext) delayedRequeue(err error) error {
 	return requeue.NeededAfter(err, rcx.Config.DefaultRequeueDuration)
 }
 
+func (dcx *DeletionContext) delayedRequeue(err error) error {
+	if dcx.Config.DefaultRequeueDuration == 0 {
+		return requeue.None(err)
+	}
+	return requeue.NeededAfter(err, dcx.Config.DefaultRequeueDuration)
+}
+
 func (rcx *ReconcileContext) InstanceClient() dynamic.ResourceInterface {
 	base := rcx.Client.Resource(rcx.GVR)
 	if rcx.Namespaced {
 		return base.Namespace(rcx.Instance.GetNamespace())
+	}
+	return base
+}
+
+func (dcx *DeletionContext) InstanceClient() dynamic.ResourceInterface {
+	base := dcx.Client.Resource(dcx.GVR)
+	if dcx.Namespaced {
+		return base.Namespace(dcx.Instance.GetNamespace())
 	}
 	return base
 }

--- a/pkg/controller/instance/context.go
+++ b/pkg/controller/instance/context.go
@@ -76,7 +76,6 @@ type DeletionContext struct {
 
 	Mark         *ConditionsMarker
 	StateManager *StateManager
-	Watcher      dynamiccontroller.InstanceWatcher
 }
 
 // NewReconcileContext constructs a ReconcileContext for a single reconciliation cycle.

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -228,7 +228,10 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	// Deletion must not depend on resolving the current GraphRevision or CEL.
 	// Build a context without a runtime and use persisted ApplySet inventory.
 	if inst.GetDeletionTimestamp() != nil {
-		rcx = NewReconcileContext(ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(), c.childResourceLabeler, nil, c.reconcileConfig, inst)
+		rcx = NewReconcileContext(
+			ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(),
+			c.childResourceLabeler, nil, c.reconcileConfig, inst,
+		)
 		rcx.Watcher = watcher
 		if err := c.reconcileDeletion(rcx); err != nil {
 			_ = c.updateStatus(rcx)

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -225,6 +225,18 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		}()
 	}
 
+	// Deletion must not depend on resolving the current GraphRevision or CEL.
+	// Build a context without a runtime and use persisted ApplySet inventory.
+	if inst.GetDeletionTimestamp() != nil {
+		rcx = NewReconcileContext(ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(), c.childResourceLabeler, nil, c.reconcileConfig, inst)
+		rcx.Watcher = watcher
+		if err := c.reconcileDeletion(rcx); err != nil {
+			_ = c.updateStatus(rcx)
+			return err
+		}
+		return c.updateStatus(rcx)
+	}
+
 	//--------------------------------------------------------------
 	// 2. Create a fresh runtime for this reconciliation
 	//--------------------------------------------------------------
@@ -258,17 +270,6 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		inst,
 	)
 	rcx.Watcher = watcher
-
-	//--------------------------------------------------------------
-	// 4. Handle deletion: clean up children and status
-	//--------------------------------------------------------------
-	if inst.GetDeletionTimestamp() != nil {
-		if err := c.reconcileDeletion(rcx); err != nil {
-			_ = c.updateStatus(rcx)
-			return err
-		}
-		return c.updateStatus(rcx)
-	}
 
 	//--------------------------------------------------------------
 	// 5. Ensure finalizer + management labels before mutating children

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -401,7 +401,7 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 	// Fast path: if everything is already correct → no patch
 	hasFinalizer := metadata.HasInstanceFinalizer(obj)
 	needFinalizer := !hasFinalizer
-	hasInventoryMetadata := hasApplySetInventoryMetadata(obj)
+	hasInventoryMetadata := hasAnyApplySetInventoryMetadata(obj)
 	if needFinalizer && hasInventoryMetadata {
 		if err := applyset.ValidateParentInventory(obj); err != nil {
 			return nil, fmt.Errorf(
@@ -466,7 +466,10 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 	return patched, nil
 }
 
-func hasApplySetInventoryMetadata(obj metav1.Object) bool {
+// hasAnyApplySetInventoryMetadata deliberately detects partial inventory. If
+// any field exists, the caller validates the complete inventory instead of
+// replacing it with an empty one, which could hide and orphan managed members.
+func hasAnyApplySetInventoryMetadata(obj metav1.Object) bool {
 	if _, found := obj.GetLabels()[applyset.ApplySetParentIDLabel]; found {
 		return true
 	}

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -204,11 +204,14 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	// Events and metrics are gated behind separate feature flags so operators
 	// can enable them independently.
 	var rcx *ReconcileContext
+	var dcx *DeletionContext
 	if c.eventsEnabled || c.metricsEnabled {
 		initialConditions := conditionsFromInstance(inst)
 		defer func() {
 			obj := inst
-			if rcx != nil {
+			if dcx != nil {
+				obj = dcx.Instance
+			} else if rcx != nil {
 				obj = rcx.Instance
 			}
 			finalConditions := conditionsFromInstance(obj)
@@ -227,16 +230,16 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	// Deletion must not depend on resolving the current GraphRevision or CEL.
 	// Build a context without a runtime and use persisted ApplySet inventory.
 	if inst.GetDeletionTimestamp() != nil {
-		rcx = NewReconcileContext(
+		dcx = NewDeletionContext(
 			ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(),
-			c.childResourceLabeler, nil, c.reconcileConfig, inst,
+			c.reconcileConfig, inst,
 		)
-		rcx.Watcher = watcher
-		if err := c.reconcileDeletion(rcx); err != nil {
-			_ = c.updateStatus(rcx)
+		dcx.Watcher = watcher
+		if err := c.reconcileDeletion(dcx); err != nil {
+			_ = c.updateDeletionStatus(dcx)
 			return err
 		}
-		return c.updateStatus(rcx)
+		return c.updateDeletionStatus(dcx)
 	}
 
 	//--------------------------------------------------------------

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -221,6 +221,18 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		}()
 	}
 
+	// Deletion must not depend on resolving the current GraphRevision or CEL.
+	// Build a context without a runtime and use persisted ApplySet inventory.
+	if inst.GetDeletionTimestamp() != nil {
+		rcx = NewReconcileContext(ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(), c.childResourceLabeler, nil, c.reconcileConfig, inst)
+		rcx.Watcher = watcher
+		if err := c.reconcileDeletion(rcx); err != nil {
+			_ = c.updateStatus(rcx)
+			return err
+		}
+		return c.updateStatus(rcx)
+	}
+
 	//--------------------------------------------------------------
 	// 2. Create a fresh runtime for this reconciliation
 	//--------------------------------------------------------------
@@ -254,17 +266,6 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		inst,
 	)
 	rcx.Watcher = watcher
-
-	//--------------------------------------------------------------
-	// 4. Handle deletion: clean up children and status
-	//--------------------------------------------------------------
-	if inst.GetDeletionTimestamp() != nil {
-		if err := c.reconcileDeletion(rcx); err != nil {
-			_ = c.updateStatus(rcx)
-			return err
-		}
-		return c.updateStatus(rcx)
-	}
 
 	//--------------------------------------------------------------
 	// 5. Ensure finalizer + management labels before mutating children

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -259,6 +259,11 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		log.Error(err, "failed to create runtime")
 		return err
 	}
+	if runtimeObj == nil {
+		err := errors.New("runtime creation returned nil without an error")
+		log.Error(err, "failed to create runtime")
+		return err
+	}
 
 	//--------------------------------------------------------------
 	// 4. Build reconciliation context (clients, mapper, labeler, runtime)

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -221,6 +221,9 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 		}()
 	}
 
+	//--------------------------------------------------------------
+	// 2. Handle deletion before graph resolution
+	//--------------------------------------------------------------
 	// Deletion must not depend on resolving the current GraphRevision or CEL.
 	// Build a context without a runtime and use persisted ApplySet inventory.
 	if inst.GetDeletionTimestamp() != nil {
@@ -237,7 +240,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	}
 
 	//--------------------------------------------------------------
-	// 2. Create a fresh runtime for this reconciliation
+	// 3. Create a fresh runtime for this reconciliation
 	//--------------------------------------------------------------
 	compiledGraph, err := c.resolveCompiledGraph()
 	if err != nil {
@@ -256,7 +259,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	}
 
 	//--------------------------------------------------------------
-	// 3. Build reconciliation context (clients, mapper, labeler, runtime)
+	// 4. Build reconciliation context (clients, mapper, labeler, runtime)
 	//--------------------------------------------------------------
 	rcx = NewReconcileContext(
 		ctx, log, c.gvr,

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -224,7 +224,10 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 	// Deletion must not depend on resolving the current GraphRevision or CEL.
 	// Build a context without a runtime and use persisted ApplySet inventory.
 	if inst.GetDeletionTimestamp() != nil {
-		rcx = NewReconcileContext(ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(), c.childResourceLabeler, nil, c.reconcileConfig, inst)
+		rcx = NewReconcileContext(
+			ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(),
+			c.childResourceLabeler, nil, c.reconcileConfig, inst,
+		)
 		rcx.Watcher = watcher
 		if err := c.reconcileDeletion(rcx); err != nil {
 			_ = c.updateStatus(rcx)

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
 	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
@@ -400,6 +401,16 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 	// Fast path: if everything is already correct → no patch
 	hasFinalizer := metadata.HasInstanceFinalizer(obj)
 	needFinalizer := !hasFinalizer
+	hasInventoryMetadata := hasApplySetInventoryMetadata(obj)
+	if needFinalizer && hasInventoryMetadata {
+		if err := applyset.ValidateParentInventory(obj); err != nil {
+			return nil, fmt.Errorf(
+				"cannot install finalizer with invalid ApplySet inventory; repair the metadata, "+
+					"or remove it only after confirming no managed members remain: %w",
+				err,
+			)
+		}
+	}
 
 	wantLabels := c.instanceLabeler.Labels()
 	haveLabels := obj.GetLabels()
@@ -424,7 +435,19 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 	// Label + finalizers patch
 	// we patch together here because otherwise we could revert a previous patch
 	// result if only one of finalizers or labels change.
-	patch.SetLabels(maps.Clone(wantLabels))
+	patchLabels := maps.Clone(wantLabels)
+	if needFinalizer && !hasInventoryMetadata {
+		// Install a valid empty inventory in the same write as the finalizer.
+		// This guarantees that deletion can make progress even if normal
+		// reconciliation stops before projecting the first set of children.
+		emptyInventory := applyset.Metadata{
+			ID:      applyset.ID(obj),
+			Tooling: applyset.ToolingID(),
+		}
+		maps.Copy(patchLabels, emptyInventory.Labels())
+		patch.SetAnnotations(emptyInventory.Annotations())
+	}
+	patch.SetLabels(patchLabels)
 	metadata.SetInstanceFinalizer(patch)
 
 	patched, err := rcx.InstanceClient().Apply(
@@ -441,4 +464,22 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 	}
 
 	return patched, nil
+}
+
+func hasApplySetInventoryMetadata(obj metav1.Object) bool {
+	if _, found := obj.GetLabels()[applyset.ApplySetParentIDLabel]; found {
+		return true
+	}
+	annotations := obj.GetAnnotations()
+	for _, key := range []string{
+		applyset.ApplySetToolingAnnotation,
+		applyset.ApplySetGKsAnnotation,
+		applyset.ApplySetAdditionalNamespacesAnnotation,
+		applyset.ApplySetInventoryHashAnnotation,
+	} {
+		if _, found := annotations[key]; found {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -234,7 +234,6 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 			ctx, log, c.gvr, c.namespaced, c.client.Dynamic(), c.client.RESTMapper(),
 			c.reconcileConfig, inst,
 		)
-		dcx.Watcher = watcher
 		if err := c.reconcileDeletion(dcx); err != nil {
 			_ = c.updateDeletionStatus(dcx)
 			return err

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -620,10 +620,46 @@ func TestReconcileDeletionPreservesAuthorStatusWithoutRuntime(t *testing.T) {
 	assert.False(t, metadata.HasInstanceFinalizer(stored))
 	assert.Equal(t, "https://example.test", stored.Object["status"].(map[string]interface{})["endpoint"])
 	conditions := conditionsFromInstance(stored)
-	require.Len(t, conditions, 1)
-	assert.Equal(t, v1alpha1.ConditionType("AuthorHealthy"), conditions[0].Type)
-	require.NotNil(t, conditions[0].LastTransitionTime)
-	assert.Equal(t, "2026-01-01T00:00:00Z", conditions[0].LastTransitionTime.UTC().Format(time.RFC3339))
+	require.Len(t, conditions, 2)
+	authorHealthy := conditionByType(t, stored, "AuthorHealthy")
+	require.NotNil(t, authorHealthy.LastTransitionTime)
+	assert.Equal(t, "2026-01-01T00:00:00Z", authorHealthy.LastTransitionTime.UTC().Format(time.RFC3339))
+	resourcesReady := conditionByType(t, stored, ResourcesReady)
+	assert.Equal(t, metav1.ConditionUnknown, resourcesReady.Status)
+	assert.Equal(t, new("UnderDeletion"), resourcesReady.Reason)
+}
+
+func TestReconcileDeletionSurfacesErrorsWithAuthorConditions(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	metadata.SetInstanceFinalizer(instance)
+	instance.SetDeletionTimestamp(new(metav1.NewTime(time.Now())))
+	require.NoError(t, unstructured.SetNestedMap(instance.Object, map[string]interface{}{
+		"state": string(v1alpha1.InstanceStateActive),
+		"conditions": []interface{}{map[string]interface{}{
+			"type":               "AuthorHealthy",
+			"status":             "True",
+			"reason":             "Healthy",
+			"lastTransitionTime": "2026-01-01T00:00:00Z",
+		}},
+	}, "status"))
+
+	raw := newControllerTestDynamicClient(t, instance.DeepCopy())
+	controller, _ := newControllerUnderTest(t, raw, newTestGraph())
+	controller.reconcileConfig.HasAuthorConditions = true
+
+	err := controller.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()},
+	})
+	require.Error(t, err)
+
+	stored := getStoredParentObject(t, raw)
+	assert.True(t, metadata.HasInstanceFinalizer(stored))
+	assert.Equal(t, metav1.ConditionTrue, conditionByType(t, stored, "AuthorHealthy").Status)
+	resourcesReady := conditionByType(t, stored, ResourcesReady)
+	assert.Equal(t, metav1.ConditionUnknown, resourcesReady.Status)
+	require.NotNil(t, resourcesReady.Message)
+	assert.Contains(t, *resourcesReady.Message, "deletion blocked")
+	assert.Contains(t, *resourcesReady.Message, applyset.ApplySetParentIDLabel)
 }
 
 func TestReconcileResourceMutationRequestsRequeue(t *testing.T) {

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -549,6 +549,39 @@ func TestReconcileDeletionRemovesFinalizer(t *testing.T) {
 	assert.Equal(t, metav1.ConditionUnknown, conditionByType(t, stored, ResourcesReady).Status)
 }
 
+func TestReconcileDeletionPreservesAuthorStatusWithoutRuntime(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	metadata.SetInstanceFinalizer(instance)
+	instance.SetDeletionTimestamp(new(metav1.NewTime(time.Now())))
+	require.NoError(t, unstructured.SetNestedMap(instance.Object, map[string]interface{}{
+		"state":    string(v1alpha1.InstanceStateActive),
+		"endpoint": "https://example.test",
+		"conditions": []interface{}{map[string]interface{}{
+			"type":               "AuthorHealthy",
+			"status":             "True",
+			"reason":             "Healthy",
+			"lastTransitionTime": "2026-01-01T00:00:00Z",
+		}},
+	}, "status"))
+
+	raw := newControllerTestDynamicClient(t, instance.DeepCopy())
+	controller, _ := newControllerUnderTest(t, raw, newTestGraph())
+	controller.reconcileConfig.HasAuthorConditions = true
+
+	require.NoError(t, controller.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()},
+	}))
+
+	stored := getStoredParentObject(t, raw)
+	assert.False(t, metadata.HasInstanceFinalizer(stored))
+	assert.Equal(t, "https://example.test", stored.Object["status"].(map[string]interface{})["endpoint"])
+	conditions := conditionsFromInstance(stored)
+	require.Len(t, conditions, 1)
+	assert.Equal(t, v1alpha1.ConditionType("AuthorHealthy"), conditions[0].Type)
+	require.NotNil(t, conditions[0].LastTransitionTime)
+	assert.Equal(t, "2026-01-01T00:00:00Z", conditions[0].LastTransitionTime.UTC().Format(time.RFC3339))
+}
+
 func TestReconcileResourceMutationRequestsRequeue(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	resourceNode := &graph.Node{

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -533,6 +533,7 @@ func TestReconcileSkipsNoopStatusWriteForWholeNumbers(t *testing.T) {
 
 func TestReconcileDeletionRemovesFinalizer(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
+	addEmptyDeletionScope(instance)
 	metadata.SetInstanceFinalizer(instance)
 	instance.SetDeletionTimestamp(new(metav1.NewTime(time.Now())))
 
@@ -551,6 +552,7 @@ func TestReconcileDeletionRemovesFinalizer(t *testing.T) {
 
 func TestReconcileDeletionPreservesAuthorStatusWithoutRuntime(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
+	addEmptyDeletionScope(instance)
 	metadata.SetInstanceFinalizer(instance)
 	instance.SetDeletionTimestamp(new(metav1.NewTime(time.Now())))
 	require.NoError(t, unstructured.SetNestedMap(instance.Object, map[string]interface{}{

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/cel/library"
 	clientfake "github.com/kubernetes-sigs/kro/pkg/client/fake"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/graph/revisions"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
@@ -46,8 +47,12 @@ func TestApplyManagedFinalizerAndLabels(t *testing.T) {
 		name            string
 		presetFinalizer bool
 		presetLabels    bool
+		presetInventory bool
 		wantActions     int
 		wantPatched     bool
+		wantInventory   bool
+		wantGroupKinds  string
+		wantNamespaces  string
 	}{
 		{
 			name:            "no patch needed returns nil",
@@ -55,9 +60,20 @@ func TestApplyManagedFinalizerAndLabels(t *testing.T) {
 			presetLabels:    true,
 		},
 		{
-			name:        "patches missing finalizer and labels",
-			wantActions: 1,
-			wantPatched: true,
+			name:          "patches missing finalizer and labels",
+			wantActions:   1,
+			wantPatched:   true,
+			wantInventory: true,
+		},
+		{
+			name:            "preserves inventory when adding finalizer",
+			presetLabels:    true,
+			presetInventory: true,
+			wantActions:     1,
+			wantPatched:     true,
+			wantInventory:   true,
+			wantGroupKinds:  "Deployment.apps",
+			wantNamespaces:  "other",
 		},
 	}
 
@@ -69,6 +85,9 @@ func TestApplyManagedFinalizerAndLabels(t *testing.T) {
 			}
 			if tt.presetLabels {
 				metadata.NewKROMetaLabeler().ApplyLabels(instance)
+			}
+			if tt.presetInventory {
+				addDeletionScope(instance, controllerTestDeployGVK, "other")
 			}
 
 			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
@@ -86,8 +105,31 @@ func TestApplyManagedFinalizerAndLabels(t *testing.T) {
 			for key, value := range metadata.NewKROMetaLabeler().Labels() {
 				assert.Equal(t, value, patched.GetLabels()[key])
 			}
+			if tt.wantInventory {
+				require.NoError(t, applyset.ValidateParentInventory(patched))
+				assert.Equal(t, tt.wantGroupKinds, patched.GetAnnotations()[applyset.ApplySetGKsAnnotation])
+				assert.Equal(t, tt.wantNamespaces,
+					patched.GetAnnotations()[applyset.ApplySetAdditionalNamespacesAnnotation])
+			} else {
+				require.Error(t, applyset.ValidateParentInventory(patched))
+			}
 		})
 	}
+}
+
+func TestApplyManagedFinalizerAndLabelsRejectsPartialInventory(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	instance.SetLabels(map[string]string{
+		applyset.ApplySetParentIDLabel: applyset.ID(instance),
+	})
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+
+	patched, err := controller.applyManagedFinalizerAndLabels(rcx)
+	require.Error(t, err)
+	assert.Nil(t, patched)
+	assert.Contains(t, err.Error(), "invalid ApplySet inventory")
+	assert.Empty(t, raw.Actions())
+	assert.False(t, metadata.HasInstanceFinalizer(instance))
 }
 
 func TestApplyManagedFinalizerAndLabelsError(t *testing.T) {

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -17,126 +17,151 @@ package instance
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 )
 
-// liveResource pairs a cluster object with its GVR so deletion can issue
-// the DELETE call without CEL-based identity resolution.
-type liveResource struct {
-	Object *unstructured.Unstructured
-	GVR    schema.GroupVersionResource
-}
-
 // reconcileDeletion drives deletion workflow for an instance.
-//
-// Instead of resolving resource identities via CEL (which fails when the
-// identity depends on another resource that might already be gone), it
-// discovers managed resources by their kro ownership labels and deletes
-// them directly.
 func (c *Controller) reconcileDeletion(rcx *ReconcileContext) error {
 	rcx.StateManager.State = v1alpha1.InstanceStateDeleting
 	rcx.Mark.ResourcesUnderDeletion("deleting resources")
 
-	live, err := c.discoverLiveResources(rcx)
+	candidates, applier, err := c.discoverDeletionInventory(rcx)
 	if err != nil {
 		return err
 	}
 
-	if len(live) == 0 {
+	if len(candidates) == 0 {
 		return c.removeFinalizer(rcx)
 	}
 
-	// nodesDeleting tracks which nodes had at least one resource deleted or
-	// already terminating. Absent means no live resources found for that node.
-	// Delete errors set state inline and return early, so this set only
-	// contains successful outcomes.
-	nodesDeleting := map[string]struct{}{}
+	orders, highest, orderErr := parseDeletionOrders(candidates)
+	if orderErr != nil {
+		if nodeID := orderErr.nodeID; nodeID != "" {
+			rcx.StateManager.SetNodeState(nodeID, errorState(orderErr))
+		}
+		return orderErr
+	}
 
-	for _, res := range live {
-		nodeID := res.Object.GetLabels()[metadata.NodeIDLabel]
+	c.updateDeletionNodeStates(rcx, candidates)
 
-		if res.Object.GetDeletionTimestamp() != nil {
-			nodesDeleting[nodeID] = struct{}{}
+	conflict := false
+	for i, candidate := range candidates {
+		if orders[i] != highest || candidate.Object.GetDeletionTimestamp() != nil {
 			continue
 		}
 
-		var rc dynamic.ResourceInterface = rcx.Client.Resource(res.GVR)
-		if ns := res.Object.GetNamespace(); ns != "" {
-			rc = rcx.Client.Resource(res.GVR).Namespace(ns)
-		}
-		err := rc.Delete(rcx.Ctx, res.Object.GetName(), metav1.DeleteOptions{})
-		if apierrors.IsNotFound(err) {
-			continue
-		}
+		result, err := applier.DeleteOrphan(rcx.Ctx, candidate)
 		if err != nil {
-			if nodeID != "" {
+			if nodeID := candidate.Object.GetLabels()[metadata.NodeIDLabel]; nodeID != "" {
 				rcx.StateManager.SetNodeState(nodeID, errorState(err))
 			}
 			return err
 		}
-		nodesDeleting[nodeID] = struct{}{}
+		conflict = conflict || result.Conflict
 	}
 
-	for _, node := range rcx.Runtime.Nodes() {
-		id := node.Spec.Meta.ID
-		t := node.Spec.Meta.Type
-		if t == graph.NodeTypeExternal || t == graph.NodeTypeExternalCollection {
-			rcx.StateManager.SetNodeState(id, skippedState())
-		} else if _, deleting := nodesDeleting[id]; deleting {
-			rcx.StateManager.SetNodeState(id, deletingState())
-		} else {
-			rcx.StateManager.SetNodeState(id, deletedState())
-		}
+	if conflict {
+		return rcx.delayedRequeue(fmt.Errorf("deletion encountered UID conflicts; retrying"))
 	}
-
-	return rcx.delayedRequeue(fmt.Errorf("deleting resources"))
+	return rcx.delayedRequeue(fmt.Errorf("deleting apply-order wave %d", highest))
 }
 
-// discoverLiveResources finds all managed resources owned by this instance
-// using label selectors. One LIST call per unique GVR, across all namespaces.
-func (c *Controller) discoverLiveResources(
+// discoverDeletionInventory reconstructs the deletion search scope solely from
+// the parent ApplySet metadata. It does not evaluate the current graph or CEL.
+func (c *Controller) discoverDeletionInventory(
 	rcx *ReconcileContext,
-) ([]liveResource, error) {
-	gvrs := map[schema.GroupVersionResource]struct{}{}
+) ([]applyset.OrphanCandidate, *applyset.ApplySet, error) {
+	applier := c.createApplySet(rcx)
+	inventory, err := applier.Project(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("project deletion inventory: %w", err)
+	}
+	candidates, err := applier.ListOrphans(rcx.Ctx, applyset.PruneOptions{
+		KeepUIDs: sets.New[types.UID](),
+		Scope:    inventory.PruneScope(),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list deletion inventory: %w", err)
+	}
+	return candidates, applier, nil
+}
+
+type deletionOrderError struct {
+	nodeID string
+	err    error
+}
+
+func (e *deletionOrderError) Error() string { return e.err.Error() }
+func (e *deletionOrderError) Unwrap() error { return e.err }
+
+// parseDeletionOrders validates the complete inventory before any mutation.
+func parseDeletionOrders(candidates []applyset.OrphanCandidate) ([]int, int, *deletionOrderError) {
+	orders := make([]int, len(candidates))
+	highest := 0
+	for i, candidate := range candidates {
+		obj := candidate.Object
+		raw := obj.GetLabels()[metadata.ApplyOrderLabel]
+		validDigits := raw != ""
+		for _, digit := range raw {
+			validDigits = validDigits && digit >= '0' && digit <= '9'
+		}
+		order, err := strconv.Atoi(raw)
+		if !validDigits || err != nil || order <= 0 {
+			gvk := obj.GroupVersionKind().String()
+			if obj.GroupVersionKind().Empty() {
+				gvk = candidate.GVR.String()
+			}
+			return nil, 0, &deletionOrderError{
+				nodeID: obj.GetLabels()[metadata.NodeIDLabel],
+				err: fmt.Errorf(
+					"resource %s %s has invalid %s label %q: expected a positive base-10 integer",
+					gvk, resourceRef(obj), metadata.ApplyOrderLabel, raw,
+				),
+			}
+		}
+		orders[i] = order
+		if order > highest {
+			highest = order
+		}
+	}
+	return orders, highest, nil
+}
+
+func (c *Controller) updateDeletionNodeStates(rcx *ReconcileContext, candidates []applyset.OrphanCandidate) {
+	if rcx.Runtime == nil {
+		return
+	}
+	liveNodes := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if nodeID := candidate.Object.GetLabels()[metadata.NodeIDLabel]; nodeID != "" {
+			liveNodes[nodeID] = struct{}{}
+		}
+	}
 	for _, node := range rcx.Runtime.Nodes() {
+		id := node.Spec.Meta.ID
 		switch node.Spec.Meta.Type {
-		case graph.NodeTypeExternal, graph.NodeTypeExternalCollection, graph.NodeTypeInstance:
-			continue
-		}
-		gvrs[node.Spec.Meta.GVR] = struct{}{}
-	}
-
-	instanceUID := string(rcx.Instance.GetUID())
-	selector := fmt.Sprintf("%s=%s", metadata.InstanceIDLabel, instanceUID)
-
-	var result []liveResource
-	for gvr := range gvrs {
-		list, err := rcx.Client.Resource(gvr).List(rcx.Ctx, metav1.ListOptions{
-			LabelSelector: selector,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to list %s for deletion: %w", gvr.Resource, err)
-		}
-		for i := range list.Items {
-			result = append(result, liveResource{
-				Object: &list.Items[i],
-				GVR:    gvr,
-			})
+		case graph.NodeTypeExternal, graph.NodeTypeExternalCollection:
+			rcx.StateManager.SetNodeState(id, skippedState())
+		default:
+			if _, exists := liveNodes[id]; exists {
+				rcx.StateManager.SetNodeState(id, deletingState())
+			} else {
+				rcx.StateManager.SetNodeState(id, deletedState())
+			}
 		}
 	}
-
-	return result, nil
 }
 
 // removeFinalizer clears managed state on the instance after deletions complete.
@@ -153,7 +178,9 @@ func (c *Controller) removeFinalizer(rcx *ReconcileContext) error {
 		return err
 	}
 	rcx.Instance = patched
-	rcx.Runtime.Instance().SetObserved([]*unstructured.Unstructured{patched})
+	if rcx.Runtime != nil {
+		rcx.Runtime.Instance().SetObserved([]*unstructured.Unstructured{patched})
+	}
 	rcx.Mark = NewConditionsMarkerFor(rcx.Instance)
 	rcx.Mark.ResourcesUnderDeletion("deleting resources")
 	return nil

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
@@ -28,187 +29,114 @@ import (
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
-	"github.com/kubernetes-sigs/kro/pkg/runtime"
 )
 
+// liveResource pairs a cluster object with its GVR so deletion can issue
+// the DELETE call without CEL-based identity resolution.
+type liveResource struct {
+	Object *unstructured.Unstructured
+	GVR    schema.GroupVersionResource
+}
+
 // reconcileDeletion drives deletion workflow for an instance.
+//
+// Instead of resolving resource identities via CEL (which fails when the
+// identity depends on another resource that might already be gone), it
+// discovers managed resources by their kro ownership labels and deletes
+// them directly.
 func (c *Controller) reconcileDeletion(rcx *ReconcileContext) error {
 	rcx.StateManager.State = v1alpha1.InstanceStateDeleting
 	rcx.Mark.ResourcesUnderDeletion("deleting resources")
 
-	deletionNode, err := c.planNodesForDeletion(rcx)
+	live, err := c.discoverLiveResources(rcx)
 	if err != nil {
 		return err
 	}
 
-	if deletionNode != nil {
-		state := rcx.StateManager.NodeStates[deletionNode.Spec.Meta.ID]
-		if err := c.deleteTarget(rcx, deletionNode, state); err != nil {
-			return err
-		}
-		// Deletion is in progress; requeue.
-		return rcx.delayedRequeue(fmt.Errorf("deleting resource %s", deletionNode.Spec.Meta.ID))
+	if len(live) == 0 {
+		return c.removeFinalizer(rcx)
 	}
 
-	return c.removeFinalizer(rcx)
-}
+	// nodesDeleting tracks which nodes had at least one resource deleted or
+	// already terminating. Absent means no live resources found for that node.
+	// Delete errors set state inline and return early, so this set only
+	// contains successful outcomes.
+	nodesDeleting := map[string]struct{}{}
 
-// planNodesForDeletion resolves identities and observes existing objects to
-// select the last deletable node (topologically).
-func (c *Controller) planNodesForDeletion(
-	rcx *ReconcileContext,
-) (*runtime.Node, error) {
-	var deletionNode *runtime.Node
+	for _, res := range live {
+		nodeID := res.Object.GetLabels()[metadata.NodeIDLabel]
 
-	// Loop through nodes in topological order and try to observe their state.
-	// stop at the first node that can't be observed (e.g. due to pending data).
-	for _, node := range rcx.Runtime.Nodes() {
-		rid := node.Spec.Meta.ID
-		nodeMeta := node.Spec.Meta
-
-		state := rcx.StateManager.NewNodeState(rid)
-
-		// 1/ check if the node is ignored.
-		ignored, err := node.IsIgnored()
-		if err != nil {
-			state.SetError(err)
-			return nil, err
-		}
-		if ignored {
-			state.SetSkipped()
+		if res.Object.GetDeletionTimestamp() != nil {
+			nodesDeleting[nodeID] = struct{}{}
 			continue
 		}
 
-		isExternal := nodeMeta.Type == graph.NodeTypeExternal || nodeMeta.Type == graph.NodeTypeExternalCollection
-
-		// Resolve identity without readiness gating. External nodes use this to
-		// locate the resource for observation; managed nodes use it as the deletion target.
-		desired, err := node.GetDesiredIdentity()
-		if err != nil {
-			if !isExternal && runtime.IsDataPending(err) {
-				// Identity depends on a resource that lost its data. Treat as deleted —
-				// there is no better mechanism today for tracking identity across data loss.
-				state.SetDeleted()
-				continue
-			}
-			state.SetError(err)
-			return nil, err
+		var rc dynamic.ResourceInterface = rcx.Client.Resource(res.GVR)
+		if ns := res.Object.GetNamespace(); ns != "" {
+			rc = rcx.Client.Resource(res.GVR).Namespace(ns)
 		}
-
-		// External nodes are never deleted by the controller. Observe them so
-		// downstream managed nodes can resolve their identity from the CEL context.
-		if isExternal {
-			if len(desired) > 0 {
-				if err := c.observeExternal(rcx, node, desired[0]); err != nil {
-					state.SetError(err)
-					return nil, err
-				}
-			}
-			state.SetSkipped()
-			continue
-		}
-
-		if len(desired) == 0 {
-			state.SetDeleted()
-			continue
-		}
-
-		// At this point, identity is resolvable and we can safely observe (GET/LIST)
-		// to find the next deletable node.
-		switch nodeMeta.Type {
-
-		case graph.NodeTypeInstance:
-			panic(fmt.Sprintf("unexpected instance node in deletion: %s", rid))
-
-		case graph.NodeTypeCollection:
-			// Collections are label-selected and can span namespaces; LIST once and
-			// set observed so runtime can compute delete targets in desired order.
-			//
-			// Differently from single resources, we do not do GETs per-item here because
-			// that would be inefficient and cause many API calls during deletion.
-			items, err := c.listCollectionItems(rcx, nodeMeta.GVR, rid)
-			if err != nil {
-				state.SetError(err)
-				return nil, fmt.Errorf("failed to list collection items for %s: %w", rid, err)
-			}
-			if len(items) == 0 {
-				state.SetDeleted()
-				continue
-			}
-			node.SetObserved(items)
-			state.SetInProgress()
-			deletionNode = node
-
-		case graph.NodeTypeResource:
-			// Single resources delete by identity; GET the object to mark observed and
-			// allow DeleteTargets to return the correct target.
-			obj := desired[0]
-			rc := resourceClientFor(rcx, nodeMeta, obj.GetNamespace())
-			observed, err := rc.Get(rcx.Ctx, obj.GetName(), metav1.GetOptions{})
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					state.SetDeleted()
-					continue
-				}
-				state.SetError(err)
-				return nil, err
-			}
-			node.SetObserved([]*unstructured.Unstructured{observed})
-			state.SetInProgress()
-			deletionNode = node
-
-		default:
-			panic(fmt.Sprintf("unknown node type: %v", nodeMeta.Type))
-		}
-	}
-
-	return deletionNode, nil
-}
-
-// deleteTarget issues delete requests for the node's delete targets and updates state.
-func (c *Controller) deleteTarget(
-	rcx *ReconcileContext,
-	node *runtime.Node,
-	state *NodeState,
-) error {
-	targets, err := node.DeleteTargets()
-	if err != nil {
-		state.SetError(err)
-		return err
-	}
-	if len(targets) == 0 {
-		state.SetDeleted()
-		return nil
-	}
-
-	// Track whether any delete request was accepted. a successful Delete does NOT
-	// mean the object is gone yet, just that deletion is in progress.
-	anyDeleted := false
-	for _, target := range targets {
-		rc := resourceClientFor(rcx, node.Spec.Meta, target.GetNamespace())
-		err := rc.Delete(rcx.Ctx, target.GetName(), metav1.DeleteOptions{})
+		err := rc.Delete(rcx.Ctx, res.Object.GetName(), metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
-			// Already gone: leave anyDeleted as is and keep checking others.
 			continue
 		}
 		if err != nil {
-			state.SetError(err)
+			if nodeID != "" {
+				rcx.StateManager.SetNodeState(nodeID, errorState(err))
+			}
 			return err
 		}
-
-		// at least one delete call was accepted by the API server.
-		anyDeleted = true
+		nodesDeleting[nodeID] = struct{}{}
 	}
 
-	if !anyDeleted {
-		// All targets were NotFound, so the node is fully deleted.
-		state.SetDeleted()
-		return nil
+	for _, node := range rcx.Runtime.Nodes() {
+		id := node.Spec.Meta.ID
+		t := node.Spec.Meta.Type
+		if t == graph.NodeTypeExternal || t == graph.NodeTypeExternalCollection {
+			rcx.StateManager.SetNodeState(id, skippedState())
+		} else if _, deleting := nodesDeleting[id]; deleting {
+			rcx.StateManager.SetNodeState(id, deletingState())
+		} else {
+			rcx.StateManager.SetNodeState(id, deletedState())
+		}
 	}
 
-	// At least one delete call succeeded; resources may still be terminating.
-	state.SetDeleting()
-	return nil
+	return rcx.delayedRequeue(fmt.Errorf("deleting resources"))
+}
+
+// discoverLiveResources finds all managed resources owned by this instance
+// using label selectors. One LIST call per unique GVR, across all namespaces.
+func (c *Controller) discoverLiveResources(
+	rcx *ReconcileContext,
+) ([]liveResource, error) {
+	gvrs := map[schema.GroupVersionResource]struct{}{}
+	for _, node := range rcx.Runtime.Nodes() {
+		switch node.Spec.Meta.Type {
+		case graph.NodeTypeExternal, graph.NodeTypeExternalCollection, graph.NodeTypeInstance:
+			continue
+		}
+		gvrs[node.Spec.Meta.GVR] = struct{}{}
+	}
+
+	instanceUID := string(rcx.Instance.GetUID())
+	selector := fmt.Sprintf("%s=%s", metadata.InstanceIDLabel, instanceUID)
+
+	var result []liveResource
+	for gvr := range gvrs {
+		list, err := rcx.Client.Resource(gvr).List(rcx.Ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list %s for deletion: %w", gvr.Resource, err)
+		}
+		for i := range list.Items {
+			result = append(result, liveResource{
+				Object: &list.Items[i],
+				GVR:    gvr,
+			})
+		}
+	}
+
+	return result, nil
 }
 
 // removeFinalizer clears managed state on the instance after deletions complete.

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -46,13 +46,7 @@ func (c *Controller) reconcileDeletion(rcx *ReconcileContext) error {
 		return c.removeFinalizer(rcx)
 	}
 
-	wave, highest, orderErr := highestDeletionWave(candidates)
-	if orderErr != nil {
-		if nodeID := orderErr.nodeID; nodeID != "" {
-			rcx.StateManager.SetNodeState(nodeID, errorState(orderErr))
-		}
-		return orderErr
-	}
+	wave, highest := highestDeletionWave(candidates)
 
 	c.updateDeletionNodeStates(rcx, candidates)
 
@@ -98,41 +92,19 @@ func (c *Controller) discoverDeletionInventory(
 	return candidates, applier, nil
 }
 
-type deletionOrderError struct {
-	nodeID string
-	err    error
-}
+const fallbackDeletionOrder = 0
 
-func (e *deletionOrderError) Error() string { return e.err.Error() }
-func (e *deletionOrderError) Unwrap() error { return e.err }
-
-// highestDeletionWave validates the complete inventory before any mutation and
-// returns only candidates in the highest remaining order.
-func highestDeletionWave(
-	candidates []applyset.OrphanCandidate,
-) ([]applyset.OrphanCandidate, int, *deletionOrderError) {
-	highest := 0
+// highestDeletionWave returns only candidates in the highest remaining order.
+// Resources without a valid positive order share the fallback wave, which runs
+// after every ordered wave has disappeared.
+func highestDeletionWave(candidates []applyset.OrphanCandidate) ([]applyset.OrphanCandidate, int) {
+	highest := fallbackDeletionOrder
 	wave := make([]applyset.OrphanCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
-		obj := candidate.Object
-		raw := obj.GetLabels()[metadata.ApplyOrderLabel]
-		validDigits := raw != ""
-		for _, digit := range raw {
-			validDigits = validDigits && digit >= '0' && digit <= '9'
-		}
+		raw := candidate.Object.GetLabels()[metadata.ApplyOrderLabel]
 		order, err := strconv.Atoi(raw)
-		if !validDigits || err != nil || order <= 0 {
-			gvk := obj.GroupVersionKind().String()
-			if obj.GroupVersionKind().Empty() {
-				gvk = candidate.GVR.String()
-			}
-			return nil, 0, &deletionOrderError{
-				nodeID: obj.GetLabels()[metadata.NodeIDLabel],
-				err: fmt.Errorf(
-					"resource %s %s has invalid %s label %q: expected a positive base-10 integer",
-					gvk, resourceRef(obj), metadata.ApplyOrderLabel, raw,
-				),
-			}
+		if err != nil || order <= 0 {
+			order = fallbackDeletionOrder
 		}
 		if order > highest {
 			highest = order
@@ -142,7 +114,7 @@ func highestDeletionWave(
 			wave = append(wave, candidate)
 		}
 	}
-	return wave, highest, nil
+	return wave, highest
 }
 
 func (c *Controller) updateDeletionNodeStates(rcx *ReconcileContext, candidates []applyset.OrphanCandidate) {

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -33,22 +33,20 @@ import (
 )
 
 // reconcileDeletion drives deletion workflow for an instance.
-func (c *Controller) reconcileDeletion(rcx *ReconcileContext) error {
-	rcx.StateManager.State = v1alpha1.InstanceStateDeleting
-	rcx.Mark.ResourcesUnderDeletion("deleting resources")
+func (c *Controller) reconcileDeletion(dcx *DeletionContext) error {
+	dcx.StateManager.State = v1alpha1.InstanceStateDeleting
+	dcx.Mark.ResourcesUnderDeletion("deleting resources")
 
-	candidates, applier, err := c.discoverDeletionInventory(rcx)
+	candidates, applier, err := c.discoverDeletionInventory(dcx)
 	if err != nil {
 		return err
 	}
 
 	if len(candidates) == 0 {
-		return c.removeFinalizer(rcx)
+		return c.removeFinalizer(dcx)
 	}
 
 	wave, highest := highestDeletionWave(candidates)
-
-	c.updateDeletionNodeStates(rcx, candidates)
 
 	conflict := false
 	for _, candidate := range wave {
@@ -56,36 +54,38 @@ func (c *Controller) reconcileDeletion(rcx *ReconcileContext) error {
 			continue
 		}
 
-		result, err := applier.DeleteOrphan(rcx.Ctx, candidate)
+		result, err := applier.DeleteOrphan(dcx.Ctx, candidate)
 		if err != nil {
-			if nodeID := candidate.Object.GetLabels()[metadata.NodeIDLabel]; nodeID != "" {
-				rcx.StateManager.SetNodeState(nodeID, errorState(err))
-			}
 			return err
 		}
 		conflict = conflict || result.Conflict
 	}
 
 	if conflict {
-		return rcx.delayedRequeue(fmt.Errorf("deletion encountered UID conflicts; retrying"))
+		return dcx.delayedRequeue(fmt.Errorf("deletion encountered UID conflicts; retrying"))
 	}
-	return rcx.delayedRequeue(fmt.Errorf("deleting apply-order wave %d", highest))
+	return dcx.delayedRequeue(fmt.Errorf("deleting apply-order wave %d", highest))
 }
 
 // discoverDeletionInventory reconstructs the deletion search scope solely from
 // the parent ApplySet metadata. It does not evaluate the current graph or CEL.
 func (c *Controller) discoverDeletionInventory(
-	rcx *ReconcileContext,
+	dcx *DeletionContext,
 ) ([]applyset.OrphanCandidate, *applyset.ApplySet, error) {
-	if err := applyset.ValidateParentInventory(rcx.Instance); err != nil {
+	if err := applyset.ValidateParentInventory(dcx.Instance); err != nil {
 		return nil, nil, fmt.Errorf("validate deletion inventory: %w", err)
 	}
-	applier := c.createApplySet(rcx)
+	applier := applyset.New(applyset.Config{
+		Client:          dcx.Client,
+		RESTMapper:      dcx.RestMapper,
+		Log:             dcx.Log,
+		ParentNamespace: dcx.Instance.GetNamespace(),
+	}, dcx.Instance)
 	inventory, err := applier.Project(nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("project deletion inventory: %w", err)
 	}
-	candidates, err := applier.ListOrphans(rcx.Ctx, applyset.PruneOptions{
+	candidates, err := applier.ListOrphans(dcx.Ctx, applyset.PruneOptions{
 		KeepUIDs: sets.New[types.UID](),
 		Scope:    inventory.PruneScope(),
 	})
@@ -120,51 +120,23 @@ func highestDeletionWave(candidates []applyset.OrphanCandidate) ([]applyset.Orph
 	return wave, highest
 }
 
-func (c *Controller) updateDeletionNodeStates(rcx *ReconcileContext, candidates []applyset.OrphanCandidate) {
-	if rcx.Runtime == nil {
-		return
-	}
-	liveNodes := make(map[string]struct{}, len(candidates))
-	for _, candidate := range candidates {
-		if nodeID := candidate.Object.GetLabels()[metadata.NodeIDLabel]; nodeID != "" {
-			liveNodes[nodeID] = struct{}{}
-		}
-	}
-	for _, node := range rcx.Runtime.Nodes() {
-		id := node.Spec.Meta.ID
-		switch node.Spec.Meta.Type {
-		case graph.NodeTypeExternal, graph.NodeTypeExternalCollection:
-			rcx.StateManager.SetNodeState(id, skippedState())
-		default:
-			if _, exists := liveNodes[id]; exists {
-				rcx.StateManager.SetNodeState(id, deletingState())
-			} else {
-				rcx.StateManager.SetNodeState(id, deletedState())
-			}
-		}
-	}
-}
-
 // removeFinalizer clears managed state on the instance after deletions complete.
-func (c *Controller) removeFinalizer(rcx *ReconcileContext) error {
+func (c *Controller) removeFinalizer(dcx *DeletionContext) error {
 	// Clean up coordinator watch requests before removing the finalizer.
 	c.coordinator.RemoveInstance(c.gvr, types.NamespacedName{
-		Name:      rcx.Instance.GetName(),
-		Namespace: rcx.Instance.GetNamespace(),
+		Name:      dcx.Instance.GetName(),
+		Namespace: dcx.Instance.GetNamespace(),
 	})
 
-	patched, err := c.setUnmanaged(rcx, rcx.Instance)
+	patched, err := c.setUnmanaged(dcx, dcx.Instance)
 	if err != nil {
-		rcx.Mark.InstanceNotManaged("failed removing finalizer: %v", err)
+		dcx.Mark.InstanceNotManaged("failed removing finalizer: %v", err)
 		return err
 	}
 	if patched != nil {
-		rcx.rebindInstance(patched)
-		if rcx.Runtime != nil {
-			rcx.Runtime.Instance().SetObserved([]*unstructured.Unstructured{patched})
-		}
+		dcx.rebindInstance(patched)
 	}
-	rcx.Mark.ResourcesUnderDeletion("deleting resources")
+	dcx.Mark.ResourcesUnderDeletion("deleting resources")
 	return nil
 }
 
@@ -184,16 +156,16 @@ func resourceClientFor(
 // Uses merge patch (not SSA) to avoid field manager ownership blocking finalizer removal.
 // Returns the server's response, or nil when the finalizer was already absent
 // and no request was made (callers must only rebind on a non-nil return).
-func (c *Controller) setUnmanaged(rcx *ReconcileContext, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (c *Controller) setUnmanaged(dcx *DeletionContext, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	if exist := metadata.HasInstanceFinalizer(obj); !exist {
 		return nil, nil
 	}
-	rcx.Log.Info("Removing managed state", "name", obj.GetName(), "namespace", obj.GetNamespace())
+	dcx.Log.Info("Removing managed state", "name", obj.GetName(), "namespace", obj.GetNamespace())
 
 	var updated *unstructured.Unstructured
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Re-fetch fresh object on each retry attempt
-		current, err := rcx.InstanceClient().Get(rcx.Ctx, obj.GetName(), metav1.GetOptions{})
+		current, err := dcx.InstanceClient().Get(dcx.Ctx, obj.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -217,8 +189,8 @@ func (c *Controller) setUnmanaged(rcx *ReconcileContext, obj *unstructured.Unstr
 			return fmt.Errorf("failed to marshal finalizer patch: %w", err)
 		}
 
-		updated, err = rcx.InstanceClient().Patch(
-			rcx.Ctx,
+		updated, err = dcx.InstanceClient().Patch(
+			dcx.Ctx,
 			current.GetName(),
 			types.MergePatchType,
 			patchData,

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -17,126 +17,157 @@ package instance
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 )
 
-// liveResource pairs a cluster object with its GVR so deletion can issue
-// the DELETE call without CEL-based identity resolution.
-type liveResource struct {
-	Object *unstructured.Unstructured
-	GVR    schema.GroupVersionResource
-}
-
 // reconcileDeletion drives deletion workflow for an instance.
-//
-// Instead of resolving resource identities via CEL (which fails when the
-// identity depends on another resource that might already be gone), it
-// discovers managed resources by their kro ownership labels and deletes
-// them directly.
 func (c *Controller) reconcileDeletion(rcx *ReconcileContext) error {
 	rcx.StateManager.State = v1alpha1.InstanceStateDeleting
 	rcx.Mark.ResourcesUnderDeletion("deleting resources")
 
-	live, err := c.discoverLiveResources(rcx)
+	candidates, applier, err := c.discoverDeletionInventory(rcx)
 	if err != nil {
 		return err
 	}
 
-	if len(live) == 0 {
+	if len(candidates) == 0 {
 		return c.removeFinalizer(rcx)
 	}
 
-	// nodesDeleting tracks which nodes had at least one resource deleted or
-	// already terminating. Absent means no live resources found for that node.
-	// Delete errors set state inline and return early, so this set only
-	// contains successful outcomes.
-	nodesDeleting := map[string]struct{}{}
+	wave, highest, orderErr := highestDeletionWave(candidates)
+	if orderErr != nil {
+		if nodeID := orderErr.nodeID; nodeID != "" {
+			rcx.StateManager.SetNodeState(nodeID, errorState(orderErr))
+		}
+		return orderErr
+	}
 
-	for _, res := range live {
-		nodeID := res.Object.GetLabels()[metadata.NodeIDLabel]
+	c.updateDeletionNodeStates(rcx, candidates)
 
-		if res.Object.GetDeletionTimestamp() != nil {
-			nodesDeleting[nodeID] = struct{}{}
+	conflict := false
+	for _, candidate := range wave {
+		if candidate.Object.GetDeletionTimestamp() != nil {
 			continue
 		}
 
-		var rc dynamic.ResourceInterface = rcx.Client.Resource(res.GVR)
-		if ns := res.Object.GetNamespace(); ns != "" {
-			rc = rcx.Client.Resource(res.GVR).Namespace(ns)
-		}
-		err := rc.Delete(rcx.Ctx, res.Object.GetName(), metav1.DeleteOptions{})
-		if apierrors.IsNotFound(err) {
-			continue
-		}
+		result, err := applier.DeleteOrphan(rcx.Ctx, candidate)
 		if err != nil {
-			if nodeID != "" {
+			if nodeID := candidate.Object.GetLabels()[metadata.NodeIDLabel]; nodeID != "" {
 				rcx.StateManager.SetNodeState(nodeID, errorState(err))
 			}
 			return err
 		}
-		nodesDeleting[nodeID] = struct{}{}
+		conflict = conflict || result.Conflict
 	}
 
-	for _, node := range rcx.Runtime.Nodes() {
-		id := node.Spec.Meta.ID
-		t := node.Spec.Meta.Type
-		if t == graph.NodeTypeExternal || t == graph.NodeTypeExternalCollection {
-			rcx.StateManager.SetNodeState(id, skippedState())
-		} else if _, deleting := nodesDeleting[id]; deleting {
-			rcx.StateManager.SetNodeState(id, deletingState())
-		} else {
-			rcx.StateManager.SetNodeState(id, deletedState())
-		}
+	if conflict {
+		return rcx.delayedRequeue(fmt.Errorf("deletion encountered UID conflicts; retrying"))
 	}
-
-	return rcx.delayedRequeue(fmt.Errorf("deleting resources"))
+	return rcx.delayedRequeue(fmt.Errorf("deleting apply-order wave %d", highest))
 }
 
-// discoverLiveResources finds all managed resources owned by this instance
-// using label selectors. One LIST call per unique GVR, across all namespaces.
-func (c *Controller) discoverLiveResources(
+// discoverDeletionInventory reconstructs the deletion search scope solely from
+// the parent ApplySet metadata. It does not evaluate the current graph or CEL.
+func (c *Controller) discoverDeletionInventory(
 	rcx *ReconcileContext,
-) ([]liveResource, error) {
-	gvrs := map[schema.GroupVersionResource]struct{}{}
+) ([]applyset.OrphanCandidate, *applyset.ApplySet, error) {
+	applier := c.createApplySet(rcx)
+	inventory, err := applier.Project(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("project deletion inventory: %w", err)
+	}
+	candidates, err := applier.ListOrphans(rcx.Ctx, applyset.PruneOptions{
+		KeepUIDs: sets.New[types.UID](),
+		Scope:    inventory.PruneScope(),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list deletion inventory: %w", err)
+	}
+	return candidates, applier, nil
+}
+
+type deletionOrderError struct {
+	nodeID string
+	err    error
+}
+
+func (e *deletionOrderError) Error() string { return e.err.Error() }
+func (e *deletionOrderError) Unwrap() error { return e.err }
+
+// highestDeletionWave validates the complete inventory before any mutation and
+// returns only candidates in the highest remaining order.
+func highestDeletionWave(
+	candidates []applyset.OrphanCandidate,
+) ([]applyset.OrphanCandidate, int, *deletionOrderError) {
+	highest := 0
+	wave := make([]applyset.OrphanCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		obj := candidate.Object
+		raw := obj.GetLabels()[metadata.ApplyOrderLabel]
+		validDigits := raw != ""
+		for _, digit := range raw {
+			validDigits = validDigits && digit >= '0' && digit <= '9'
+		}
+		order, err := strconv.Atoi(raw)
+		if !validDigits || err != nil || order <= 0 {
+			gvk := obj.GroupVersionKind().String()
+			if obj.GroupVersionKind().Empty() {
+				gvk = candidate.GVR.String()
+			}
+			return nil, 0, &deletionOrderError{
+				nodeID: obj.GetLabels()[metadata.NodeIDLabel],
+				err: fmt.Errorf(
+					"resource %s %s has invalid %s label %q: expected a positive base-10 integer",
+					gvk, resourceRef(obj), metadata.ApplyOrderLabel, raw,
+				),
+			}
+		}
+		if order > highest {
+			highest = order
+			wave = wave[:0]
+		}
+		if order == highest {
+			wave = append(wave, candidate)
+		}
+	}
+	return wave, highest, nil
+}
+
+func (c *Controller) updateDeletionNodeStates(rcx *ReconcileContext, candidates []applyset.OrphanCandidate) {
+	if rcx.Runtime == nil {
+		return
+	}
+	liveNodes := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if nodeID := candidate.Object.GetLabels()[metadata.NodeIDLabel]; nodeID != "" {
+			liveNodes[nodeID] = struct{}{}
+		}
+	}
 	for _, node := range rcx.Runtime.Nodes() {
+		id := node.Spec.Meta.ID
 		switch node.Spec.Meta.Type {
-		case graph.NodeTypeExternal, graph.NodeTypeExternalCollection, graph.NodeTypeInstance:
-			continue
-		}
-		gvrs[node.Spec.Meta.GVR] = struct{}{}
-	}
-
-	instanceUID := string(rcx.Instance.GetUID())
-	selector := fmt.Sprintf("%s=%s", metadata.InstanceIDLabel, instanceUID)
-
-	var result []liveResource
-	for gvr := range gvrs {
-		list, err := rcx.Client.Resource(gvr).List(rcx.Ctx, metav1.ListOptions{
-			LabelSelector: selector,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to list %s for deletion: %w", gvr.Resource, err)
-		}
-		for i := range list.Items {
-			result = append(result, liveResource{
-				Object: &list.Items[i],
-				GVR:    gvr,
-			})
+		case graph.NodeTypeExternal, graph.NodeTypeExternalCollection:
+			rcx.StateManager.SetNodeState(id, skippedState())
+		default:
+			if _, exists := liveNodes[id]; exists {
+				rcx.StateManager.SetNodeState(id, deletingState())
+			} else {
+				rcx.StateManager.SetNodeState(id, deletedState())
+			}
 		}
 	}
-
-	return result, nil
 }
 
 // removeFinalizer clears managed state on the instance after deletions complete.
@@ -154,7 +185,9 @@ func (c *Controller) removeFinalizer(rcx *ReconcileContext) error {
 	}
 	if patched != nil {
 		rcx.rebindInstance(patched)
-		rcx.Runtime.Instance().SetObserved([]*unstructured.Unstructured{patched})
+		if rcx.Runtime != nil {
+			rcx.Runtime.Instance().SetObserved([]*unstructured.Unstructured{patched})
+		}
 	}
 	rcx.Mark.ResourcesUnderDeletion("deleting resources")
 	return nil

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -108,7 +108,7 @@ func highestDeletionWave(candidates []applyset.OrphanCandidate) ([]applyset.Orph
 	highest := fallbackDeletionOrder
 	wave := make([]applyset.OrphanCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
-		raw := candidate.Object.GetLabels()[metadata.ApplyOrderLabel]
+		raw := candidate.Object.GetAnnotations()[metadata.ApplyOrderAnnotation]
 		order, err := strconv.Atoi(raw)
 		if err != nil || order <= 0 {
 			order = fallbackDeletionOrder

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -77,6 +77,9 @@ func (c *Controller) reconcileDeletion(rcx *ReconcileContext) error {
 func (c *Controller) discoverDeletionInventory(
 	rcx *ReconcileContext,
 ) ([]applyset.OrphanCandidate, *applyset.ApplySet, error) {
+	if err := applyset.ValidateParentInventory(rcx.Instance); err != nil {
+		return nil, nil, fmt.Errorf("validate deletion inventory: %w", err)
+	}
 	applier := c.createApplySet(rcx)
 	inventory, err := applier.Project(nil)
 	if err != nil {

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -39,6 +39,7 @@ func (c *Controller) reconcileDeletion(dcx *DeletionContext) error {
 
 	candidates, applier, err := c.discoverDeletionInventory(dcx)
 	if err != nil {
+		dcx.Mark.ResourcesUnderDeletion("deletion blocked: %v", err)
 		return err
 	}
 
@@ -56,13 +57,16 @@ func (c *Controller) reconcileDeletion(dcx *DeletionContext) error {
 
 		result, err := applier.DeleteOrphan(dcx.Ctx, candidate)
 		if err != nil {
+			dcx.Mark.ResourcesUnderDeletion("deletion blocked: %v", err)
 			return err
 		}
 		conflict = conflict || result.Conflict
 	}
 
 	if conflict {
-		return dcx.delayedRequeue(fmt.Errorf("deletion encountered UID conflicts; retrying"))
+		err := fmt.Errorf("deletion encountered UID conflicts; retrying")
+		dcx.Mark.ResourcesUnderDeletion("deletion blocked: %v", err)
+		return dcx.delayedRequeue(err)
 	}
 	return dcx.delayedRequeue(fmt.Errorf("deleting apply-order wave %d", highest))
 }

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -17,6 +17,9 @@ package instance
 import (
 	"encoding/json"
 	"errors"
+	"sort"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,31 +31,70 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
-// newManagedObject creates a resource with the kro ownership labels that
-// discoverLiveResources uses to find managed resources.
-func newManagedObject(base *unstructured.Unstructured, instanceUID, nodeID string) *unstructured.Unstructured {
+func addDeletionScope(instance *unstructured.Unstructured, gvk schema.GroupVersionKind, namespace string) {
+	annotations := instance.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	gks := map[string]struct{}{}
+	for _, value := range strings.Split(annotations[applyset.ApplySetGKsAnnotation], ",") {
+		if value != "" {
+			gks[value] = struct{}{}
+		}
+	}
+	gk := gvk.Kind
+	if gvk.Group != "" {
+		gk += "." + gvk.Group
+	}
+	gks[gk] = struct{}{}
+	values := make([]string, 0, len(gks))
+	for value := range gks {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	annotations[applyset.ApplySetGKsAnnotation] = strings.Join(values, ",")
+	if namespace != "" && namespace != instance.GetNamespace() {
+		annotations[applyset.ApplySetAdditionalNamespacesAnnotation] = namespace
+	}
+	instance.SetAnnotations(annotations)
+	labels := instance.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[applyset.ApplySetParentIDLabel] = applyset.ID(instance)
+	instance.SetLabels(labels)
+}
+
+// newManagedObject creates a stable ApplySet member in the parent's persisted scope.
+func newManagedObject(base, instance *unstructured.Unstructured, nodeID string, order int) *unstructured.Unstructured {
 	obj := base.DeepCopy()
+	addDeletionScope(instance, obj.GroupVersionKind(), obj.GetNamespace())
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	labels[metadata.InstanceIDLabel] = instanceUID
+	labels[metadata.InstanceIDLabel] = string(instance.GetUID())
 	labels[metadata.NodeIDLabel] = nodeID
+	labels[metadata.ApplyOrderLabel] = strconv.Itoa(order)
+	labels[applyset.ApplysetPartOfLabel] = applyset.ID(instance)
 	obj.SetLabels(labels)
+	obj.SetUID(types.UID(nodeID + "-uid"))
 	return obj
 }
 
 func TestDiscoverLiveResources(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -64,11 +106,11 @@ func TestDiscoverLiveResources(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
 
-	live, err := controller.discoverLiveResources(rcx)
+	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
 	require.Len(t, live, 1)
 	assert.Equal(t, "demo", live[0].Object.GetName())
@@ -101,11 +143,11 @@ func TestDiscoverLiveResourcesSkipsExternalNodes(t *testing.T) {
 	// The external ConfigMap exists but should not be discovered.
 	sourceCM := newConfigMapObject("source", "default")
 	sourceCM.SetLabels(map[string]string{metadata.InstanceIDLabel: uid, metadata.NodeIDLabel: "source"})
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), sourceCM, managed)
 
-	live, err := controller.discoverLiveResources(rcx)
+	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
 	require.Len(t, live, 1)
 	assert.Equal(t, "demo", live[0].Object.GetName())
@@ -113,7 +155,6 @@ func TestDiscoverLiveResourcesSkipsExternalNodes(t *testing.T) {
 
 func TestDiscoverLiveResourcesMultipleGVRs(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -134,12 +175,12 @@ func TestDiscoverLiveResourcesMultipleGVRs(t *testing.T) {
 		Template: newConfigMapObject("config", ""),
 	}
 
-	managedDeploy := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
-	managedCM := newManagedObject(newConfigMapObject("config", "default"), uid, "config")
+	managedDeploy := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
+	managedCM := newManagedObject(newConfigMapObject("config", "default"), instance, "config", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode, cmNode), managedDeploy, managedCM)
 
-	live, err := controller.discoverLiveResources(rcx)
+	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
 	assert.Len(t, live, 2)
 }
@@ -157,19 +198,19 @@ func TestDiscoverLiveResourcesListError(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
+	addDeletionScope(instance, controllerTestDeployGVK, "default")
 	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode))
 	raw.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		return true, nil, errors.New("list failed")
 	})
 
-	_, err := controller.discoverLiveResources(rcx)
+	_, _, err := controller.discoverDeletionInventory(rcx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list failed")
 }
 
 func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -181,7 +222,7 @@ func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
 
@@ -216,7 +257,6 @@ func TestReconcileDeletionRemovesFinalizerWhenNoLiveResources(t *testing.T) {
 
 func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -228,7 +268,7 @@ func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 	now := metav1.NewTime(time.Now())
 	managed.SetDeletionTimestamp(&now)
 
@@ -250,7 +290,6 @@ func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 
 func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -262,7 +301,7 @@ func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
 	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
@@ -277,7 +316,6 @@ func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 
 func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	externalNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -301,7 +339,7 @@ func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
 
 	// External ref is gone — not in the fake client.
 	// Managed resource still exists (has a controller finalizer keeping it alive).
-	managed := newManagedObject(newDeploymentObject("mirror", "default"), uid, "mirror")
+	managed := newManagedObject(newDeploymentObject("mirror", "default"), instance, "mirror", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), managed)
 
@@ -314,7 +352,6 @@ func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
 
 func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	externalNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -336,7 +373,7 @@ func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
 	}
 
 	// One managed resource still alive — the state loop will run.
-	managed := newManagedObject(newDeploymentObject("deploy", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("deploy", "default"), instance, "deploy", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, managedNode), managed)
 
@@ -345,6 +382,159 @@ func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
 	require.ErrorAs(t, err, &retryAfter)
 	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["ext"].State)
 	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestReconcileDeletionDeletesOnlyHighestOrderWave(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
+		return true, nil, nil
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, []string{"b"}, deleted)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["a"].State)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["b"].State)
+}
+
+func TestReconcileDeletionAdvancesAfterHigherWaveDisappears(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	require.Error(t, controller.reconcileDeletion(rcx))
+
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
+		return true, nil, nil
+	})
+	require.Error(t, controller.reconcileDeletion(rcx))
+	assert.Equal(t, []string{"a"}, deleted)
+}
+
+func TestReconcileDeletionTerminatingHighestOrderBlocksLowerOrders(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+	now := metav1.Now()
+	b.SetDeletionTimestamp(&now)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	deletes := 0
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deletes++
+		return true, nil, nil
+	})
+
+	require.Error(t, controller.reconcileDeletion(rcx))
+	assert.Zero(t, deletes)
+}
+
+func TestReconcileDeletionDeletesAllResourcesInHighestWave(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	node := &graph.Node{Meta: graph.NodeMeta{ID: "workers", Type: graph.NodeTypeCollection, GVR: controllerTestDeployGVR, Namespaced: true}}
+	one := newManagedObject(newDeploymentObject("one", "default"), instance, "workers", 3)
+	two := newManagedObject(newDeploymentObject("two", "default"), instance, "workers", 3)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(node), one, two)
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
+		return true, nil, nil
+	})
+
+	require.Error(t, controller.reconcileDeletion(rcx))
+	sort.Strings(deleted)
+	assert.Equal(t, []string{"one", "two"}, deleted)
+}
+
+func TestReconcileDeletionRejectsInvalidOrderBeforeDeleting(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  *string
+	}{
+		{name: "missing"},
+		{name: "malformed", raw: ptr.To("later")},
+		{name: "zero", raw: ptr.To("0")},
+		{name: "negative", raw: ptr.To("-1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+			nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+			a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+			b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+			labels := b.GetLabels()
+			delete(labels, metadata.ApplyOrderLabel)
+			if tt.raw != nil {
+				labels[metadata.ApplyOrderLabel] = *tt.raw
+			}
+			b.SetLabels(labels)
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+			deletes := 0
+			raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+				deletes++
+				return true, nil, nil
+			})
+
+			err := controller.reconcileDeletion(rcx)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), metadata.ApplyOrderLabel)
+			assert.Contains(t, err.Error(), "default/b")
+			assert.Zero(t, deletes)
+			assert.Equal(t, v1alpha1.NodeStateError, rcx.StateManager.NodeStates["b"].State)
+		})
+	}
+}
+
+func TestReconcileDeletionUIDConflictDoesNotAdvance(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		name := action.(k8stesting.DeleteAction).GetName()
+		deleted = append(deleted, name)
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "apps", Resource: "deployments"}, name, errors.New("UID mismatch"))
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, []string{"b"}, deleted)
+}
+
+func TestDeletionInventoryIncludesRemovedGraphNodes(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	current := &graph.Node{Meta: graph.NodeMeta{ID: "current", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	removed := newManagedObject(newDeploymentObject("removed", "default"), instance, "old-node", 4)
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(current), removed)
+
+	candidates, _, err := controller.discoverDeletionInventory(rcx)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "removed", candidates[0].Object.GetName())
 }
 
 // --- Tests for setUnmanaged and removeFinalizer (unchanged) ---

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,37 +31,30 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
-	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
-	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
-func TestPlanNodesForDeletionSkipsUnresolvedIdentityAndPicksLastExistingNode(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-
-	pendingNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "pending",
-			Type:       graph.NodeTypeResource,
-			GVR:        controllerTestDeployGVR,
-			Namespaced: true,
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
-				"kind":       controllerTestDeployGVK.Kind,
-				"metadata": map[string]interface{}{
-					"name": "${schema.spec.name}",
-				},
-			},
-		},
-		Variables: []*variable.ResourceField{
-			standaloneField("metadata.name", mustCompileControllerExpr(t, "schema.spec.name", "schema"), variable.ResourceVariableKindStatic),
-		},
+// newManagedObject creates a resource with the kro ownership labels that
+// discoverLiveResources uses to find managed resources.
+func newManagedObject(base *unstructured.Unstructured, instanceUID, nodeID string) *unstructured.Unstructured {
+	obj := base.DeepCopy()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
 	}
-	existingNode := &graph.Node{
+	labels[metadata.InstanceIDLabel] = instanceUID
+	labels[metadata.NodeIDLabel] = nodeID
+	obj.SetLabels(labels)
+	return obj
+}
+
+func TestDiscoverLiveResources(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
 			ID:         "deploy",
 			Type:       graph.NodeTypeResource,
@@ -70,193 +64,31 @@ func TestPlanNodesForDeletionSkipsUnresolvedIdentityAndPicksLastExistingNode(t *
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(pendingNode, existingNode), newDeploymentObject("demo", "default"))
-	node, err := controller.planNodesForDeletion(rcx)
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+
+	live, err := controller.discoverLiveResources(rcx)
 	require.NoError(t, err)
-	require.NotNil(t, node)
-	assert.Equal(t, "deploy", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateDeleted, rcx.StateManager.NodeStates["pending"].State)
-	assert.Equal(t, v1alpha1.NodeStateInProgress, rcx.StateManager.NodeStates["deploy"].State)
+	require.Len(t, live, 1)
+	assert.Equal(t, "demo", live[0].Object.GetName())
+	assert.Equal(t, controllerTestDeployGVR, live[0].GVR)
 }
 
-func TestPlanNodesForDeletionSkipsIgnoredExternalAndMissingNodes(t *testing.T) {
+func TestDiscoverLiveResourcesSkipsExternalNodes(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
-	_ = unstructured.SetNestedField(instance.Object, false, "spec", "enabled")
+	uid := string(instance.GetUID())
 
-	ignoredNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "ignored",
-			Type:       graph.NodeTypeResource,
-			GVR:        controllerTestDeployGVR,
-			Namespaced: true,
-		},
-		Template: newDeploymentObject("ignored", ""),
-		IncludeWhen: []*krocel.Expression{
-			mustCompileControllerExpr(t, "schema.spec.enabled", "schema"),
-		},
-	}
 	externalNode := &graph.Node{
 		Meta: graph.NodeMeta{
-			ID:         "external",
+			ID:         "source",
 			Type:       graph.NodeTypeExternal,
 			GVR:        controllerTestCMGVR,
 			Namespaced: true,
 		},
-		Template: newConfigMapObject("external", ""),
+		Template: newConfigMapObject("source", ""),
 	}
-	collectionNode := newDeletionCollectionNode(t, "configs")
-	missingNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "missing",
-			Type:       graph.NodeTypeResource,
-			GVR:        controllerTestDeployGVR,
-			Namespaced: true,
-		},
-		Template: newDeploymentObject("missing", ""),
-	}
-
-	currentCollection := newConfigMapObject("one", "default")
-	currentCollection.SetLabels(map[string]string{
-		metadata.InstanceIDLabel: string(instance.GetUID()),
-		metadata.NodeIDLabel:     "configs",
-	})
-
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(ignoredNode, externalNode, collectionNode, missingNode), currentCollection)
-	node, err := controller.planNodesForDeletion(rcx)
-	require.NoError(t, err)
-	require.NotNil(t, node)
-	assert.Equal(t, "configs", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["ignored"].State)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["external"].State)
-	assert.Equal(t, v1alpha1.NodeStateDeleted, rcx.StateManager.NodeStates["missing"].State)
-}
-
-func TestPlanNodesForDeletionErrors(t *testing.T) {
-	tests := []struct {
-		name      string
-		node      *graph.Node
-		configure func(*unstructured.Unstructured)
-		verb      string
-		resource  string
-		wantErr   string
-	}{
-		{
-			name: "list errors bubble up for collection nodes",
-			node: newDeletionCollectionNode(t, "configs"),
-			configure: func(instance *unstructured.Unstructured) {
-				_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
-			},
-			verb:     "list",
-			resource: "configmaps",
-			wantErr:  "list failed",
-		},
-		{
-			name: "get errors bubble up for resource nodes",
-			node: &graph.Node{
-				Meta: graph.NodeMeta{
-					ID:         "deploy",
-					Type:       graph.NodeTypeResource,
-					GVR:        controllerTestDeployGVR,
-					Namespaced: true,
-				},
-				Template: newDeploymentObject("demo", ""),
-			},
-			verb:     "get",
-			resource: "deployments",
-			wantErr:  "get failed",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			instance := newInstanceObject("demo", "default")
-			if tt.configure != nil {
-				tt.configure(instance)
-			}
-
-			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(tt.node))
-			raw.PrependReactor(tt.verb, tt.resource, func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
-				return true, nil, errors.New(tt.wantErr)
-			})
-
-			_, err := controller.planNodesForDeletion(rcx)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
-		})
-	}
-}
-
-func TestDeleteTarget(t *testing.T) {
-	tests := []struct {
-		name        string
-		observed    []*unstructured.Unstructured
-		deleteErr   string
-		wantState   v1alpha1.NodeState
-		wantErrText string
-	}{
-		{
-			name:      "marks deleted when there are no targets",
-			wantState: v1alpha1.NodeStateDeleted,
-		},
-		{
-			name:      "marks deleted when the target no longer exists",
-			observed:  []*unstructured.Unstructured{newDeploymentObject("gone", "default")},
-			wantState: v1alpha1.NodeStateDeleted,
-		},
-		{
-			name:      "marks deleting when the API accepted deletion",
-			observed:  []*unstructured.Unstructured{newDeploymentObject("demo", "default")},
-			wantState: v1alpha1.NodeStateDeleting,
-		},
-		{
-			name:        "marks error when deletion fails",
-			observed:    []*unstructured.Unstructured{newDeploymentObject("demo", "default")},
-			deleteErr:   "delete failed",
-			wantState:   v1alpha1.NodeStateError,
-			wantErrText: "delete failed",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			instance := newInstanceObject("demo", "default")
-			resourceNode := &graph.Node{
-				Meta: graph.NodeMeta{
-					ID:         "deploy",
-					Type:       graph.NodeTypeResource,
-					GVR:        controllerTestDeployGVR,
-					Namespaced: true,
-				},
-				Template: newDeploymentObject("demo", ""),
-			}
-
-			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(resourceNode), newDeploymentObject("demo", "default"))
-			node := rcx.Runtime.Nodes()[0]
-			node.SetObserved(tt.observed)
-
-			if tt.deleteErr != "" {
-				raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
-					return true, nil, errors.New(tt.deleteErr)
-				})
-			}
-
-			state := rcx.StateManager.NewNodeState(tt.name)
-			err := controller.deleteTarget(rcx, node, state)
-			if tt.wantErrText != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErrText)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tt.wantState, state.State)
-		})
-	}
-}
-
-func TestReconcileDeletionRequeuesWhileChildDeletionInFlight(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-	node := &graph.Node{
+	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
 			ID:         "deploy",
 			Type:       graph.NodeTypeResource,
@@ -266,12 +98,256 @@ func TestReconcileDeletionRequeuesWhileChildDeletionInFlight(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(node), newDeploymentObject("demo", "default"))
+	// The external ConfigMap exists but should not be discovered.
+	sourceCM := newConfigMapObject("source", "default")
+	sourceCM.SetLabels(map[string]string{metadata.InstanceIDLabel: uid, metadata.NodeIDLabel: "source"})
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), sourceCM, managed)
+
+	live, err := controller.discoverLiveResources(rcx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	assert.Equal(t, "demo", live[0].Object.GetName())
+}
+
+func TestDiscoverLiveResourcesMultipleGVRs(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+	cmNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "config",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("config", ""),
+	}
+
+	managedDeploy := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managedCM := newManagedObject(newConfigMapObject("config", "default"), uid, "config")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode, cmNode), managedDeploy, managedCM)
+
+	live, err := controller.discoverLiveResources(rcx)
+	require.NoError(t, err)
+	assert.Len(t, live, 2)
+}
+
+func TestDiscoverLiveResourcesListError(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode))
+	raw.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("list failed")
+	})
+
+	_, err := controller.discoverLiveResources(rcx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list failed")
+}
+
+func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+
 	err := controller.reconcileDeletion(rcx)
 	var retryAfter *requeue.RequeueNeededAfter
 	require.ErrorAs(t, err, &retryAfter)
 	assert.Equal(t, v1alpha1.InstanceStateDeleting, rcx.StateManager.State)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
 }
+
+func TestReconcileDeletionRemovesFinalizerWhenNoLiveResources(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	metadata.SetInstanceFinalizer(instance)
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	// No managed objects in the cluster.
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode))
+
+	err := controller.reconcileDeletion(rcx)
+	require.NoError(t, err)
+	assert.False(t, metadata.HasInstanceFinalizer(rcx.Instance))
+}
+
+func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	now := metav1.NewTime(time.Now())
+	managed.SetDeletionTimestamp(&now)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+
+	// Track whether DELETE is called — it should NOT be.
+	deletesCalled := 0
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deletesCalled++
+		return false, nil, nil
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, 0, deletesCalled, "DELETE should not be called for already-terminating resources")
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("delete failed")
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete failed")
+	assert.Equal(t, v1alpha1.NodeStateError, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	externalNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "source",
+			Type:       graph.NodeTypeExternal,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("source", ""),
+	}
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:           "mirror",
+			Type:         graph.NodeTypeResource,
+			GVR:          controllerTestDeployGVR,
+			Namespaced:   true,
+			Dependencies: []string{"source"},
+		},
+		Template: newDeploymentObject("mirror", ""),
+	}
+
+	// External ref is gone — not in the fake client.
+	// Managed resource still exists (has a controller finalizer keeping it alive).
+	managed := newManagedObject(newDeploymentObject("mirror", "default"), uid, "mirror")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), managed)
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["mirror"].State)
+	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["source"].State)
+}
+
+func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	externalNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "ext",
+			Type:       graph.NodeTypeExternal,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("ext", ""),
+	}
+	managedNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("deploy", ""),
+	}
+
+	// One managed resource still alive — the state loop will run.
+	managed := newManagedObject(newDeploymentObject("deploy", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, managedNode), managed)
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["ext"].State)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+// --- Tests for setUnmanaged and removeFinalizer (unchanged) ---
 
 func TestSetUnmanaged(t *testing.T) {
 	tests := []struct {
@@ -393,159 +469,4 @@ func TestRemoveFinalizerMarksInstanceNotManagedOnError(t *testing.T) {
 	err := controller.removeFinalizer(rcx)
 	require.Error(t, err)
 	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, rcx.Instance, InstanceManaged).Status)
-}
-
-// TestPlanNodesForDeletionObservesExternalRefRootBeforeManagedNode verifies that
-// when an external ref is the topological root and a managed resource's identity
-// depends on a field from that external ref, the external ref is observed first
-// so the managed resource's identity can be resolved and the resource is selected
-// for deletion.
-func TestPlanNodesForDeletionObservesExternalRefRootBeforeManagedNode(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-
-	// External ref node: static name, no CEL deps.
-	externalNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "external",
-			Type:       graph.NodeTypeExternal,
-			GVR:        controllerTestCMGVR,
-			Namespaced: true,
-		},
-		Template: newConfigMapObject("source-configmap", "default"),
-	}
-
-	// Managed node: identity depends on external.data.managedName.
-	managedNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:           "deploy",
-			Type:         graph.NodeTypeResource,
-			GVR:          controllerTestDeployGVR,
-			Namespaced:   true,
-			Dependencies: []string{"external"},
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
-				"kind":       controllerTestDeployGVK.Kind,
-				"metadata": map[string]interface{}{
-					"name": "${external.data.managedName}",
-				},
-			},
-		},
-		Variables: []*variable.ResourceField{
-			standaloneField("metadata.name",
-				mustCompileControllerExpr(t, "external.data.managedName", "external"),
-				variable.ResourceVariableKindStatic),
-		},
-	}
-
-	// The external ConfigMap provides the name of the managed resource.
-	sourceCM := newConfigMapObject("source-configmap", "default")
-	sourceCM.Object["data"] = map[string]interface{}{"managedName": "managed-deploy"}
-
-	// The managed resource exists under the name resolved from the external ref.
-	managedDeploy := newDeploymentObject("managed-deploy", "default")
-
-	// Topological order: external first (root), then managed (leaf).
-	controller, rcx, _ := newControllerAndContext(t, instance,
-		newTestGraph(externalNode, managedNode),
-		sourceCM, managedDeploy,
-	)
-
-	node, err := controller.planNodesForDeletion(rcx)
-	require.NoError(t, err)
-
-	require.NotNil(t, node, "managed resource must be selected for deletion, not treated as already deleted")
-	assert.Equal(t, "deploy", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["external"].State)
-	assert.Equal(t, v1alpha1.NodeStateInProgress, rcx.StateManager.NodeStates["deploy"].State)
-}
-
-// TestPlanNodesForDeletionObservesExternalCollectionRootBeforeManagedNode verifies
-// the same ordering invariant as the ExternalRef test but for an external collection
-// root whose selector is resolved from a dep field.
-func TestPlanNodesForDeletionObservesExternalCollectionRootBeforeManagedNode(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-	_ = unstructured.SetNestedField(instance.Object, "default", "spec", "ns")
-
-	// External collection node: selector is static, namespace driven by instance.
-	externalColNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "external",
-			Type:       graph.NodeTypeExternalCollection,
-			GVR:        controllerTestCMGVR,
-			Namespaced: true,
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
-				"kind":       controllerTestCMGVK.Kind,
-				"metadata": map[string]interface{}{
-					"namespace": "default",
-					"selector":  map[string]interface{}{"app": "source"},
-				},
-			},
-		},
-	}
-
-	// Managed node: depends on data from the external collection items.
-	managedNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:           "deploy",
-			Type:         graph.NodeTypeResource,
-			GVR:          controllerTestDeployGVR,
-			Namespaced:   true,
-			Dependencies: []string{"external"},
-		},
-		Template: newDeploymentObject("managed-deploy", "default"),
-	}
-
-	// Two CMs matching the selector exist in the fake client.
-	cm1 := newConfigMapObject("source-1", "default")
-	cm1.SetLabels(map[string]string{"app": "source"})
-	cm2 := newConfigMapObject("source-2", "default")
-	cm2.SetLabels(map[string]string{"app": "source"})
-	managedDeploy := newDeploymentObject("managed-deploy", "default")
-
-	controller, rcx, _ := newControllerAndContext(t, instance,
-		newTestGraph(externalColNode, managedNode),
-		cm1, cm2, managedDeploy,
-	)
-
-	node, err := controller.planNodesForDeletion(rcx)
-	require.NoError(t, err)
-
-	require.NotNil(t, node, "managed resource must be selected for deletion")
-	assert.Equal(t, "deploy", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["external"].State)
-	assert.Equal(t, v1alpha1.NodeStateInProgress, rcx.StateManager.NodeStates["deploy"].State)
-}
-
-func newDeletionCollectionNode(t *testing.T, id string) *graph.Node {
-	t.Helper()
-
-	return &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         id,
-			Type:       graph.NodeTypeCollection,
-			GVR:        controllerTestCMGVR,
-			Namespaced: true,
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
-				"kind":       controllerTestCMGVK.Kind,
-				"metadata": map[string]interface{}{
-					"name": "${item}",
-				},
-			},
-		},
-		Variables: []*variable.ResourceField{
-			standaloneField("metadata.name", mustCompileControllerExpr(t, "item", "item"), variable.ResourceVariableKindIteration),
-		},
-		ForEach: []graph.ForEachDimension{{
-			Name:       "item",
-			Expression: mustCompileControllerExpr(t, "schema.spec.items", "schema"),
-		}},
-	}
 }

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -106,9 +106,14 @@ func newManagedObject(base, instance *unstructured.Unstructured, nodeID string, 
 	}
 	labels[metadata.InstanceIDLabel] = string(instance.GetUID())
 	labels[metadata.NodeIDLabel] = nodeID
-	labels[metadata.ApplyOrderLabel] = strconv.Itoa(order)
 	labels[applyset.ApplysetPartOfLabel] = applyset.ID(instance)
 	obj.SetLabels(labels)
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[metadata.ApplyOrderAnnotation] = strconv.Itoa(order)
+	obj.SetAnnotations(annotations)
 	obj.SetUID(types.UID(nodeID + "-uid"))
 	return obj
 }
@@ -519,12 +524,12 @@ func TestReconcileDeletionDefersInvalidOrdersUntilLastWave(t *testing.T) {
 			nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
 			a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
 			b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
-			labels := b.GetLabels()
-			delete(labels, metadata.ApplyOrderLabel)
+			annotations := b.GetAnnotations()
+			delete(annotations, metadata.ApplyOrderAnnotation)
 			if tt.raw != "" {
-				labels[metadata.ApplyOrderLabel] = tt.raw
+				annotations[metadata.ApplyOrderAnnotation] = tt.raw
 			}
-			b.SetLabels(labels)
+			b.SetAnnotations(annotations)
 
 			controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
 
@@ -554,12 +559,12 @@ func TestReconcileDeletionDeletesInvalidOrdersInSharedFallbackWave(t *testing.T)
 	}}
 	one := newManagedObject(newDeploymentObject("one", "default"), instance, "workers", 1)
 	two := newManagedObject(newDeploymentObject("two", "default"), instance, "workers", 1)
-	oneLabels := one.GetLabels()
-	delete(oneLabels, metadata.ApplyOrderLabel)
-	one.SetLabels(oneLabels)
-	twoLabels := two.GetLabels()
-	twoLabels[metadata.ApplyOrderLabel] = "invalid"
-	two.SetLabels(twoLabels)
+	oneAnnotations := one.GetAnnotations()
+	delete(oneAnnotations, metadata.ApplyOrderAnnotation)
+	one.SetAnnotations(oneAnnotations)
+	twoAnnotations := two.GetAnnotations()
+	twoAnnotations[metadata.ApplyOrderAnnotation] = "invalid"
+	two.SetAnnotations(twoAnnotations)
 
 	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(node), one, two)
 	var deleted []string

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -63,9 +63,30 @@ func addDeletionScope(instance *unstructured.Unstructured, gvk schema.GroupVersi
 	}
 	sort.Strings(values)
 	annotations[applyset.ApplySetGKsAnnotation] = strings.Join(values, ",")
+	annotations[applyset.ApplySetToolingAnnotation] = applyset.ToolingID()
+	if _, exists := annotations[applyset.ApplySetAdditionalNamespacesAnnotation]; !exists {
+		annotations[applyset.ApplySetAdditionalNamespacesAnnotation] = ""
+	}
 	if namespace != "" && namespace != instance.GetNamespace() {
 		annotations[applyset.ApplySetAdditionalNamespacesAnnotation] = namespace
 	}
+	instance.SetAnnotations(annotations)
+	labels := instance.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[applyset.ApplySetParentIDLabel] = applyset.ID(instance)
+	instance.SetLabels(labels)
+}
+
+func addEmptyDeletionScope(instance *unstructured.Unstructured) {
+	annotations := instance.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[applyset.ApplySetToolingAnnotation] = applyset.ToolingID()
+	annotations[applyset.ApplySetGKsAnnotation] = ""
+	annotations[applyset.ApplySetAdditionalNamespacesAnnotation] = ""
 	instance.SetAnnotations(annotations)
 	labels := instance.GetLabels()
 	if labels == nil {
@@ -208,6 +229,26 @@ func TestDiscoverLiveResourcesListError(t *testing.T) {
 	assert.Contains(t, err.Error(), "list failed")
 }
 
+func TestDiscoverDeletionInventoryRejectsMissingScope(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	addEmptyDeletionScope(instance)
+	annotations := instance.GetAnnotations()
+	delete(annotations, applyset.ApplySetGKsAnnotation)
+	instance.SetAnnotations(annotations)
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+
+	lists := 0
+	raw.PrependReactor("list", "*", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		lists++
+		return false, nil, nil
+	})
+
+	_, _, err := controller.discoverDeletionInventory(rcx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), applyset.ApplySetGKsAnnotation)
+	assert.Zero(t, lists, "invalid inventory must fail before listing resources")
+}
+
 func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 
@@ -235,6 +276,7 @@ func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 func TestReconcileDeletionRemovesFinalizerWhenNoLiveResources(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	metadata.SetInstanceFinalizer(instance)
+	addEmptyDeletionScope(instance)
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -128,7 +128,7 @@ func TestDiscoverLiveResources(t *testing.T) {
 
 	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+	controller, rcx, _ := newControllerAndDeletionContext(t, instance, newTestGraph(deployNode), managed)
 
 	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestDiscoverLiveResourcesSkipsExternalNodes(t *testing.T) {
 	sourceCM.SetLabels(map[string]string{metadata.InstanceIDLabel: uid, metadata.NodeIDLabel: "source"})
 	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 2)
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), sourceCM, managed)
+	controller, rcx, _ := newControllerAndDeletionContext(t, instance, newTestGraph(externalNode, deployNode), sourceCM, managed)
 
 	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestDiscoverLiveResourcesMultipleGVRs(t *testing.T) {
 	managedDeploy := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 	managedCM := newManagedObject(newConfigMapObject("config", "default"), instance, "config", 2)
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode, cmNode), managedDeploy, managedCM)
+	controller, rcx, _ := newControllerAndDeletionContext(t, instance, newTestGraph(deployNode, cmNode), managedDeploy, managedCM)
 
 	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestDiscoverLiveResourcesListError(t *testing.T) {
 	}
 
 	addDeletionScope(instance, controllerTestDeployGVK, "default")
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode))
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(deployNode))
 	raw.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		return true, nil, errors.New("list failed")
 	})
@@ -235,7 +235,7 @@ func TestDiscoverDeletionInventoryRejectsMissingScope(t *testing.T) {
 	annotations := instance.GetAnnotations()
 	delete(annotations, applyset.ApplySetGKsAnnotation)
 	instance.SetAnnotations(annotations)
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph())
 
 	lists := 0
 	raw.PrependReactor("list", "*", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
@@ -264,13 +264,14 @@ func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 
 	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(deployNode), managed)
 
 	err := controller.reconcileDeletion(rcx)
 	var retryAfter *requeue.RequeueNeededAfter
 	require.ErrorAs(t, err, &retryAfter)
 	assert.Equal(t, v1alpha1.InstanceStateDeleting, rcx.StateManager.State)
-	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+	_, getErr := raw.Tracker().Get(controllerTestDeployGVR, "default", "demo")
+	require.Error(t, getErr)
 }
 
 func TestReconcileDeletionRemovesFinalizerWhenNoLiveResources(t *testing.T) {
@@ -289,7 +290,7 @@ func TestReconcileDeletionRemovesFinalizerWhenNoLiveResources(t *testing.T) {
 	}
 
 	// No managed objects in the cluster.
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode))
+	controller, rcx, _ := newControllerAndDeletionContext(t, instance, newTestGraph(deployNode))
 
 	err := controller.reconcileDeletion(rcx)
 	require.NoError(t, err)
@@ -313,7 +314,7 @@ func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 	now := metav1.NewTime(time.Now())
 	managed.SetDeletionTimestamp(&now)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(deployNode), managed)
 
 	// Track whether DELETE is called — it should NOT be.
 	deletesCalled := 0
@@ -326,7 +327,6 @@ func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 	var retryAfter *requeue.RequeueNeededAfter
 	require.ErrorAs(t, err, &retryAfter)
 	assert.Equal(t, 0, deletesCalled, "DELETE should not be called for already-terminating resources")
-	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
 }
 
 func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
@@ -344,7 +344,7 @@ func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 
 	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(deployNode), managed)
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		return true, nil, errors.New("delete failed")
 	})
@@ -352,7 +352,6 @@ func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 	err := controller.reconcileDeletion(rcx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete failed")
-	assert.Equal(t, v1alpha1.NodeStateError, rcx.StateManager.NodeStates["deploy"].State)
 }
 
 func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
@@ -382,47 +381,13 @@ func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
 	// Managed resource still exists (has a controller finalizer keeping it alive).
 	managed := newManagedObject(newDeploymentObject("mirror", "default"), instance, "mirror", 2)
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), managed)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(externalNode, deployNode), managed)
 
 	err := controller.reconcileDeletion(rcx)
 	var retryAfter *requeue.RequeueNeededAfter
 	require.ErrorAs(t, err, &retryAfter)
-	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["mirror"].State)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["source"].State)
-}
-
-func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-
-	externalNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "ext",
-			Type:       graph.NodeTypeExternal,
-			GVR:        controllerTestCMGVR,
-			Namespaced: true,
-		},
-		Template: newConfigMapObject("ext", ""),
-	}
-	managedNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "deploy",
-			Type:       graph.NodeTypeResource,
-			GVR:        controllerTestDeployGVR,
-			Namespaced: true,
-		},
-		Template: newDeploymentObject("deploy", ""),
-	}
-
-	// One managed resource still alive — the state loop will run.
-	managed := newManagedObject(newDeploymentObject("deploy", "default"), instance, "deploy", 2)
-
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, managedNode), managed)
-
-	err := controller.reconcileDeletion(rcx)
-	var retryAfter *requeue.RequeueNeededAfter
-	require.ErrorAs(t, err, &retryAfter)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["ext"].State)
-	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+	_, getErr := raw.Tracker().Get(controllerTestDeployGVR, "default", "mirror")
+	require.Error(t, getErr)
 }
 
 func TestReconcileDeletionDeletesOnlyHighestOrderWave(t *testing.T) {
@@ -432,7 +397,7 @@ func TestReconcileDeletionDeletesOnlyHighestOrderWave(t *testing.T) {
 	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
 	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
 	var deleted []string
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
@@ -443,8 +408,6 @@ func TestReconcileDeletionDeletesOnlyHighestOrderWave(t *testing.T) {
 	var retryAfter *requeue.RequeueNeededAfter
 	require.ErrorAs(t, err, &retryAfter)
 	assert.Equal(t, []string{"b"}, deleted)
-	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["a"].State)
-	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["b"].State)
 }
 
 func TestReconcileDeletionAdvancesAfterHigherWaveDisappears(t *testing.T) {
@@ -454,7 +417,7 @@ func TestReconcileDeletionAdvancesAfterHigherWaveDisappears(t *testing.T) {
 	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
 	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
 	require.Error(t, controller.reconcileDeletion(rcx))
 
 	var deleted []string
@@ -475,7 +438,7 @@ func TestReconcileDeletionTerminatingHighestOrderBlocksLowerOrders(t *testing.T)
 	now := metav1.Now()
 	b.SetDeletionTimestamp(&now)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
 	deletes := 0
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		deletes++
@@ -492,7 +455,7 @@ func TestReconcileDeletionDeletesAllResourcesInHighestWave(t *testing.T) {
 	one := newManagedObject(newDeploymentObject("one", "default"), instance, "workers", 3)
 	two := newManagedObject(newDeploymentObject("two", "default"), instance, "workers", 3)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(node), one, two)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(node), one, two)
 	var deleted []string
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
@@ -544,7 +507,7 @@ func TestReconcileDeletionDefersInvalidOrdersUntilLastWave(t *testing.T) {
 			}
 			b.SetLabels(labels)
 
-			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+			controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
 
 			// The valid order runs before the fallback wave.
 			require.Error(t, controller.reconcileDeletion(rcx))
@@ -579,7 +542,7 @@ func TestReconcileDeletionDeletesInvalidOrdersInSharedFallbackWave(t *testing.T)
 	twoLabels[metadata.ApplyOrderLabel] = "invalid"
 	two.SetLabels(twoLabels)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(node), one, two)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(node), one, two)
 	var deleted []string
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
@@ -598,7 +561,7 @@ func TestReconcileDeletionUIDConflictDoesNotAdvance(t *testing.T) {
 	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
 	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
 	var deleted []string
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		name := action.(k8stesting.DeleteAction).GetName()
@@ -616,7 +579,7 @@ func TestDeletionInventoryIncludesRemovedGraphNodes(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	current := &graph.Node{Meta: graph.NodeMeta{ID: "current", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
 	removed := newManagedObject(newDeploymentObject("removed", "default"), instance, "old-node", 4)
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(current), removed)
+	controller, rcx, _ := newControllerAndDeletionContext(t, instance, newTestGraph(current), removed)
 
 	candidates, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
@@ -661,7 +624,7 @@ func TestSetUnmanaged(t *testing.T) {
 				metadata.SetInstanceFinalizer(instance)
 			}
 
-			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+			controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph())
 			if tt.patchErr != "" {
 				raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 					return true, nil, errors.New(tt.patchErr)
@@ -693,7 +656,7 @@ func TestSetUnmanagedRetriesOnConflict(t *testing.T) {
 	metadata.SetInstanceFinalizer(instance)
 	instance.SetFinalizers(append(instance.GetFinalizers(), "other.io/finalizer"))
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph())
 
 	var attempts atomic.Int32
 	raw.PrependReactor("get", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
@@ -743,7 +706,7 @@ func TestRemoveFinalizerMarksInstanceNotManagedOnError(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	metadata.SetInstanceFinalizer(instance)
 
-	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
+	controller, rcx, raw := newControllerAndDeletionContext(t, instance, newTestGraph())
 	raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		return true, nil, errors.New("patch failed")
 	})

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -17,6 +17,9 @@ package instance
 import (
 	"encoding/json"
 	"errors"
+	"sort"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,31 +31,70 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
-// newManagedObject creates a resource with the kro ownership labels that
-// discoverLiveResources uses to find managed resources.
-func newManagedObject(base *unstructured.Unstructured, instanceUID, nodeID string) *unstructured.Unstructured {
+func addDeletionScope(instance *unstructured.Unstructured, gvk schema.GroupVersionKind, namespace string) {
+	annotations := instance.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	gks := map[string]struct{}{}
+	for _, value := range strings.Split(annotations[applyset.ApplySetGKsAnnotation], ",") {
+		if value != "" {
+			gks[value] = struct{}{}
+		}
+	}
+	gk := gvk.Kind
+	if gvk.Group != "" {
+		gk += "." + gvk.Group
+	}
+	gks[gk] = struct{}{}
+	values := make([]string, 0, len(gks))
+	for value := range gks {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	annotations[applyset.ApplySetGKsAnnotation] = strings.Join(values, ",")
+	if namespace != "" && namespace != instance.GetNamespace() {
+		annotations[applyset.ApplySetAdditionalNamespacesAnnotation] = namespace
+	}
+	instance.SetAnnotations(annotations)
+	labels := instance.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[applyset.ApplySetParentIDLabel] = applyset.ID(instance)
+	instance.SetLabels(labels)
+}
+
+// newManagedObject creates a stable ApplySet member in the parent's persisted scope.
+func newManagedObject(base, instance *unstructured.Unstructured, nodeID string, order int) *unstructured.Unstructured {
 	obj := base.DeepCopy()
+	addDeletionScope(instance, obj.GroupVersionKind(), obj.GetNamespace())
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	labels[metadata.InstanceIDLabel] = instanceUID
+	labels[metadata.InstanceIDLabel] = string(instance.GetUID())
 	labels[metadata.NodeIDLabel] = nodeID
+	labels[metadata.ApplyOrderLabel] = strconv.Itoa(order)
+	labels[applyset.ApplysetPartOfLabel] = applyset.ID(instance)
 	obj.SetLabels(labels)
+	obj.SetUID(types.UID(nodeID + "-uid"))
 	return obj
 }
 
 func TestDiscoverLiveResources(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -64,11 +106,11 @@ func TestDiscoverLiveResources(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
 
-	live, err := controller.discoverLiveResources(rcx)
+	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
 	require.Len(t, live, 1)
 	assert.Equal(t, "demo", live[0].Object.GetName())
@@ -101,11 +143,11 @@ func TestDiscoverLiveResourcesSkipsExternalNodes(t *testing.T) {
 	// The external ConfigMap exists but should not be discovered.
 	sourceCM := newConfigMapObject("source", "default")
 	sourceCM.SetLabels(map[string]string{metadata.InstanceIDLabel: uid, metadata.NodeIDLabel: "source"})
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), sourceCM, managed)
 
-	live, err := controller.discoverLiveResources(rcx)
+	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
 	require.Len(t, live, 1)
 	assert.Equal(t, "demo", live[0].Object.GetName())
@@ -113,7 +155,6 @@ func TestDiscoverLiveResourcesSkipsExternalNodes(t *testing.T) {
 
 func TestDiscoverLiveResourcesMultipleGVRs(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -134,12 +175,12 @@ func TestDiscoverLiveResourcesMultipleGVRs(t *testing.T) {
 		Template: newConfigMapObject("config", ""),
 	}
 
-	managedDeploy := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
-	managedCM := newManagedObject(newConfigMapObject("config", "default"), uid, "config")
+	managedDeploy := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
+	managedCM := newManagedObject(newConfigMapObject("config", "default"), instance, "config", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode, cmNode), managedDeploy, managedCM)
 
-	live, err := controller.discoverLiveResources(rcx)
+	live, _, err := controller.discoverDeletionInventory(rcx)
 	require.NoError(t, err)
 	assert.Len(t, live, 2)
 }
@@ -157,19 +198,19 @@ func TestDiscoverLiveResourcesListError(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
+	addDeletionScope(instance, controllerTestDeployGVK, "default")
 	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode))
 	raw.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
 		return true, nil, errors.New("list failed")
 	})
 
-	_, err := controller.discoverLiveResources(rcx)
+	_, _, err := controller.discoverDeletionInventory(rcx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list failed")
 }
 
 func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -181,7 +222,7 @@ func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
 
@@ -216,7 +257,6 @@ func TestReconcileDeletionRemovesFinalizerWhenNoLiveResources(t *testing.T) {
 
 func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -228,7 +268,7 @@ func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 	now := metav1.NewTime(time.Now())
 	managed.SetDeletionTimestamp(&now)
 
@@ -250,7 +290,6 @@ func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
 
 func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -262,7 +301,7 @@ func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("demo", "default"), instance, "deploy", 1)
 
 	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
 	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
@@ -277,7 +316,6 @@ func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 
 func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	externalNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -301,7 +339,7 @@ func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
 
 	// External ref is gone — not in the fake client.
 	// Managed resource still exists (has a controller finalizer keeping it alive).
-	managed := newManagedObject(newDeploymentObject("mirror", "default"), uid, "mirror")
+	managed := newManagedObject(newDeploymentObject("mirror", "default"), instance, "mirror", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), managed)
 
@@ -314,7 +352,6 @@ func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
 
 func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	uid := string(instance.GetUID())
 
 	externalNode := &graph.Node{
 		Meta: graph.NodeMeta{
@@ -336,7 +373,7 @@ func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
 	}
 
 	// One managed resource still alive — the state loop will run.
-	managed := newManagedObject(newDeploymentObject("deploy", "default"), uid, "deploy")
+	managed := newManagedObject(newDeploymentObject("deploy", "default"), instance, "deploy", 2)
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, managedNode), managed)
 
@@ -345,6 +382,175 @@ func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
 	require.ErrorAs(t, err, &retryAfter)
 	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["ext"].State)
 	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestReconcileDeletionDeletesOnlyHighestOrderWave(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
+		return true, nil, nil
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, []string{"b"}, deleted)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["a"].State)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["b"].State)
+}
+
+func TestReconcileDeletionAdvancesAfterHigherWaveDisappears(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	require.Error(t, controller.reconcileDeletion(rcx))
+
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
+		return true, nil, nil
+	})
+	require.Error(t, controller.reconcileDeletion(rcx))
+	assert.Equal(t, []string{"a"}, deleted)
+}
+
+func TestReconcileDeletionTerminatingHighestOrderBlocksLowerOrders(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+	now := metav1.Now()
+	b.SetDeletionTimestamp(&now)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	deletes := 0
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deletes++
+		return true, nil, nil
+	})
+
+	require.Error(t, controller.reconcileDeletion(rcx))
+	assert.Zero(t, deletes)
+}
+
+func TestReconcileDeletionDeletesAllResourcesInHighestWave(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	node := &graph.Node{Meta: graph.NodeMeta{ID: "workers", Type: graph.NodeTypeCollection, GVR: controllerTestDeployGVR, Namespaced: true}}
+	one := newManagedObject(newDeploymentObject("one", "default"), instance, "workers", 3)
+	two := newManagedObject(newDeploymentObject("two", "default"), instance, "workers", 3)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(node), one, two)
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
+		return true, nil, nil
+	})
+
+	require.Error(t, controller.reconcileDeletion(rcx))
+	sort.Strings(deleted)
+	assert.Equal(t, []string{"one", "two"}, deleted)
+}
+
+func TestHighestDeletionWaveReturnsMatchingCandidates(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	candidates := []applyset.OrphanCandidate{
+		{Object: newManagedObject(newDeploymentObject("one", "default"), instance, "workers", 1)},
+		{Object: newManagedObject(newDeploymentObject("two", "default"), instance, "workers", 3)},
+		{Object: newManagedObject(newDeploymentObject("three", "default"), instance, "workers", 3)},
+	}
+
+	wave, highest, orderErr := highestDeletionWave(candidates)
+	require.NoError(t, orderErr)
+	require.Len(t, wave, 2)
+	assert.Equal(t, 3, highest)
+	assert.Equal(t, "two", wave[0].Object.GetName())
+	assert.Equal(t, "three", wave[1].Object.GetName())
+}
+
+func TestReconcileDeletionRejectsInvalidOrderBeforeDeleting(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  *string
+	}{
+		{name: "missing"},
+		{name: "malformed", raw: ptr.To("later")},
+		{name: "zero", raw: ptr.To("0")},
+		{name: "negative", raw: ptr.To("-1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newInstanceObject("demo", "default")
+			nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+			nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+			a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+			b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+			labels := b.GetLabels()
+			delete(labels, metadata.ApplyOrderLabel)
+			if tt.raw != nil {
+				labels[metadata.ApplyOrderLabel] = *tt.raw
+			}
+			b.SetLabels(labels)
+
+			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+			deletes := 0
+			raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+				deletes++
+				return true, nil, nil
+			})
+
+			err := controller.reconcileDeletion(rcx)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), metadata.ApplyOrderLabel)
+			assert.Contains(t, err.Error(), "default/b")
+			assert.Zero(t, deletes)
+			assert.Equal(t, v1alpha1.NodeStateError, rcx.StateManager.NodeStates["b"].State)
+		})
+	}
+}
+
+func TestReconcileDeletionUIDConflictDoesNotAdvance(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	nodeA := &graph.Node{Meta: graph.NodeMeta{ID: "a", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	nodeB := &graph.Node{Meta: graph.NodeMeta{ID: "b", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	a := newManagedObject(newDeploymentObject("a", "default"), instance, "a", 1)
+	b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		name := action.(k8stesting.DeleteAction).GetName()
+		deleted = append(deleted, name)
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "apps", Resource: "deployments"}, name, errors.New("UID mismatch"))
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, []string{"b"}, deleted)
+}
+
+func TestDeletionInventoryIncludesRemovedGraphNodes(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	current := &graph.Node{Meta: graph.NodeMeta{ID: "current", Type: graph.NodeTypeResource, GVR: controllerTestDeployGVR, Namespaced: true}}
+	removed := newManagedObject(newDeploymentObject("removed", "default"), instance, "old-node", 4)
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(current), removed)
+
+	candidates, _, err := controller.discoverDeletionInventory(rcx)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "removed", candidates[0].Object.GetName())
 }
 
 // --- Tests for setUnmanaged and removeFinalizer (unchanged) ---

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,37 +31,30 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
-	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
-	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
 )
 
-func TestPlanNodesForDeletionSkipsUnresolvedIdentityAndPicksLastExistingNode(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-
-	pendingNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "pending",
-			Type:       graph.NodeTypeResource,
-			GVR:        controllerTestDeployGVR,
-			Namespaced: true,
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
-				"kind":       controllerTestDeployGVK.Kind,
-				"metadata": map[string]interface{}{
-					"name": "${schema.spec.name}",
-				},
-			},
-		},
-		Variables: []*variable.ResourceField{
-			standaloneField("metadata.name", mustCompileControllerExpr(t, "schema.spec.name", "schema"), variable.ResourceVariableKindStatic),
-		},
+// newManagedObject creates a resource with the kro ownership labels that
+// discoverLiveResources uses to find managed resources.
+func newManagedObject(base *unstructured.Unstructured, instanceUID, nodeID string) *unstructured.Unstructured {
+	obj := base.DeepCopy()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
 	}
-	existingNode := &graph.Node{
+	labels[metadata.InstanceIDLabel] = instanceUID
+	labels[metadata.NodeIDLabel] = nodeID
+	obj.SetLabels(labels)
+	return obj
+}
+
+func TestDiscoverLiveResources(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
 			ID:         "deploy",
 			Type:       graph.NodeTypeResource,
@@ -70,193 +64,31 @@ func TestPlanNodesForDeletionSkipsUnresolvedIdentityAndPicksLastExistingNode(t *
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(pendingNode, existingNode), newDeploymentObject("demo", "default"))
-	node, err := controller.planNodesForDeletion(rcx)
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+
+	live, err := controller.discoverLiveResources(rcx)
 	require.NoError(t, err)
-	require.NotNil(t, node)
-	assert.Equal(t, "deploy", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateDeleted, rcx.StateManager.NodeStates["pending"].State)
-	assert.Equal(t, v1alpha1.NodeStateInProgress, rcx.StateManager.NodeStates["deploy"].State)
+	require.Len(t, live, 1)
+	assert.Equal(t, "demo", live[0].Object.GetName())
+	assert.Equal(t, controllerTestDeployGVR, live[0].GVR)
 }
 
-func TestPlanNodesForDeletionSkipsIgnoredExternalAndMissingNodes(t *testing.T) {
+func TestDiscoverLiveResourcesSkipsExternalNodes(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
-	_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
-	_ = unstructured.SetNestedField(instance.Object, false, "spec", "enabled")
+	uid := string(instance.GetUID())
 
-	ignoredNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "ignored",
-			Type:       graph.NodeTypeResource,
-			GVR:        controllerTestDeployGVR,
-			Namespaced: true,
-		},
-		Template: newDeploymentObject("ignored", ""),
-		IncludeWhen: []*krocel.Expression{
-			mustCompileControllerExpr(t, "schema.spec.enabled", "schema"),
-		},
-	}
 	externalNode := &graph.Node{
 		Meta: graph.NodeMeta{
-			ID:         "external",
+			ID:         "source",
 			Type:       graph.NodeTypeExternal,
 			GVR:        controllerTestCMGVR,
 			Namespaced: true,
 		},
-		Template: newConfigMapObject("external", ""),
+		Template: newConfigMapObject("source", ""),
 	}
-	collectionNode := newDeletionCollectionNode(t, "configs")
-	missingNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "missing",
-			Type:       graph.NodeTypeResource,
-			GVR:        controllerTestDeployGVR,
-			Namespaced: true,
-		},
-		Template: newDeploymentObject("missing", ""),
-	}
-
-	currentCollection := newConfigMapObject("one", "default")
-	currentCollection.SetLabels(map[string]string{
-		metadata.InstanceIDLabel: string(instance.GetUID()),
-		metadata.NodeIDLabel:     "configs",
-	})
-
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(ignoredNode, externalNode, collectionNode, missingNode), currentCollection)
-	node, err := controller.planNodesForDeletion(rcx)
-	require.NoError(t, err)
-	require.NotNil(t, node)
-	assert.Equal(t, "configs", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["ignored"].State)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["external"].State)
-	assert.Equal(t, v1alpha1.NodeStateDeleted, rcx.StateManager.NodeStates["missing"].State)
-}
-
-func TestPlanNodesForDeletionErrors(t *testing.T) {
-	tests := []struct {
-		name      string
-		node      *graph.Node
-		configure func(*unstructured.Unstructured)
-		verb      string
-		resource  string
-		wantErr   string
-	}{
-		{
-			name: "list errors bubble up for collection nodes",
-			node: newDeletionCollectionNode(t, "configs"),
-			configure: func(instance *unstructured.Unstructured) {
-				_ = unstructured.SetNestedSlice(instance.Object, []interface{}{"one"}, "spec", "items")
-			},
-			verb:     "list",
-			resource: "configmaps",
-			wantErr:  "list failed",
-		},
-		{
-			name: "get errors bubble up for resource nodes",
-			node: &graph.Node{
-				Meta: graph.NodeMeta{
-					ID:         "deploy",
-					Type:       graph.NodeTypeResource,
-					GVR:        controllerTestDeployGVR,
-					Namespaced: true,
-				},
-				Template: newDeploymentObject("demo", ""),
-			},
-			verb:     "get",
-			resource: "deployments",
-			wantErr:  "get failed",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			instance := newInstanceObject("demo", "default")
-			if tt.configure != nil {
-				tt.configure(instance)
-			}
-
-			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(tt.node))
-			raw.PrependReactor(tt.verb, tt.resource, func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
-				return true, nil, errors.New(tt.wantErr)
-			})
-
-			_, err := controller.planNodesForDeletion(rcx)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
-		})
-	}
-}
-
-func TestDeleteTarget(t *testing.T) {
-	tests := []struct {
-		name        string
-		observed    []*unstructured.Unstructured
-		deleteErr   string
-		wantState   v1alpha1.NodeState
-		wantErrText string
-	}{
-		{
-			name:      "marks deleted when there are no targets",
-			wantState: v1alpha1.NodeStateDeleted,
-		},
-		{
-			name:      "marks deleted when the target no longer exists",
-			observed:  []*unstructured.Unstructured{newDeploymentObject("gone", "default")},
-			wantState: v1alpha1.NodeStateDeleted,
-		},
-		{
-			name:      "marks deleting when the API accepted deletion",
-			observed:  []*unstructured.Unstructured{newDeploymentObject("demo", "default")},
-			wantState: v1alpha1.NodeStateDeleting,
-		},
-		{
-			name:        "marks error when deletion fails",
-			observed:    []*unstructured.Unstructured{newDeploymentObject("demo", "default")},
-			deleteErr:   "delete failed",
-			wantState:   v1alpha1.NodeStateError,
-			wantErrText: "delete failed",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			instance := newInstanceObject("demo", "default")
-			resourceNode := &graph.Node{
-				Meta: graph.NodeMeta{
-					ID:         "deploy",
-					Type:       graph.NodeTypeResource,
-					GVR:        controllerTestDeployGVR,
-					Namespaced: true,
-				},
-				Template: newDeploymentObject("demo", ""),
-			}
-
-			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(resourceNode), newDeploymentObject("demo", "default"))
-			node := rcx.Runtime.Nodes()[0]
-			node.SetObserved(tt.observed)
-
-			if tt.deleteErr != "" {
-				raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
-					return true, nil, errors.New(tt.deleteErr)
-				})
-			}
-
-			state := rcx.StateManager.NewNodeState(tt.name)
-			err := controller.deleteTarget(rcx, node, state)
-			if tt.wantErrText != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErrText)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tt.wantState, state.State)
-		})
-	}
-}
-
-func TestReconcileDeletionRequeuesWhileChildDeletionInFlight(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-	node := &graph.Node{
+	deployNode := &graph.Node{
 		Meta: graph.NodeMeta{
 			ID:         "deploy",
 			Type:       graph.NodeTypeResource,
@@ -266,12 +98,256 @@ func TestReconcileDeletionRequeuesWhileChildDeletionInFlight(t *testing.T) {
 		Template: newDeploymentObject("demo", ""),
 	}
 
-	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(node), newDeploymentObject("demo", "default"))
+	// The external ConfigMap exists but should not be discovered.
+	sourceCM := newConfigMapObject("source", "default")
+	sourceCM.SetLabels(map[string]string{metadata.InstanceIDLabel: uid, metadata.NodeIDLabel: "source"})
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), sourceCM, managed)
+
+	live, err := controller.discoverLiveResources(rcx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	assert.Equal(t, "demo", live[0].Object.GetName())
+}
+
+func TestDiscoverLiveResourcesMultipleGVRs(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+	cmNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "config",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("config", ""),
+	}
+
+	managedDeploy := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	managedCM := newManagedObject(newConfigMapObject("config", "default"), uid, "config")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode, cmNode), managedDeploy, managedCM)
+
+	live, err := controller.discoverLiveResources(rcx)
+	require.NoError(t, err)
+	assert.Len(t, live, 2)
+}
+
+func TestDiscoverLiveResourcesListError(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode))
+	raw.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("list failed")
+	})
+
+	_, err := controller.discoverLiveResources(rcx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list failed")
+}
+
+func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+
 	err := controller.reconcileDeletion(rcx)
 	var retryAfter *requeue.RequeueNeededAfter
 	require.ErrorAs(t, err, &retryAfter)
 	assert.Equal(t, v1alpha1.InstanceStateDeleting, rcx.StateManager.State)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
 }
+
+func TestReconcileDeletionRemovesFinalizerWhenNoLiveResources(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	metadata.SetInstanceFinalizer(instance)
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	// No managed objects in the cluster.
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(deployNode))
+
+	err := controller.reconcileDeletion(rcx)
+	require.NoError(t, err)
+	assert.False(t, metadata.HasInstanceFinalizer(rcx.Instance))
+}
+
+func TestReconcileDeletionSkipsAlreadyTerminatingResources(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+	now := metav1.NewTime(time.Now())
+	managed.SetDeletionTimestamp(&now)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+
+	// Track whether DELETE is called — it should NOT be.
+	deletesCalled := 0
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deletesCalled++
+		return false, nil, nil
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, 0, deletesCalled, "DELETE should not be called for already-terminating resources")
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	managed := newManagedObject(newDeploymentObject("demo", "default"), uid, "deploy")
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(deployNode), managed)
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		return true, nil, errors.New("delete failed")
+	})
+
+	err := controller.reconcileDeletion(rcx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete failed")
+	assert.Equal(t, v1alpha1.NodeStateError, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	externalNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "source",
+			Type:       graph.NodeTypeExternal,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("source", ""),
+	}
+	deployNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:           "mirror",
+			Type:         graph.NodeTypeResource,
+			GVR:          controllerTestDeployGVR,
+			Namespaced:   true,
+			Dependencies: []string{"source"},
+		},
+		Template: newDeploymentObject("mirror", ""),
+	}
+
+	// External ref is gone — not in the fake client.
+	// Managed resource still exists (has a controller finalizer keeping it alive).
+	managed := newManagedObject(newDeploymentObject("mirror", "default"), uid, "mirror")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, deployNode), managed)
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["mirror"].State)
+	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["source"].State)
+}
+
+func TestReconcileDeletionMarksExternalAndMissingNodesCorrectly(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	uid := string(instance.GetUID())
+
+	externalNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "ext",
+			Type:       graph.NodeTypeExternal,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("ext", ""),
+	}
+	managedNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("deploy", ""),
+	}
+
+	// One managed resource still alive — the state loop will run.
+	managed := newManagedObject(newDeploymentObject("deploy", "default"), uid, "deploy")
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(externalNode, managedNode), managed)
+
+	err := controller.reconcileDeletion(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["ext"].State)
+	assert.Equal(t, v1alpha1.NodeStateDeleting, rcx.StateManager.NodeStates["deploy"].State)
+}
+
+// --- Tests for setUnmanaged and removeFinalizer (unchanged) ---
 
 func TestSetUnmanaged(t *testing.T) {
 	tests := []struct {
@@ -398,159 +474,4 @@ func TestRemoveFinalizerMarksInstanceNotManagedOnError(t *testing.T) {
 	err := controller.removeFinalizer(rcx)
 	require.Error(t, err)
 	assert.Equal(t, metav1.ConditionFalse, conditionByType(t, rcx.Instance, InstanceManaged).Status)
-}
-
-// TestPlanNodesForDeletionObservesExternalRefRootBeforeManagedNode verifies that
-// when an external ref is the topological root and a managed resource's identity
-// depends on a field from that external ref, the external ref is observed first
-// so the managed resource's identity can be resolved and the resource is selected
-// for deletion.
-func TestPlanNodesForDeletionObservesExternalRefRootBeforeManagedNode(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-
-	// External ref node: static name, no CEL deps.
-	externalNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "external",
-			Type:       graph.NodeTypeExternal,
-			GVR:        controllerTestCMGVR,
-			Namespaced: true,
-		},
-		Template: newConfigMapObject("source-configmap", "default"),
-	}
-
-	// Managed node: identity depends on external.data.managedName.
-	managedNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:           "deploy",
-			Type:         graph.NodeTypeResource,
-			GVR:          controllerTestDeployGVR,
-			Namespaced:   true,
-			Dependencies: []string{"external"},
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestDeployGVK.GroupVersion().String(),
-				"kind":       controllerTestDeployGVK.Kind,
-				"metadata": map[string]interface{}{
-					"name": "${external.data.managedName}",
-				},
-			},
-		},
-		Variables: []*variable.ResourceField{
-			standaloneField("metadata.name",
-				mustCompileControllerExpr(t, "external.data.managedName", "external"),
-				variable.ResourceVariableKindStatic),
-		},
-	}
-
-	// The external ConfigMap provides the name of the managed resource.
-	sourceCM := newConfigMapObject("source-configmap", "default")
-	sourceCM.Object["data"] = map[string]interface{}{"managedName": "managed-deploy"}
-
-	// The managed resource exists under the name resolved from the external ref.
-	managedDeploy := newDeploymentObject("managed-deploy", "default")
-
-	// Topological order: external first (root), then managed (leaf).
-	controller, rcx, _ := newControllerAndContext(t, instance,
-		newTestGraph(externalNode, managedNode),
-		sourceCM, managedDeploy,
-	)
-
-	node, err := controller.planNodesForDeletion(rcx)
-	require.NoError(t, err)
-
-	require.NotNil(t, node, "managed resource must be selected for deletion, not treated as already deleted")
-	assert.Equal(t, "deploy", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["external"].State)
-	assert.Equal(t, v1alpha1.NodeStateInProgress, rcx.StateManager.NodeStates["deploy"].State)
-}
-
-// TestPlanNodesForDeletionObservesExternalCollectionRootBeforeManagedNode verifies
-// the same ordering invariant as the ExternalRef test but for an external collection
-// root whose selector is resolved from a dep field.
-func TestPlanNodesForDeletionObservesExternalCollectionRootBeforeManagedNode(t *testing.T) {
-	instance := newInstanceObject("demo", "default")
-	_ = unstructured.SetNestedField(instance.Object, "default", "spec", "ns")
-
-	// External collection node: selector is static, namespace driven by instance.
-	externalColNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         "external",
-			Type:       graph.NodeTypeExternalCollection,
-			GVR:        controllerTestCMGVR,
-			Namespaced: true,
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
-				"kind":       controllerTestCMGVK.Kind,
-				"metadata": map[string]interface{}{
-					"namespace": "default",
-					"selector":  map[string]interface{}{"app": "source"},
-				},
-			},
-		},
-	}
-
-	// Managed node: depends on data from the external collection items.
-	managedNode := &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:           "deploy",
-			Type:         graph.NodeTypeResource,
-			GVR:          controllerTestDeployGVR,
-			Namespaced:   true,
-			Dependencies: []string{"external"},
-		},
-		Template: newDeploymentObject("managed-deploy", "default"),
-	}
-
-	// Two CMs matching the selector exist in the fake client.
-	cm1 := newConfigMapObject("source-1", "default")
-	cm1.SetLabels(map[string]string{"app": "source"})
-	cm2 := newConfigMapObject("source-2", "default")
-	cm2.SetLabels(map[string]string{"app": "source"})
-	managedDeploy := newDeploymentObject("managed-deploy", "default")
-
-	controller, rcx, _ := newControllerAndContext(t, instance,
-		newTestGraph(externalColNode, managedNode),
-		cm1, cm2, managedDeploy,
-	)
-
-	node, err := controller.planNodesForDeletion(rcx)
-	require.NoError(t, err)
-
-	require.NotNil(t, node, "managed resource must be selected for deletion")
-	assert.Equal(t, "deploy", node.Spec.Meta.ID)
-	assert.Equal(t, v1alpha1.NodeStateSkipped, rcx.StateManager.NodeStates["external"].State)
-	assert.Equal(t, v1alpha1.NodeStateInProgress, rcx.StateManager.NodeStates["deploy"].State)
-}
-
-func newDeletionCollectionNode(t *testing.T, id string) *graph.Node {
-	t.Helper()
-
-	return &graph.Node{
-		Meta: graph.NodeMeta{
-			ID:         id,
-			Type:       graph.NodeTypeCollection,
-			GVR:        controllerTestCMGVR,
-			Namespaced: true,
-		},
-		Template: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": controllerTestCMGVK.GroupVersion().String(),
-				"kind":       controllerTestCMGVK.Kind,
-				"metadata": map[string]interface{}{
-					"name": "${item}",
-				},
-			},
-		},
-		Variables: []*variable.ResourceField{
-			standaloneField("metadata.name", mustCompileControllerExpr(t, "item", "item"), variable.ResourceVariableKindIteration),
-		},
-		ForEach: []graph.ForEachDimension{{
-			Name:       "item",
-			Expression: mustCompileControllerExpr(t, "schema.spec.items", "schema"),
-		}},
-	}
 }

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -249,6 +249,21 @@ func TestDiscoverDeletionInventoryRejectsMissingScope(t *testing.T) {
 	assert.Zero(t, lists, "invalid inventory must fail before listing resources")
 }
 
+func TestReconcileDeletionSurfacesInvalidInventory(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	metadata.SetInstanceFinalizer(instance)
+	controller, dcx, _ := newControllerAndDeletionContext(t, instance, newTestGraph())
+
+	err := controller.reconcileDeletion(dcx)
+	require.Error(t, err)
+	condition := conditionByType(t, dcx.Instance, ResourcesReady)
+	assert.Equal(t, metav1.ConditionUnknown, condition.Status)
+	require.NotNil(t, condition.Message)
+	assert.Contains(t, *condition.Message, "deletion blocked")
+	assert.Contains(t, *condition.Message, applyset.ApplySetParentIDLabel)
+	assert.True(t, metadata.HasInstanceFinalizer(dcx.Instance))
+}
+
 func TestReconcileDeletionDeletesAllAndRequeues(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 
@@ -352,6 +367,10 @@ func TestReconcileDeletionDeleteErrorBubblesUp(t *testing.T) {
 	err := controller.reconcileDeletion(rcx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete failed")
+	condition := conditionByType(t, rcx.Instance, ResourcesReady)
+	require.NotNil(t, condition.Message)
+	assert.Contains(t, *condition.Message, "deletion blocked")
+	assert.Contains(t, *condition.Message, "delete failed")
 }
 
 func TestReconcileDeletionExternalRefGoneDoesNotBlock(t *testing.T) {

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/ptr"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
@@ -469,25 +468,25 @@ func TestHighestDeletionWaveReturnsMatchingCandidates(t *testing.T) {
 		{Object: newManagedObject(newDeploymentObject("one", "default"), instance, "workers", 1)},
 		{Object: newManagedObject(newDeploymentObject("two", "default"), instance, "workers", 3)},
 		{Object: newManagedObject(newDeploymentObject("three", "default"), instance, "workers", 3)},
+		{Object: newManagedObject(newDeploymentObject("fallback", "default"), instance, "workers", 0)},
 	}
 
-	wave, highest, orderErr := highestDeletionWave(candidates)
-	require.NoError(t, orderErr)
+	wave, highest := highestDeletionWave(candidates)
 	require.Len(t, wave, 2)
 	assert.Equal(t, 3, highest)
 	assert.Equal(t, "two", wave[0].Object.GetName())
 	assert.Equal(t, "three", wave[1].Object.GetName())
 }
 
-func TestReconcileDeletionRejectsInvalidOrderBeforeDeleting(t *testing.T) {
+func TestReconcileDeletionDefersInvalidOrdersUntilLastWave(t *testing.T) {
 	tests := []struct {
 		name string
-		raw  *string
+		raw  string
 	}{
 		{name: "missing"},
-		{name: "malformed", raw: ptr.To("later")},
-		{name: "zero", raw: ptr.To("0")},
-		{name: "negative", raw: ptr.To("-1")},
+		{name: "malformed", raw: "later"},
+		{name: "zero", raw: "0"},
+		{name: "negative", raw: "-1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -498,26 +497,56 @@ func TestReconcileDeletionRejectsInvalidOrderBeforeDeleting(t *testing.T) {
 			b := newManagedObject(newDeploymentObject("b", "default"), instance, "b", 2)
 			labels := b.GetLabels()
 			delete(labels, metadata.ApplyOrderLabel)
-			if tt.raw != nil {
-				labels[metadata.ApplyOrderLabel] = *tt.raw
+			if tt.raw != "" {
+				labels[metadata.ApplyOrderLabel] = tt.raw
 			}
 			b.SetLabels(labels)
 
 			controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(nodeA, nodeB), a, b)
-			deletes := 0
+
+			// The valid order runs before the fallback wave.
+			require.Error(t, controller.reconcileDeletion(rcx))
+			_, err := raw.Tracker().Get(controllerTestDeployGVR, "default", "a")
+			require.Error(t, err)
+			_, err = raw.Tracker().Get(controllerTestDeployGVR, "default", "b")
+			require.NoError(t, err)
+
+			var deleted []string
 			raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
-				deletes++
+				deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
 				return true, nil, nil
 			})
 
-			err := controller.reconcileDeletion(rcx)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), metadata.ApplyOrderLabel)
-			assert.Contains(t, err.Error(), "default/b")
-			assert.Zero(t, deletes)
-			assert.Equal(t, v1alpha1.NodeStateError, rcx.StateManager.NodeStates["b"].State)
+			require.Error(t, controller.reconcileDeletion(rcx))
+			assert.Equal(t, []string{"b"}, deleted)
 		})
 	}
+}
+
+func TestReconcileDeletionDeletesInvalidOrdersInSharedFallbackWave(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	node := &graph.Node{Meta: graph.NodeMeta{
+		ID: "workers", Type: graph.NodeTypeCollection, GVR: controllerTestDeployGVR, Namespaced: true,
+	}}
+	one := newManagedObject(newDeploymentObject("one", "default"), instance, "workers", 1)
+	two := newManagedObject(newDeploymentObject("two", "default"), instance, "workers", 1)
+	oneLabels := one.GetLabels()
+	delete(oneLabels, metadata.ApplyOrderLabel)
+	one.SetLabels(oneLabels)
+	twoLabels := two.GetLabels()
+	twoLabels[metadata.ApplyOrderLabel] = "invalid"
+	two.SetLabels(twoLabels)
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(node), one, two)
+	var deleted []string
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleted = append(deleted, action.(k8stesting.DeleteAction).GetName())
+		return true, nil, nil
+	})
+
+	require.Error(t, controller.reconcileDeletion(rcx))
+	sort.Strings(deleted)
+	assert.Equal(t, []string{"one", "two"}, deleted)
 }
 
 func TestReconcileDeletionUIDConflictDoesNotAdvance(t *testing.T) {

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -194,8 +195,8 @@ func (c *Controller) processNodes(
 	var resources []applyset.Resource
 
 	var firstUnresolvedErr error
-	for _, node := range nodes {
-		resourcesToAdd, err := c.processNode(rcx, node)
+	for i, node := range nodes {
+		resourcesToAdd, err := c.processNode(rcx, node, i+1)
 		if err != nil {
 			if !runtime.IsDataPending(err) {
 				return nil, err
@@ -337,6 +338,7 @@ func (c *Controller) createApplySet(rcx *ReconcileContext) *applyset.ApplySet {
 func (c *Controller) processNode(
 	rcx *ReconcileContext,
 	node *runtime.Node,
+	applyOrder int,
 ) ([]applyset.Resource, error) {
 	id := node.Spec.Meta.ID
 	rcx.Log.V(3).Info("Preparing resource", "id", id)
@@ -381,9 +383,9 @@ func (c *Controller) processNode(
 	case graph.NodeTypeExternalCollection:
 		nodeState, err = c.processExternalCollectionNode(rcx, node, desired)
 	case graph.NodeTypeCollection:
-		resources, nodeState, err = c.processCollectionNode(rcx, node, desired)
+		resources, nodeState, err = c.processCollectionNode(rcx, node, desired, applyOrder)
 	case graph.NodeTypeResource:
-		resources, nodeState, err = c.processRegularNode(rcx, node, desired)
+		resources, nodeState, err = c.processRegularNode(rcx, node, desired, applyOrder)
 	case graph.NodeTypeInstance:
 		panic("instance node should not be processed for apply")
 	default:
@@ -400,6 +402,7 @@ func (c *Controller) processRegularNode(
 	rcx *ReconcileContext,
 	node *runtime.Node,
 	desiredList []*unstructured.Unstructured,
+	applyOrder int,
 ) ([]applyset.Resource, NodeState, error) {
 	id := node.Spec.Meta.ID
 	nodeMeta := node.Spec.Meta
@@ -436,7 +439,7 @@ func (c *Controller) processRegularNode(
 	}
 
 	// Apply decorator labels to desired object
-	c.applyDecoratorLabels(rcx, desired, id, nil)
+	c.applyDecoratorLabels(rcx, desired, id, applyOrder, nil)
 
 	resource := applyset.Resource{
 		ID:      id,
@@ -452,6 +455,7 @@ func (c *Controller) applyDecoratorLabels(
 	rcx *ReconcileContext,
 	obj *unstructured.Unstructured,
 	nodeID string,
+	applyOrder int,
 	collectionInfo *CollectionInfo,
 ) {
 	labels := obj.GetLabels()
@@ -479,6 +483,7 @@ func (c *Controller) applyDecoratorLabels(
 
 	// Add node ID label
 	labels[metadata.NodeIDLabel] = nodeID
+	labels[metadata.ApplyOrderLabel] = strconv.Itoa(applyOrder)
 
 	// Add collection labels if applicable
 	if collectionInfo != nil {

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -195,8 +195,17 @@ func (c *Controller) processNodes(
 	var resources []applyset.Resource
 
 	var firstUnresolvedErr error
-	for i, node := range nodes {
-		resourcesToAdd, err := c.processNode(rcx, node, i+1)
+	for _, node := range nodes {
+		applyOrder, ok := rcx.Runtime.ApplyOrder(node.Spec.Meta.ID)
+		if !ok {
+			rcx.Log.Error(
+				fmt.Errorf("apply-order wave missing for node %q", node.Spec.Meta.ID),
+				"using fallback apply order",
+				"nodeID", node.Spec.Meta.ID,
+			)
+			applyOrder = fallbackDeletionOrder
+		}
+		resourcesToAdd, err := c.processNode(rcx, node, applyOrder)
 		if err != nil {
 			if !runtime.IsDataPending(err) {
 				return nil, err

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -448,7 +448,7 @@ func (c *Controller) processRegularNode(
 	}
 
 	// Apply decorator labels to desired object
-	c.applyDecoratorLabels(rcx, desired, id, applyOrder, nil)
+	c.applyDecoratorMetadata(rcx, desired, id, applyOrder, nil)
 
 	resource := applyset.Resource{
 		ID:      id,
@@ -459,8 +459,8 @@ func (c *Controller) processRegularNode(
 	return []applyset.Resource{resource}, inProgressState(), nil
 }
 
-// applyDecoratorLabels merges tool labels and adds node/collection identifiers.
-func (c *Controller) applyDecoratorLabels(
+// applyDecoratorMetadata adds controller-owned labels and annotations.
+func (c *Controller) applyDecoratorMetadata(
 	rcx *ReconcileContext,
 	obj *unstructured.Unstructured,
 	nodeID string,
@@ -490,9 +490,8 @@ func (c *Controller) applyDecoratorLabels(
 		labels[k] = v
 	}
 
-	// Add node ID label
+	// Add searchable identity labels and persist deletion order as an annotation.
 	labels[metadata.NodeIDLabel] = nodeID
-	labels[metadata.ApplyOrderLabel] = strconv.Itoa(applyOrder)
 
 	// Add collection labels if applicable
 	if collectionInfo != nil {
@@ -501,6 +500,13 @@ func (c *Controller) applyDecoratorLabels(
 	}
 
 	obj.SetLabels(labels)
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[metadata.ApplyOrderAnnotation] = strconv.Itoa(applyOrder)
+	obj.SetAnnotations(annotations)
 }
 
 // patchInstanceWithApplySetMetadata applies applyset metadata to the parent instance.

--- a/pkg/controller/instance/resources_collection.go
+++ b/pkg/controller/instance/resources_collection.go
@@ -39,6 +39,7 @@ func (c *Controller) processCollectionNode(
 	rcx *ReconcileContext,
 	node *runtime.Node,
 	expandedResources []*unstructured.Unstructured,
+	applyOrder int,
 ) ([]applyset.Resource, NodeState, error) {
 	id := node.Spec.Meta.ID
 	nodeMeta := node.Spec.Meta
@@ -97,7 +98,7 @@ func (c *Controller) processCollectionNode(
 	for i, expandedResource := range expandedResources {
 		// Apply decorator labels with collection info
 		collectionInfo := &CollectionInfo{Index: i, Size: collectionSize}
-		c.applyDecoratorLabels(rcx, expandedResource, id, collectionInfo)
+		c.applyDecoratorLabels(rcx, expandedResource, id, applyOrder, collectionInfo)
 
 		// Look up current revision from LIST results
 		key := expandedResource.GetNamespace() + "/" + expandedResource.GetName()

--- a/pkg/controller/instance/resources_collection.go
+++ b/pkg/controller/instance/resources_collection.go
@@ -98,7 +98,7 @@ func (c *Controller) processCollectionNode(
 	for i, expandedResource := range expandedResources {
 		// Apply decorator labels with collection info
 		collectionInfo := &CollectionInfo{Index: i, Size: collectionSize}
-		c.applyDecoratorLabels(rcx, expandedResource, id, applyOrder, collectionInfo)
+		c.applyDecoratorMetadata(rcx, expandedResource, id, applyOrder, collectionInfo)
 
 		// Look up current revision from LIST results
 		key := expandedResource.GetNamespace() + "/" + expandedResource.GetName()

--- a/pkg/controller/instance/resources_external.go
+++ b/pkg/controller/instance/resources_external.go
@@ -24,23 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/runtime"
 )
-
-// observeExternal observes an external node (ref or collection)
-// so that downstream CEL expressions can reference its fields.
-func (c *Controller) observeExternal(
-	rcx *ReconcileContext,
-	node *runtime.Node,
-	desired *unstructured.Unstructured,
-) error {
-	if node.Spec.Meta.Type == graph.NodeTypeExternalCollection {
-		return c.observeExternalCollection(rcx, node, desired)
-	}
-	_, err := c.observeExternalRef(rcx, node, desired)
-	return err
-}
 
 // observeExternalRef fetches the external ref and calls SetObserved on the node
 // so that downstream CEL expressions can reference its fields.

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -313,7 +313,7 @@ func TestProcessNodePaths(t *testing.T) {
 				})
 			}
 
-			resources, err := controller.processNode(rcx, rcx.Runtime.Nodes()[0])
+			resources, err := controller.processNode(rcx, rcx.Runtime.Nodes()[0], 1)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -324,6 +324,9 @@ func TestProcessNodePaths(t *testing.T) {
 			assert.Len(t, resources, tt.wantResources)
 			if tt.wantResources > 0 {
 				assert.Equal(t, tt.wantSkipApply, resources[0].SkipApply)
+				if resources[0].Object != nil {
+					assert.Equal(t, "1", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
+				}
 			}
 
 			assert.Equal(t, tt.wantState, rcx.StateManager.NodeStates[tt.node.Meta.ID].State)
@@ -347,14 +350,16 @@ func TestProcessNodeCollectionTypes(t *testing.T) {
 	currentExternal.SetLabels(map[string]string{"app": "demo"})
 
 	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(collectionNode, externalCollection), currentCollection, currentExternal)
-	resources, err := controller.processNode(rcx, rcx.Runtime.Nodes()[0])
+	resources, err := controller.processNode(rcx, rcx.Runtime.Nodes()[0], 1)
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 	assert.Equal(t, "configs-0", resources[0].ID)
+	assert.Equal(t, "1", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
 
-	resources, err = controller.processNode(rcx, rcx.Runtime.Nodes()[1])
+	resources, err = controller.processNode(rcx, rcx.Runtime.Nodes()[1], 2)
 	require.NoError(t, err)
 	assert.Nil(t, resources)
+	assert.Empty(t, externalCollection.Template.GetLabels()[metadata.ApplyOrderLabel])
 	assert.Equal(t, v1alpha1.NodeStateSynced, rcx.StateManager.NodeStates["external-configs"].State)
 }
 
@@ -423,13 +428,15 @@ func TestCollectionAndExternalCollectionProcessing(t *testing.T) {
 	collectionRuntimeNode := rcx.Runtime.Nodes()[0]
 	desired, err := collectionRuntimeNode.GetDesired()
 	require.NoError(t, err)
-	resources, nodeState, err := controller.processCollectionNode(rcx, collectionRuntimeNode, desired)
+	resources, nodeState, err := controller.processCollectionNode(rcx, collectionRuntimeNode, desired, 1)
 	require.NoError(t, err)
 	require.Len(t, resources, 2)
 	assert.Equal(t, "one", resources[0].Object.GetName())
 	assert.NotNil(t, resources[0].Current)
 	assert.Equal(t, "0", resources[0].Object.GetLabels()[metadata.CollectionIndexLabel])
 	assert.Equal(t, "2", resources[0].Object.GetLabels()[metadata.CollectionSizeLabel])
+	assert.Equal(t, "1", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
+	assert.Equal(t, "1", resources[1].Object.GetLabels()[metadata.ApplyOrderLabel])
 	_ = nodeState // state registered by caller
 
 	extState, err := controller.processExternalCollectionNode(
@@ -641,10 +648,11 @@ func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
 
 	obj := newConfigMapObject("demo", "default")
 	obj.SetLabels(map[string]string{"keep": "yes"})
-	controller.applyDecoratorLabels(rcx, obj, "configs", &CollectionInfo{Index: 1, Size: 3})
+	controller.applyDecoratorLabels(rcx, obj, "configs", 4, &CollectionInfo{Index: 1, Size: 3})
 
 	assert.Equal(t, "yes", obj.GetLabels()["keep"])
 	assert.Equal(t, "configs", obj.GetLabels()[metadata.NodeIDLabel])
+	assert.Equal(t, "4", obj.GetLabels()[metadata.ApplyOrderLabel])
 	assert.Equal(t, "1", obj.GetLabels()[metadata.CollectionIndexLabel])
 	assert.Equal(t, string(instance.GetUID()), obj.GetLabels()[metadata.InstanceIDLabel])
 	assert.Empty(t, obj.GetLabels()[metadata.ManagedByLabelKey])
@@ -657,6 +665,31 @@ func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
 	}))
 	stored := getStoredParentObject(t, raw)
 	assert.Equal(t, "demo", stored.GetLabels()[applyset.ApplySetParentIDLabel])
+}
+
+func TestReconcileNodesBackfillsApplyOrderOnExistingResource(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	node := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+	existing := newDeploymentObject("demo", "default")
+	existing.SetUID("deploy-uid")
+	existing.SetResourceVersion("1")
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(node), existing)
+	err := controller.reconcileNodes(rcx)
+	var retryAfter *requeue.RequeueNeededAfter
+	require.ErrorAs(t, err, &retryAfter)
+
+	stored, err := raw.Tracker().Get(controllerTestDeployGVR, "default", "demo")
+	require.NoError(t, err)
+	assert.Equal(t, "1", stored.(*unstructured.Unstructured).GetLabels()[metadata.ApplyOrderLabel])
 }
 
 func TestPruneOrphansPaths(t *testing.T) {

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -118,7 +118,7 @@ func TestProcessNodesLabelsReverseTopologicalWaves(t *testing.T) {
 
 	orders := make(map[string]string, len(resources))
 	for _, resource := range resources {
-		orders[resource.ID] = resource.Object.GetLabels()[metadata.ApplyOrderLabel]
+		orders[resource.ID] = resource.Object.GetAnnotations()[metadata.ApplyOrderAnnotation]
 	}
 	assert.Equal(t, map[string]string{
 		"a": "1",
@@ -146,7 +146,7 @@ func TestProcessNodesFallsBackWhenApplyOrderIsMissing(t *testing.T) {
 	resources, err := controller.processNodes(rcx)
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
-	assert.Equal(t, "0", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
+	assert.Equal(t, "0", resources[0].Object.GetAnnotations()[metadata.ApplyOrderAnnotation])
 }
 
 func TestReconcileNodesPaths(t *testing.T) {
@@ -401,7 +401,7 @@ func TestProcessNodePaths(t *testing.T) {
 			if tt.wantResources > 0 {
 				assert.Equal(t, tt.wantSkipApply, resources[0].SkipApply)
 				if resources[0].Object != nil {
-					assert.Equal(t, "1", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
+					assert.Equal(t, "1", resources[0].Object.GetAnnotations()[metadata.ApplyOrderAnnotation])
 				}
 			}
 
@@ -430,12 +430,12 @@ func TestProcessNodeCollectionTypes(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 	assert.Equal(t, "configs-0", resources[0].ID)
-	assert.Equal(t, "1", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
+	assert.Equal(t, "1", resources[0].Object.GetAnnotations()[metadata.ApplyOrderAnnotation])
 
 	resources, err = controller.processNode(rcx, rcx.Runtime.Nodes()[1], 2)
 	require.NoError(t, err)
 	assert.Nil(t, resources)
-	assert.Empty(t, externalCollection.Template.GetLabels()[metadata.ApplyOrderLabel])
+	assert.Empty(t, externalCollection.Template.GetAnnotations()[metadata.ApplyOrderAnnotation])
 	assert.Equal(t, v1alpha1.NodeStateSynced, rcx.StateManager.NodeStates["external-configs"].State)
 }
 
@@ -511,8 +511,8 @@ func TestCollectionAndExternalCollectionProcessing(t *testing.T) {
 	assert.NotNil(t, resources[0].Current)
 	assert.Equal(t, "0", resources[0].Object.GetLabels()[metadata.CollectionIndexLabel])
 	assert.Equal(t, "2", resources[0].Object.GetLabels()[metadata.CollectionSizeLabel])
-	assert.Equal(t, "1", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
-	assert.Equal(t, "1", resources[1].Object.GetLabels()[metadata.ApplyOrderLabel])
+	assert.Equal(t, "1", resources[0].Object.GetAnnotations()[metadata.ApplyOrderAnnotation])
+	assert.Equal(t, "1", resources[1].Object.GetAnnotations()[metadata.ApplyOrderAnnotation])
 	_ = nodeState // state registered by caller
 
 	extState, err := controller.processExternalCollectionNode(
@@ -724,11 +724,11 @@ func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
 
 	obj := newConfigMapObject("demo", "default")
 	obj.SetLabels(map[string]string{"keep": "yes"})
-	controller.applyDecoratorLabels(rcx, obj, "configs", 4, &CollectionInfo{Index: 1, Size: 3})
+	controller.applyDecoratorMetadata(rcx, obj, "configs", 4, &CollectionInfo{Index: 1, Size: 3})
 
 	assert.Equal(t, "yes", obj.GetLabels()["keep"])
 	assert.Equal(t, "configs", obj.GetLabels()[metadata.NodeIDLabel])
-	assert.Equal(t, "4", obj.GetLabels()[metadata.ApplyOrderLabel])
+	assert.Equal(t, "4", obj.GetAnnotations()[metadata.ApplyOrderAnnotation])
 	assert.Equal(t, "1", obj.GetLabels()[metadata.CollectionIndexLabel])
 	assert.Equal(t, string(instance.GetUID()), obj.GetLabels()[metadata.InstanceIDLabel])
 	assert.Empty(t, obj.GetLabels()[metadata.ManagedByLabelKey])
@@ -765,7 +765,7 @@ func TestReconcileNodesBackfillsApplyOrderOnExistingResource(t *testing.T) {
 
 	stored, err := raw.Tracker().Get(controllerTestDeployGVR, "default", "demo")
 	require.NoError(t, err)
-	assert.Equal(t, "1", stored.(*unstructured.Unstructured).GetLabels()[metadata.ApplyOrderLabel])
+	assert.Equal(t, "1", stored.(*unstructured.Unstructured).GetAnnotations()[metadata.ApplyOrderAnnotation])
 }
 
 func TestPruneOrphansPaths(t *testing.T) {

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -43,6 +43,14 @@ import (
 	krt "github.com/kubernetes-sigs/kro/pkg/runtime"
 )
 
+type runtimeWithoutApplyOrders struct {
+	krt.Interface
+}
+
+func (runtimeWithoutApplyOrders) ApplyOrder(string) (int, bool) {
+	return 0, false
+}
+
 func TestProcessNodesReturnsDataPending(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	pendingNode := &graph.Node{
@@ -71,6 +79,74 @@ func TestProcessNodesReturnsDataPending(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, krt.IsDataPending(err))
 	assert.Empty(t, resources)
+}
+
+func TestProcessNodesLabelsReverseTopologicalWaves(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	newNode := func(id string, dependencies ...string) *graph.Node {
+		return &graph.Node{
+			Meta: graph.NodeMeta{
+				ID:           id,
+				Type:         graph.NodeTypeResource,
+				GVR:          controllerTestCMGVR,
+				Namespaced:   true,
+				Dependencies: dependencies,
+			},
+			Template: newConfigMapObject(id, ""),
+		}
+	}
+
+	// Diamond topology: A -> B,C -> D. B and C can be deleted together.
+	controller, rcx, _ := newControllerAndContext(
+		t,
+		instance,
+		newTestGraph(
+			newNode("a"),
+			newNode("b", "a"),
+			newNode("c", "a"),
+			newNode("d", "b", "c"),
+		),
+		newConfigMapObject("a", "default"),
+		newConfigMapObject("b", "default"),
+		newConfigMapObject("c", "default"),
+		newConfigMapObject("d", "default"),
+	)
+
+	resources, err := controller.processNodes(rcx)
+	require.NoError(t, err)
+	require.Len(t, resources, 4)
+
+	orders := make(map[string]string, len(resources))
+	for _, resource := range resources {
+		orders[resource.ID] = resource.Object.GetLabels()[metadata.ApplyOrderLabel]
+	}
+	assert.Equal(t, map[string]string{
+		"a": "1",
+		"b": "2",
+		"c": "2",
+		"d": "3",
+	}, orders)
+}
+
+func TestProcessNodesFallsBackWhenApplyOrderIsMissing(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	node := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "config",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestCMGVR,
+			Namespaced: true,
+		},
+		Template: newConfigMapObject("config", ""),
+	}
+
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph(node))
+	rcx.Runtime = runtimeWithoutApplyOrders{Interface: rcx.Runtime}
+
+	resources, err := controller.processNodes(rcx)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "0", resources[0].Object.GetLabels()[metadata.ApplyOrderLabel])
 }
 
 func TestReconcileNodesPaths(t *testing.T) {

--- a/pkg/controller/instance/state.go
+++ b/pkg/controller/instance/state.go
@@ -44,6 +44,10 @@ func readyState() NodeState {
 	return NodeState{State: v1alpha1.NodeStateSynced}
 }
 
+func deletedState() NodeState {
+	return NodeState{State: v1alpha1.NodeStateDeleted}
+}
+
 func deletingState() NodeState {
 	return NodeState{State: v1alpha1.NodeStateDeleting}
 }

--- a/pkg/controller/instance/state.go
+++ b/pkg/controller/instance/state.go
@@ -44,10 +44,6 @@ func readyState() NodeState {
 	return NodeState{State: v1alpha1.NodeStateSynced}
 }
 
-func deletedState() NodeState {
-	return NodeState{State: v1alpha1.NodeStateDeleted}
-}
-
 func deletingState() NodeState {
 	return NodeState{State: v1alpha1.NodeStateDeleting}
 }

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -199,36 +199,42 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 	rcx.updateInstanceState()
 	status := rcx.initialStatus()
 
-	// instance desired is guaranteed to have one item.
-	desired, err := rcx.Runtime.Instance().GetDesired()
-	if err != nil {
-		return err
-	}
-	if resolved, found, _ := unstructured.NestedMap(desired[0].Object, "status"); found {
-		for k, v := range resolved {
-			if k == "conditions" || k == "state" {
-				continue
+	// During early deletion there may be no resolved runtime. In that case
+	// preserve the existing instance status fields and update only kro-owned
+	// deletion state and conditions.
+	if rcx.Runtime != nil {
+		desired, err := rcx.Runtime.Instance().GetDesired()
+		if err != nil {
+			return err
+		}
+		if resolved, found, _ := unstructured.NestedMap(desired[0].Object, "status"); found {
+			for k, v := range resolved {
+				if k == "conditions" || k == "state" {
+					continue
+				}
+				status[k] = v
 			}
-			status[k] = v
 		}
 	}
 
 	// When the RGD declares conditions, only the author's conditions appear
 	// on the wire. kroBuiltins lets runtime.condition(schema, 'X') resolve
 	// kro's internal value for the four reserved condition types.
-	instanceNode := rcx.Runtime.Instance()
-	if instanceNode.HasConditions() {
-		kroBuiltins := condSet.For(&unstructuredWrapper{rcx.Instance}).List()
-		authored, evalErr := instanceNode.EvaluateConditions(rcx.Log, kroBuiltins)
-		previous := getPreviousConditions(rcx.Instance)
-		stamped := stampAuthorConditions(authored, previous, rcx.Instance.GetGeneration())
-		status["conditions"] = conditionsToInterfaceSlice(stamped)
+	if rcx.Runtime != nil {
+		instanceNode := rcx.Runtime.Instance()
+		if instanceNode.HasConditions() {
+			kroBuiltins := condSet.For(&unstructuredWrapper{rcx.Instance}).List()
+			authored, evalErr := instanceNode.EvaluateConditions(rcx.Log, kroBuiltins)
+			previous := getPreviousConditions(rcx.Instance)
+			stamped := stampAuthorConditions(authored, previous, rcx.Instance.GetGeneration())
+			status["conditions"] = conditionsToInterfaceSlice(stamped)
 
-		// A degraded result still surfaces its surviving conditions; set
-		// state=Error rather than failing the reconcile.
-		if evalErr != nil {
-			rcx.Log.Error(evalErr, "author conditions degraded; setting state=Error")
-			status["state"] = string(v1alpha1.InstanceStateError)
+			// A degraded result still surfaces its surviving conditions; set
+			// state=Error rather than failing the reconcile.
+			if evalErr != nil {
+				rcx.Log.Error(evalErr, "author conditions degraded; setting state=Error")
+				status["state"] = string(v1alpha1.InstanceStateError)
+			}
 		}
 	}
 
@@ -246,7 +252,7 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 		return nil
 	}
 
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		cur, err := rcx.InstanceClient().Get(rcx.Ctx, rcx.Instance.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return err

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
@@ -187,86 +188,104 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 	rcx.updateInstanceState()
 	status := rcx.initialStatus()
 
-	if rcx.Runtime == nil {
-		// Early deletion deliberately bypasses graph resolution. Keep status
-		// projections that cannot be recomputed without a runtime.
-		for k, v := range rcx.WireStatus {
-			if k != "conditions" && k != "state" {
-				status[k] = v
+	desired, err := rcx.Runtime.Instance().GetDesired()
+	if err != nil {
+		return err
+	}
+	if resolved, found, _ := unstructured.NestedMap(desired[0].Object, "status"); found {
+		for k, v := range resolved {
+			if k == "conditions" || k == "state" {
+				continue
 			}
-		}
-		// Author conditions cannot be evaluated without a runtime. Preserve
-		// them exactly as fetched instead of replacing them with kro built-ins.
-		if c.reconcileConfig.HasAuthorConditions {
-			if conditions, found := rcx.WireStatus["conditions"]; found {
-				status["conditions"] = conditions
-			} else {
-				delete(status, "conditions")
-			}
-		}
-	} else {
-		desired, err := rcx.Runtime.Instance().GetDesired()
-		if err != nil {
-			return err
-		}
-		if resolved, found, _ := unstructured.NestedMap(desired[0].Object, "status"); found {
-			for k, v := range resolved {
-				if k == "conditions" || k == "state" {
-					continue
-				}
-				status[k] = v
-			}
-		}
-
-		// When the RGD declares author conditions, only those appear on the
-		// wire. kro's built-ins stay readable from author CEL through
-		// runtime.condition(schema, 'X').
-		instanceNode := rcx.Runtime.Instance()
-		if instanceNode.HasConditions() {
-			authored, incomplete, evalErr := instanceNode.EvaluateConditions(
-				rcx.Log, builtinConditions(rcx.Instance),
-			)
-
-			// Read previous conditions from the wire snapshot, not rcx.Instance:
-			// the markers have already overwritten any built-in-typed override.
-			conds, _ := rcx.WireStatus["conditions"].([]interface{})
-			previous := decodeConditions(conds)
-			stamped := stampAuthorConditions(authored, previous, rcx.Instance.GetGeneration())
-			if incomplete {
-				// Keep the previously persisted conditions for the types that
-				// produced no output this reconcile.
-				stamped = mergeWithPrevious(stamped, previous)
-			}
-			status["conditions"] = conditionsToInterfaceSlice(stamped)
-
-			// A degraded result still surfaces its surviving conditions; set
-			// state=Error rather than failing the reconcile.
-			if evalErr != nil {
-				rcx.Log.Error(evalErr, "author conditions degraded; setting state=Error")
-				status["state"] = string(v1alpha1.InstanceStateError)
-			}
+			status[k] = v
 		}
 	}
 
+	// When the RGD declares author conditions, only those appear on the
+	// wire. kro's built-ins stay readable from author CEL through
+	// runtime.condition(schema, 'X').
+	instanceNode := rcx.Runtime.Instance()
+	if instanceNode.HasConditions() {
+		authored, incomplete, evalErr := instanceNode.EvaluateConditions(
+			rcx.Log, builtinConditions(rcx.Instance),
+		)
+
+		// Read previous conditions from the wire snapshot, not rcx.Instance:
+		// the markers have already overwritten any built-in-typed override.
+		conds, _ := rcx.WireStatus["conditions"].([]interface{})
+		previous := decodeConditions(conds)
+		stamped := stampAuthorConditions(authored, previous, rcx.Instance.GetGeneration())
+		if incomplete {
+			// Keep the previously persisted conditions for the types that
+			// produced no output this reconcile.
+			stamped = mergeWithPrevious(stamped, previous)
+		}
+		status["conditions"] = conditionsToInterfaceSlice(stamped)
+
+		// A degraded result still surfaces its surviving conditions; set
+		// state=Error rather than failing the reconcile.
+		if evalErr != nil {
+			rcx.Log.Error(evalErr, "author conditions degraded; setting state=Error")
+			status["state"] = string(v1alpha1.InstanceStateError)
+		}
+	}
+
+	return c.persistStatus(
+		rcx.Ctx, rcx.InstanceClient(), rcx.Instance, rcx.WireStatus, status, previousState,
+	)
+}
+
+// updateDeletionStatus updates instance-level deletion status without a
+// runtime. Status projections and author conditions that cannot be evaluated
+// during early deletion are preserved from the wire.
+func (c *Controller) updateDeletionStatus(dcx *DeletionContext) error {
+	previousState, _ := dcx.WireStatus["state"].(string)
+	status := initialStatus(dcx.Instance, dcx.StateManager)
+	for k, v := range dcx.WireStatus {
+		if k != "conditions" && k != "state" {
+			status[k] = v
+		}
+	}
+	if dcx.Config.HasAuthorConditions {
+		if conditions, found := dcx.WireStatus["conditions"]; found {
+			status["conditions"] = conditions
+		} else {
+			delete(status, "conditions")
+		}
+	}
+	return c.persistStatus(
+		dcx.Ctx, dcx.InstanceClient(), dcx.Instance, dcx.WireStatus, status, previousState,
+	)
+}
+
+func (c *Controller) persistStatus(
+	ctx context.Context,
+	client dynamic.ResourceInterface,
+	instance *unstructured.Unstructured,
+	wireStatus map[string]interface{},
+	status map[string]interface{},
+	previousState string,
+) error {
+
 	// Mirror the computed status onto the instance so the deferred emitters
 	// read what's on the wire, not the marker's built-ins.
-	rcx.Instance.Object["status"] = status
+	instance.Object["status"] = status
 
 	// Skip the API server write if the persisted status already matches.
 	// This prevents an infinite reconcile loop where every unconditional
 	// UpdateStatus bumps resourceVersion, which triggers a watch event,
 	// which re-enqueues the instance, which reconciles again.
-	if statusesMatch(rcx.WireStatus, status) {
+	if statusesMatch(wireStatus, status) {
 		return nil
 	}
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cur, err := rcx.InstanceClient().Get(rcx.Ctx, rcx.Instance.GetName(), metav1.GetOptions{})
+		cur, err := client.Get(ctx, instance.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 		cur.Object["status"] = status
-		_, err = rcx.InstanceClient().UpdateStatus(rcx.Ctx, cur, metav1.UpdateOptions{})
+		_, err = client.UpdateStatus(ctx, cur, metav1.UpdateOptions{})
 		return err
 	})
 	if err != nil {
@@ -277,7 +296,7 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 	// differ from the state manager's view (degraded author conditions).
 	writtenState, _ := status["state"].(string)
 	if previousState != writtenState {
-		gvk := rcx.Instance.GroupVersionKind().String()
+		gvk := instance.GroupVersionKind().String()
 		metrics.InstanceStateTransitionsTotal.WithLabelValues(
 			gvk,
 			previousState,
@@ -337,7 +356,11 @@ func mergeWithPrevious(current, previous []v1alpha1.Condition) []v1alpha1.Condit
 }
 
 func (rcx *ReconcileContext) initialStatus() map[string]interface{} {
-	cs := condSet.For(&unstructuredWrapper{rcx.Instance})
+	return initialStatus(rcx.Instance, rcx.StateManager)
+}
+
+func initialStatus(instance *unstructured.Unstructured, stateManager *StateManager) map[string]interface{} {
+	cs := condSet.For(&unstructuredWrapper{instance})
 
 	// Start fresh - user-defined status fields come solely from current
 	// resolution, so fields disappear when their dependencies become
@@ -346,12 +369,12 @@ func (rcx *ReconcileContext) initialStatus() map[string]interface{} {
 	// removed) is dropped. State is a plain string to compare equal to the
 	// wire value.
 	status := map[string]interface{}{
-		"conditions": conditionsToInterfaceSlice(builtinConditions(rcx.Instance)),
+		"conditions": conditionsToInterfaceSlice(builtinConditions(instance)),
 	}
 	if cs.IsRootReady() {
 		status["state"] = string(v1alpha1.InstanceStateActive)
 	} else {
-		status["state"] = string(rcx.StateManager.State)
+		status["state"] = string(stateManager.State)
 	}
 	return status
 }

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -247,15 +247,31 @@ func (c *Controller) updateDeletionStatus(dcx *DeletionContext) error {
 		}
 	}
 	if dcx.Config.HasAuthorConditions {
-		if conditions, found := dcx.WireStatus["conditions"]; found {
-			status["conditions"] = conditions
-		} else {
-			delete(status, "conditions")
-		}
+		status["conditions"] = deletionConditions(dcx.Instance, dcx.WireStatus)
 	}
 	return c.persistStatus(
 		dcx.Ctx, dcx.InstanceClient(), dcx.Instance, dcx.WireStatus, status, previousState,
 	)
+}
+
+// deletionConditions preserves author conditions that cannot be evaluated
+// without a runtime and overlays kro's ResourcesReady deletion condition. The
+// overlay makes progress and blocking errors visible even when the RGD owns
+// the normal condition surface.
+func deletionConditions(
+	instance *unstructured.Unstructured,
+	wireStatus map[string]interface{},
+) []interface{} {
+	current := make([]v1alpha1.Condition, 0, 1)
+	for _, condition := range builtinConditions(instance) {
+		if condition.Type == v1alpha1.ConditionType(ResourcesReady) {
+			current = append(current, condition)
+			break
+		}
+	}
+
+	previousRaw, _ := wireStatus["conditions"].([]interface{})
+	return conditionsToInterfaceSlice(mergeWithPrevious(current, decodeConditions(previousRaw)))
 }
 
 func (c *Controller) persistStatus(

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -187,44 +187,64 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 	rcx.updateInstanceState()
 	status := rcx.initialStatus()
 
-	// instance desired is guaranteed to have one item.
-	desired, err := rcx.Runtime.Instance().GetDesired()
-	if err != nil {
-		return err
-	}
-	if resolved, found, _ := unstructured.NestedMap(desired[0].Object, "status"); found {
-		for k, v := range resolved {
-			if k == "conditions" || k == "state" {
-				continue
+	if rcx.Runtime == nil {
+		// Early deletion deliberately bypasses graph resolution. Keep status
+		// projections that cannot be recomputed without a runtime.
+		for k, v := range rcx.WireStatus {
+			if k != "conditions" && k != "state" {
+				status[k] = v
 			}
-			status[k] = v
 		}
-	}
-
-	// When the RGD declares author conditions, only those appear on the
-	// wire. kro's built-ins stay readable from author CEL through
-	// runtime.condition(schema, 'X').
-	instanceNode := rcx.Runtime.Instance()
-	if instanceNode.HasConditions() {
-		authored, incomplete, evalErr := instanceNode.EvaluateConditions(rcx.Log, builtinConditions(rcx.Instance))
-
-		// Read previous conditions from the wire snapshot, not rcx.Instance:
-		// the markers have already overwritten any built-in-typed override.
-		conds, _ := rcx.WireStatus["conditions"].([]interface{})
-		previous := decodeConditions(conds)
-		stamped := stampAuthorConditions(authored, previous, rcx.Instance.GetGeneration())
-		if incomplete {
-			// Keep the previously persisted conditions for the types that
-			// produced no output this reconcile.
-			stamped = mergeWithPrevious(stamped, previous)
+		// Author conditions cannot be evaluated without a runtime. Preserve
+		// them exactly as fetched instead of replacing them with kro built-ins.
+		if c.reconcileConfig.HasAuthorConditions {
+			if conditions, found := rcx.WireStatus["conditions"]; found {
+				status["conditions"] = conditions
+			} else {
+				delete(status, "conditions")
+			}
 		}
-		status["conditions"] = conditionsToInterfaceSlice(stamped)
+	} else {
+		desired, err := rcx.Runtime.Instance().GetDesired()
+		if err != nil {
+			return err
+		}
+		if resolved, found, _ := unstructured.NestedMap(desired[0].Object, "status"); found {
+			for k, v := range resolved {
+				if k == "conditions" || k == "state" {
+					continue
+				}
+				status[k] = v
+			}
+		}
 
-		// A degraded result still surfaces its surviving conditions; set
-		// state=Error rather than failing the reconcile.
-		if evalErr != nil {
-			rcx.Log.Error(evalErr, "author conditions degraded; setting state=Error")
-			status["state"] = string(v1alpha1.InstanceStateError)
+		// When the RGD declares author conditions, only those appear on the
+		// wire. kro's built-ins stay readable from author CEL through
+		// runtime.condition(schema, 'X').
+		instanceNode := rcx.Runtime.Instance()
+		if instanceNode.HasConditions() {
+			authored, incomplete, evalErr := instanceNode.EvaluateConditions(
+				rcx.Log, builtinConditions(rcx.Instance),
+			)
+
+			// Read previous conditions from the wire snapshot, not rcx.Instance:
+			// the markers have already overwritten any built-in-typed override.
+			conds, _ := rcx.WireStatus["conditions"].([]interface{})
+			previous := decodeConditions(conds)
+			stamped := stampAuthorConditions(authored, previous, rcx.Instance.GetGeneration())
+			if incomplete {
+				// Keep the previously persisted conditions for the types that
+				// produced no output this reconcile.
+				stamped = mergeWithPrevious(stamped, previous)
+			}
+			status["conditions"] = conditionsToInterfaceSlice(stamped)
+
+			// A degraded result still surfaces its surviving conditions; set
+			// state=Error rather than failing the reconcile.
+			if evalErr != nil {
+				rcx.Log.Error(evalErr, "author conditions degraded; setting state=Error")
+				status["state"] = string(v1alpha1.InstanceStateError)
+			}
 		}
 	}
 
@@ -240,7 +260,7 @@ func (c *Controller) updateStatus(rcx *ReconcileContext) error {
 		return nil
 	}
 
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		cur, err := rcx.InstanceClient().Get(rcx.Ctx, rcx.Instance.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return err

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -277,6 +277,33 @@ func newControllerAndContext(
 	return controller, rcx, raw
 }
 
+func newControllerAndDeletionContext(
+	t *testing.T,
+	instance *unstructured.Unstructured,
+	g *graph.Graph,
+	extraObjs ...apimachineryruntime.Object,
+) (*Controller, *DeletionContext, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	objs := append([]apimachineryruntime.Object{instance.DeepCopy()}, extraObjs...)
+	raw := newControllerTestDynamicClient(t, objs...)
+	controller, clientSet := newControllerUnderTest(t, raw, g)
+
+	dcx := NewDeletionContext(
+		context.Background(),
+		controller.log,
+		controllerTestParentGVR,
+		instance.GetNamespace() != "",
+		clientSet.Dynamic(),
+		clientSet.RESTMapper(),
+		controller.reconcileConfig,
+		instance.DeepCopy(),
+	)
+	dcx.Watcher = dynamiccontroller.NoopInstanceWatcher{}
+
+	return controller, dcx, raw
+}
+
 func newInstanceObject(name, namespace string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -299,7 +299,6 @@ func newControllerAndDeletionContext(
 		controller.reconcileConfig,
 		instance.DeepCopy(),
 	)
-	dcx.Watcher = dynamiccontroller.NoopInstanceWatcher{}
 
 	return controller, dcx, raw
 }

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -409,6 +409,16 @@ func newTestGraphWithInstance(instanceNode *graph.Node, nodes ...*graph.Node) *g
 			panic(fmt.Sprintf("adding test graph dependencies for %q: %v", node.Meta.ID, err))
 		}
 	}
+	layers, err := dependencyGraph.ReverseTopologicalLayers()
+	if err != nil {
+		panic(fmt.Sprintf("calculating test graph apply orders: %v", err))
+	}
+	applyOrders := make(map[string]int, len(nodes))
+	for i, layer := range layers {
+		for _, nodeID := range layer {
+			applyOrders[nodeID] = len(layers) - i
+		}
+	}
 
 	return &graph.Graph{
 		DAG:              dependencyGraph,
@@ -416,6 +426,7 @@ func newTestGraphWithInstance(instanceNode *graph.Node, nodes ...*graph.Node) *g
 		Nodes:            nodeMap,
 		Resources:        nodeMap,
 		TopologicalOrder: order,
+		ApplyOrders:      applyOrders,
 		ResourceSchemas:  resourceSchemas,
 	}
 }

--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
 	"github.com/kubernetes-sigs/kro/pkg/graph/revisions"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
@@ -390,6 +391,7 @@ func newTestGraph(nodes ...*graph.Node) *graph.Graph {
 
 func newTestGraphWithInstance(instanceNode *graph.Node, nodes ...*graph.Node) *graph.Graph {
 	nodeMap := make(map[string]*graph.Node, len(nodes))
+	dependencyGraph := dag.NewDirectedAcyclicGraph[string]()
 	resourceSchemas := map[string]*spec.Schema{
 		graph.InstanceNodeID: nil,
 	}
@@ -398,9 +400,18 @@ func newTestGraphWithInstance(instanceNode *graph.Node, nodes ...*graph.Node) *g
 		nodeMap[node.Meta.ID] = node
 		resourceSchemas[node.Meta.ID] = nil
 		order = append(order, node.Meta.ID)
+		if err := dependencyGraph.AddVertex(node.Meta.ID, node.Meta.Index); err != nil {
+			panic(fmt.Sprintf("adding test graph vertex %q: %v", node.Meta.ID, err))
+		}
+	}
+	for _, node := range nodes {
+		if err := dependencyGraph.AddDependencies(node.Meta.ID, node.Meta.Dependencies); err != nil {
+			panic(fmt.Sprintf("adding test graph dependencies for %q: %v", node.Meta.ID, err))
+		}
 	}
 
 	return &graph.Graph{
+		DAG:              dependencyGraph,
 		Instance:         instanceNode,
 		Nodes:            nodeMap,
 		Resources:        nodeMap,

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -277,6 +277,10 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	if err != nil {
 		return nil, fmt.Errorf("failed to get topological order: %w", err)
 	}
+	applyOrders, err := applyOrdersForDAG(dag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get apply-order waves: %w", err)
+	}
 
 	// Validate that omit() is not used on resource identity fields.
 	// Only needed when omit() is enabled — if the gate is off, the builder
@@ -385,6 +389,7 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 		Nodes:            nodes,
 		Resources:        nodes,
 		TopologicalOrder: topologicalOrder,
+		ApplyOrders:      applyOrders,
 		CRD:              instanceCRD,
 		ResourceSchemas:  resourceSchemas,
 	}

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -1017,6 +1017,11 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 
 				// Validate topological order
 				assert.Equal(t, []string{"vpc", "clusterpolicy", "clusterrole", "subnet1", "subnet2", "cluster"}, g.TopologicalOrder)
+				assert.Equal(t, map[string]int{
+					"vpc": 1, "clusterpolicy": 1,
+					"clusterrole": 2, "subnet1": 2, "subnet2": 2,
+					"cluster": 3,
+				}, g.ApplyOrders)
 			},
 		},
 		{

--- a/pkg/graph/dag/dag.go
+++ b/pkg/graph/dag/dag.go
@@ -87,6 +87,76 @@ func (h *topoHeap[T]) Pop() any {
 	return item
 }
 
+type traversalDirection int
+
+const (
+	dependenciesFirst traversalDirection = iota
+	dependentsFirst
+)
+
+type topologicalTraversal[T cmp.Ordered] struct {
+	graph     *DirectedAcyclicGraph[T]
+	remaining map[T]int
+	unlocks   map[T][]T
+	ready     topoHeap[T]
+}
+
+func newTopologicalTraversal[T cmp.Ordered](
+	graph *DirectedAcyclicGraph[T],
+	direction traversalDirection,
+) *topologicalTraversal[T] {
+	traversal := &topologicalTraversal[T]{
+		graph:     graph,
+		remaining: make(map[T]int, len(graph.Vertices)),
+		unlocks:   make(map[T][]T, len(graph.Vertices)),
+		ready:     make(topoHeap[T], 0, len(graph.Vertices)),
+	}
+
+	for id := range graph.Vertices {
+		traversal.remaining[id] = 0
+	}
+	for id, vertex := range graph.Vertices {
+		for dependency := range vertex.DependsOn {
+			switch direction {
+			case dependenciesFirst:
+				traversal.remaining[id]++
+				traversal.unlocks[dependency] = append(traversal.unlocks[dependency], id)
+			case dependentsFirst:
+				traversal.remaining[dependency]++
+				traversal.unlocks[id] = append(traversal.unlocks[id], dependency)
+			}
+		}
+	}
+
+	for id, remaining := range traversal.remaining {
+		if remaining == 0 {
+			traversal.ready = append(traversal.ready, topoHeapItem[T]{
+				ID:    id,
+				Order: graph.Vertices[id].Order,
+			})
+		}
+	}
+	heap.Init(&traversal.ready)
+
+	return traversal
+}
+
+func (t *topologicalTraversal[T]) popReady() topoHeapItem[T] {
+	return heap.Pop(&t.ready).(topoHeapItem[T])
+}
+
+func (t *topologicalTraversal[T]) advance(id T) {
+	for _, unlocked := range t.unlocks[id] {
+		t.remaining[unlocked]--
+		if t.remaining[unlocked] == 0 {
+			heap.Push(&t.ready, topoHeapItem[T]{
+				ID:    unlocked,
+				Order: t.graph.Vertices[unlocked].Order,
+			})
+		}
+	}
+}
+
 // NewDirectedAcyclicGraph creates a new directed acyclic graph.
 func NewDirectedAcyclicGraph[T cmp.Ordered]() *DirectedAcyclicGraph[T] {
 	return &DirectedAcyclicGraph[T]{
@@ -172,39 +242,13 @@ func (d *DirectedAcyclicGraph[T]) AddDependencies(from T, dependencies []T) erro
 // TopologicalSort returns the vertexes of the graph, respecting topological ordering first,
 // and preserving order of nodes within each "depth" of the topological ordering.
 func (d *DirectedAcyclicGraph[T]) TopologicalSort() ([]T, error) {
-	remainingDeps := make(map[T]int, len(d.Vertices))
-	dependents := make(map[T][]T, len(d.Vertices))
-	ready := make(topoHeap[T], 0, len(d.Vertices))
-
-	for id, vertex := range d.Vertices {
-		remainingDeps[id] = len(vertex.DependsOn)
-		if len(vertex.DependsOn) == 0 {
-			ready = append(ready, topoHeapItem[T]{
-				ID:    id,
-				Order: vertex.Order,
-			})
-		}
-		for dependency := range vertex.DependsOn {
-			dependents[dependency] = append(dependents[dependency], id)
-		}
-	}
-
-	heap.Init(&ready)
+	traversal := newTopologicalTraversal(d, dependenciesFirst)
 
 	order := make([]T, 0, len(d.Vertices))
-	for ready.Len() > 0 {
-		current := heap.Pop(&ready).(topoHeapItem[T])
+	for traversal.ready.Len() > 0 {
+		current := traversal.popReady()
 		order = append(order, current.ID)
-
-		for _, dependent := range dependents[current.ID] {
-			remainingDeps[dependent]--
-			if remainingDeps[dependent] == 0 {
-				heap.Push(&ready, topoHeapItem[T]{
-					ID:    dependent,
-					Order: d.Vertices[dependent].Order,
-				})
-			}
-		}
+		traversal.advance(current.ID)
 	}
 
 	if len(order) == len(d.Vertices) {
@@ -214,6 +258,45 @@ func (d *DirectedAcyclicGraph[T]) TopologicalSort() ([]T, error) {
 	hasCycle, cycle := d.hasCycle()
 	if !hasCycle {
 		// Unexpected!
+		return nil, &CycleError[T]{}
+	}
+	return nil, &CycleError[T]{
+		Cycle: cycle,
+	}
+}
+
+// ReverseTopologicalLayers returns vertices grouped into layers with dependents
+// before their dependencies. Vertices in the same layer have no dependency
+// ordering between them and can be processed concurrently. Original vertex
+// order is preserved within each layer where possible.
+func (d *DirectedAcyclicGraph[T]) ReverseTopologicalLayers() ([][]T, error) {
+	traversal := newTopologicalTraversal(d, dependentsFirst)
+	layers := make([][]T, 0)
+	processed := 0
+
+	for traversal.ready.Len() > 0 {
+		layerSize := traversal.ready.Len()
+		items := make([]topoHeapItem[T], 0, layerSize)
+		layer := make([]T, 0, layerSize)
+		for range layerSize {
+			item := traversal.popReady()
+			items = append(items, item)
+			layer = append(layer, item.ID)
+		}
+
+		for _, item := range items {
+			traversal.advance(item.ID)
+		}
+		layers = append(layers, layer)
+		processed += len(layer)
+	}
+
+	if processed == len(d.Vertices) {
+		return layers, nil
+	}
+
+	hasCycle, cycle := d.hasCycle()
+	if !hasCycle {
 		return nil, &CycleError[T]{}
 	}
 	return nil, &CycleError[T]{

--- a/pkg/graph/dag/dag_test.go
+++ b/pkg/graph/dag/dag_test.go
@@ -98,6 +98,12 @@ func TestDAGHasCycle(t *testing.T) {
 	} else if AsCycleError[string](err) == nil {
 		t.Errorf("TopologicalSort returned unexpected error: %T %v", err, err)
 	}
+
+	if _, err := d.ReverseTopologicalLayers(); err == nil {
+		t.Errorf("ReverseTopologicalLayers failed to detect cycle")
+	} else if AsCycleError[string](err) == nil {
+		t.Errorf("ReverseTopologicalLayers returned unexpected error: %T %v", err, err)
+	}
 }
 
 func TestDAGTopologicalSort(t *testing.T) {
@@ -148,6 +154,73 @@ func TestDAGTopologicalSort(t *testing.T) {
 			}
 
 			checkValidTopologicalOrder(t, d, order)
+		})
+	}
+}
+
+func TestDAGReverseTopologicalLayers(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes string
+		edges string
+		want  [][]string
+	}{
+		{
+			name: "empty graph",
+			want: [][]string{},
+		},
+		{
+			name:  "independent vertices",
+			nodes: "A,B,C",
+			want:  [][]string{{"A", "B", "C"}},
+		},
+		{
+			name:  "chain",
+			nodes: "A,B,C",
+			edges: "A->B,B->C",
+			want:  [][]string{{"C"}, {"B"}, {"A"}},
+		},
+		{
+			name:  "diamond",
+			nodes: "A,B,C,D",
+			edges: "A->B,A->C,B->D,C->D",
+			want:  [][]string{{"D"}, {"B", "C"}, {"A"}},
+		},
+		{
+			name:  "uneven independent branches",
+			nodes: "A,B,C,D,E",
+			edges: "A->B,A->C,B->D",
+			want:  [][]string{{"C", "D", "E"}, {"B"}, {"A"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDirectedAcyclicGraph[string]()
+			if tt.nodes != "" {
+				for i, node := range strings.Split(tt.nodes, ",") {
+					if err := d.AddVertex(node, i); err != nil {
+						t.Fatalf("adding vertex: %v", err)
+					}
+				}
+			}
+
+			if tt.edges != "" {
+				for _, edge := range strings.Split(tt.edges, ",") {
+					tokens := strings.SplitN(edge, "->", 2)
+					if err := d.AddDependencies(tokens[1], []string{tokens[0]}); err != nil {
+						t.Fatalf("adding edge %q: %v", edge, err)
+					}
+				}
+			}
+
+			got, err := d.ReverseTopologicalLayers()
+			if err != nil {
+				t.Fatalf("building reverse topological layers: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unexpected reverse topological layers: got %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -40,6 +40,10 @@ type Graph struct {
 	// This excludes the instance node.
 	TopologicalOrder []string
 
+	// ApplyOrders maps node IDs to their one-based reverse topological layer.
+	// Nodes in the same layer can be deleted in the same wave.
+	ApplyOrders map[string]int
+
 	// CRD is the generated CustomResourceDefinition for the instance.
 	CRD *extv1.CustomResourceDefinition
 
@@ -47,4 +51,22 @@ type Graph struct {
 	// Includes resource schemas (keyed by resource ID) and the instance schema
 	// (keyed by InstanceNodeID). Used at runtime for schema-aware CEL value conversion.
 	ResourceSchemas map[string]*spec.Schema
+}
+
+func applyOrdersForDAG(
+	dependencyGraph *dag.DirectedAcyclicGraph[string],
+) (map[string]int, error) {
+	layers, err := dependencyGraph.ReverseTopologicalLayers()
+	if err != nil {
+		return nil, err
+	}
+
+	orders := make(map[string]int, len(dependencyGraph.Vertices))
+	for i, layer := range layers {
+		order := len(layers) - i
+		for _, nodeID := range layer {
+			orders[nodeID] = order
+		}
+	}
+	return orders, nil
 }

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
+)
+
+func TestApplyOrdersForDAG(t *testing.T) {
+	dependencyGraph := dag.NewDirectedAcyclicGraph[string]()
+	for i, nodeID := range []string{"a", "b", "c", "d"} {
+		require.NoError(t, dependencyGraph.AddVertex(nodeID, i))
+	}
+	require.NoError(t, dependencyGraph.AddDependencies("b", []string{"a"}))
+	require.NoError(t, dependencyGraph.AddDependencies("c", []string{"a"}))
+	require.NoError(t, dependencyGraph.AddDependencies("d", []string{"b", "c"}))
+
+	orders, err := applyOrdersForDAG(dependencyGraph)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{"a": 1, "b": 2, "c": 2, "d": 3}, orders)
+}

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -349,8 +349,8 @@ func isRequiredIdentityField(path string, resourceNamespaced, instanceNamespaced
 	}
 }
 
-// validateNoKROOwnedLabels enforces that the resource template doesn't define any label with
-// LabelKROPrefix (kro.run/). These labels are reserved for internal use ONLY.
+// validateNoKROOwnedLabels enforces that resource templates do not define
+// labels in either controller-owned namespace.
 func validateNoKROOwnedLabels(resourceID string, resourceObject map[string]interface{}) error {
 	labelsRaw, found, err := unstructured.NestedFieldCopy(resourceObject, "metadata", "labels")
 	if err != nil || !found {
@@ -363,8 +363,10 @@ func validateNoKROOwnedLabels(resourceID string, resourceObject map[string]inter
 	}
 
 	for key := range labelsMap {
-		if strings.HasPrefix(key, metadata.LabelKROPrefix) {
-			return fmt.Errorf("invalid label for resource %q. labels with prefix %q are reserved for internal use", resourceID, metadata.LabelKROPrefix)
+		for _, prefix := range []string{metadata.LabelKROPrefix, metadata.InternalLabelKROPrefix} {
+			if strings.HasPrefix(key, prefix) {
+				return fmt.Errorf("invalid label for resource %q. labels with prefix %q are reserved for internal use", resourceID, prefix)
+			}
 		}
 	}
 

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -355,7 +355,7 @@ func isRequiredIdentityField(path string, resourceNamespaced, instanceNamespaced
 // validateNoKROOwnedLabels enforces that resource templates do not define
 // labels in either controller-owned namespace.
 func validateNoKROOwnedLabels(resourceID string, resourceObject map[string]interface{}) error {
-	labelsRaw, found, err := unstructured.NestedFieldCopy(resourceObject, "metadata", "labels")
+	labelsRaw, found, err := unstructured.NestedFieldNoCopy(resourceObject, "metadata", "labels")
 	if err != nil || !found {
 		return nil
 	}
@@ -379,7 +379,7 @@ func validateNoKROOwnedLabels(resourceID string, resourceObject map[string]inter
 // validateNoKROOwnedAnnotations prevents resource templates from overriding
 // annotations used as persisted controller state.
 func validateNoKROOwnedAnnotations(resourceID string, resourceObject map[string]interface{}) error {
-	annotationsRaw, found, err := unstructured.NestedFieldCopy(resourceObject, "metadata", "annotations")
+	annotationsRaw, found, err := unstructured.NestedFieldNoCopy(resourceObject, "metadata", "annotations")
 	if err != nil || !found {
 		return nil
 	}

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -299,8 +299,11 @@ func validateTemplateConstraints(
 		}
 	}
 
-	// Validate that users don't set KRO-owned labels
+	// Validate that users don't set KRO-owned metadata.
 	if err := validateNoKROOwnedLabels(rgResource.ID, resourceObject); err != nil {
+		return err
+	}
+	if err := validateNoKROOwnedAnnotations(rgResource.ID, resourceObject); err != nil {
 		return err
 	}
 
@@ -366,6 +369,34 @@ func validateNoKROOwnedLabels(resourceID string, resourceObject map[string]inter
 		for _, prefix := range []string{metadata.LabelKROPrefix, metadata.InternalLabelKROPrefix} {
 			if strings.HasPrefix(key, prefix) {
 				return fmt.Errorf("invalid label for resource %q. labels with prefix %q are reserved for internal use", resourceID, prefix)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateNoKROOwnedAnnotations prevents resource templates from overriding
+// annotations used as persisted controller state.
+func validateNoKROOwnedAnnotations(resourceID string, resourceObject map[string]interface{}) error {
+	annotationsRaw, found, err := unstructured.NestedFieldCopy(resourceObject, "metadata", "annotations")
+	if err != nil || !found {
+		return nil
+	}
+
+	annotationsMap, ok := annotationsRaw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	for key := range annotationsMap {
+		for _, prefix := range []string{metadata.AnnotationKROPrefix, metadata.InternalAnnotationKROPrefix} {
+			if strings.HasPrefix(key, prefix) {
+				return fmt.Errorf(
+					"invalid annotation for resource %q. annotations with prefix %q are reserved for internal use",
+					resourceID,
+					prefix,
+				)
 			}
 		}
 	}

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -366,7 +366,7 @@ func validateNoKROOwnedLabels(resourceID string, resourceObject map[string]inter
 	}
 
 	for key := range labelsMap {
-		for _, prefix := range []string{metadata.LabelKROPrefix, metadata.InternalLabelKROPrefix} {
+		for _, prefix := range []string{metadata.KROPrefix, metadata.InternalKROPrefix} {
 			if strings.HasPrefix(key, prefix) {
 				return fmt.Errorf("invalid label for resource %q. labels with prefix %q are reserved for internal use", resourceID, prefix)
 			}
@@ -390,7 +390,7 @@ func validateNoKROOwnedAnnotations(resourceID string, resourceObject map[string]
 	}
 
 	for key := range annotationsMap {
-		for _, prefix := range []string{metadata.AnnotationKROPrefix, metadata.InternalAnnotationKROPrefix} {
+		for _, prefix := range []string{metadata.KROPrefix, metadata.InternalKROPrefix} {
 			if strings.HasPrefix(key, prefix) {
 				return fmt.Errorf(
 					"invalid annotation for resource %q. annotations with prefix %q are reserved for internal use",

--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -707,6 +707,22 @@ func TestValidateNoKROOwnedLabels(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name:       "internal kro-owned labels",
+			resourceID: "testResource",
+			obj: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "test",
+					"labels": map[string]interface{}{
+						"internal.kro.run/apply-order": "99",
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "internal.kro.run/",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -740,6 +740,47 @@ func TestValidateNoKROOwnedLabels(t *testing.T) {
 	}
 }
 
+func TestValidateNoKROOwnedAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]interface{}
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "public kro-owned annotation",
+			annotations: map[string]interface{}{"kro.run/example": "value"},
+			expectError: true,
+			errorMsg:    "kro.run/",
+		},
+		{
+			name:        "internal kro-owned annotation",
+			annotations: map[string]interface{}{"internal.kro.run/apply-order": "99"},
+			expectError: true,
+			errorMsg:    "internal.kro.run/",
+		},
+		{
+			name:        "unowned annotation",
+			annotations: map[string]interface{}{"example.com/key": "value"},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := map[string]interface{}{
+				"metadata": map[string]interface{}{"annotations": tt.annotations},
+			}
+			err := validateNoKROOwnedAnnotations("testResource", obj)
+			if tt.expectError {
+				require.ErrorContains(t, err, tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateCombinableResourceFields(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -1,0 +1,20 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+const (
+	// ApplyOrderAnnotation persists a managed resource's reverse topological deletion wave.
+	ApplyOrderAnnotation = InternalKROPrefix + "apply-order"
+)

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -31,10 +31,14 @@ import (
 const (
 	// LabelKROPrefix is the label key prefix used to identify KRO owned resources.
 	LabelKROPrefix = v1alpha1.KRODomainName + "/"
+	// InternalLabelKROPrefix is reserved for controller-internal metadata.
+	InternalLabelKROPrefix = "internal.kro.run/"
 )
 
 const (
 	NodeIDLabel = LabelKROPrefix + "node-id"
+	// ApplyOrderLabel persists a managed resource's total topological position.
+	ApplyOrderLabel = InternalLabelKROPrefix + "apply-order"
 
 	// Collection labels for tracking collection membership and position.
 	// These enable querying collection resources and understanding their position.

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -24,50 +24,41 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/release-utils/version"
-
-	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 )
 
 const (
-	// LabelKROPrefix is the label key prefix used to identify KRO owned resources.
-	LabelKROPrefix = v1alpha1.KRODomainName + "/"
-	// AnnotationKROPrefix is the annotation key prefix reserved for KRO.
-	AnnotationKROPrefix = v1alpha1.KRODomainName + "/"
-	// InternalLabelKROPrefix is reserved for controller-internal metadata.
-	InternalLabelKROPrefix = "internal." + LabelKROPrefix
-	// InternalAnnotationKROPrefix is reserved for controller-internal metadata.
-	InternalAnnotationKROPrefix = "internal." + AnnotationKROPrefix
+	// LabelKROPrefix is retained for compatibility.
+	// Deprecated: use KROPrefix.
+	LabelKROPrefix = KROPrefix
 )
 
 const (
-	NodeIDLabel = LabelKROPrefix + "node-id"
-	// ApplyOrderAnnotation persists a managed resource's reverse topological deletion wave.
-	ApplyOrderAnnotation = InternalAnnotationKROPrefix + "apply-order"
+	NodeIDLabel = KROPrefix + "node-id"
 
 	// Collection labels for tracking collection membership and position.
 	// These enable querying collection resources and understanding their position.
-	CollectionIndexLabel = LabelKROPrefix + "collection-index"
-	CollectionSizeLabel  = LabelKROPrefix + "collection-size"
+	CollectionIndexLabel = KROPrefix + "collection-index"
+	CollectionSizeLabel  = KROPrefix + "collection-size"
 
-	OwnedLabel      = LabelKROPrefix + "owned"
-	KROVersionLabel = LabelKROPrefix + "kro-version"
+	OwnedLabel      = KROPrefix + "owned"
+	KROVersionLabel = KROPrefix + "kro-version"
 
 	ManagedByLabelKey = "app.kubernetes.io/managed-by"
 	ManagedByKROValue = "kro"
 
-	InstanceIDLabel        = LabelKROPrefix + "instance-id"
-	InstanceLabel          = LabelKROPrefix + "instance-name"
-	InstanceNamespaceLabel = LabelKROPrefix + "instance-namespace"
-	InstanceGroupLabel     = LabelKROPrefix + "instance-group"
-	InstanceVersionLabel   = LabelKROPrefix + "instance-version"
-	InstanceKindLabel      = LabelKROPrefix + "instance-kind"
+	InstanceIDLabel        = KROPrefix + "instance-id"
+	InstanceLabel          = KROPrefix + "instance-name"
+	InstanceNamespaceLabel = KROPrefix + "instance-namespace"
+	InstanceGroupLabel     = KROPrefix + "instance-group"
+	InstanceVersionLabel   = KROPrefix + "instance-version"
+	InstanceKindLabel      = KROPrefix + "instance-kind"
 
-	ResourceGraphDefinitionIDLabel        = LabelKROPrefix + "resource-graph-definition-id"
-	ResourceGraphDefinitionNameLabel      = LabelKROPrefix + "resource-graph-definition-name"
-	ResourceGraphDefinitionNamespaceLabel = LabelKROPrefix + "resource-graph-definition-namespace"
-	ResourceGraphDefinitionVersionLabel   = LabelKROPrefix + "resource-graph-definition-version"
+	ResourceGraphDefinitionIDLabel        = KROPrefix + "resource-graph-definition-id"
+	ResourceGraphDefinitionNameLabel      = KROPrefix + "resource-graph-definition-name"
+	ResourceGraphDefinitionNamespaceLabel = KROPrefix + "resource-graph-definition-namespace"
+	ResourceGraphDefinitionVersionLabel   = KROPrefix + "resource-graph-definition-version"
 	// GraphRevisionHashLabel stores a label-safe representation of the GraphRevision spec hash.
-	GraphRevisionHashLabel = LabelKROPrefix + "graph-revision-hash"
+	GraphRevisionHashLabel = KROPrefix + "graph-revision-hash"
 )
 
 // IsKROOwned returns true if the resource is owned by KRO.

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -37,7 +37,7 @@ const (
 
 const (
 	NodeIDLabel = LabelKROPrefix + "node-id"
-	// ApplyOrderLabel persists a managed resource's total topological position.
+	// ApplyOrderLabel persists a managed resource's reverse topological deletion wave.
 	ApplyOrderLabel = InternalLabelKROPrefix + "apply-order"
 
 	// Collection labels for tracking collection membership and position.

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -31,14 +31,18 @@ import (
 const (
 	// LabelKROPrefix is the label key prefix used to identify KRO owned resources.
 	LabelKROPrefix = v1alpha1.KRODomainName + "/"
+	// AnnotationKROPrefix is the annotation key prefix reserved for KRO.
+	AnnotationKROPrefix = v1alpha1.KRODomainName + "/"
 	// InternalLabelKROPrefix is reserved for controller-internal metadata.
-	InternalLabelKROPrefix = "internal.kro.run/"
+	InternalLabelKROPrefix = "internal." + LabelKROPrefix
+	// InternalAnnotationKROPrefix is reserved for controller-internal metadata.
+	InternalAnnotationKROPrefix = "internal." + AnnotationKROPrefix
 )
 
 const (
 	NodeIDLabel = LabelKROPrefix + "node-id"
-	// ApplyOrderLabel persists a managed resource's reverse topological deletion wave.
-	ApplyOrderLabel = InternalLabelKROPrefix + "apply-order"
+	// ApplyOrderAnnotation persists a managed resource's reverse topological deletion wave.
+	ApplyOrderAnnotation = InternalAnnotationKROPrefix + "apply-order"
 
 	// Collection labels for tracking collection membership and position.
 	// These enable querying collection resources and understanding their position.

--- a/pkg/metadata/prefixes.go
+++ b/pkg/metadata/prefixes.go
@@ -1,0 +1,24 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import "github.com/kubernetes-sigs/kro/api/v1alpha1"
+
+const (
+	// KROPrefix is the key prefix for public kro metadata.
+	KROPrefix = v1alpha1.KRODomainName + "/"
+	// InternalKROPrefix is the key prefix for controller-internal kro metadata.
+	InternalKROPrefix = "internal." + KROPrefix
+)

--- a/pkg/runtime/conditions_test.go
+++ b/pkg/runtime/conditions_test.go
@@ -48,14 +48,14 @@ func compileConditionExpr(t *testing.T, expr string) *krocel.Expression {
 }
 
 func graphWithConditions(conditions []*krocel.Expression) *graph.Graph {
-	return &graph.Graph{
+	return withTestDAG(&graph.Graph{
 		TopologicalOrder: []string{},
 		Nodes:            map[string]*graph.Node{},
 		Instance: &graph.Node{
 			Meta:       graph.NodeMeta{ID: graph.InstanceNodeID, Type: graph.NodeTypeInstance},
 			Conditions: conditions,
 		},
-	}
+	})
 }
 
 func TestEvaluateConditions_NoConditions(t *testing.T) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,12 +15,14 @@
 package runtime
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 )
@@ -35,16 +37,20 @@ type Interface interface {
 
 	// Instance returns the instance node.
 	Instance() *Node
+
+	// ApplyOrder returns the deletion-wave value to persist for a node.
+	ApplyOrder(nodeID string) (int, bool)
 }
 
 // Runtime is the execution context for a single reconciliation.
 // It holds nodes in topological order and provides access to the instance node.
 // Expression deduplication is done during FromGraph construction via a local cache.
 type Runtime struct {
-	order     []string
-	nodes     map[string]*Node
-	instance  *Node
-	rgdConfig graph.RGDConfig
+	order       []string
+	nodes       map[string]*Node
+	instance    *Node
+	applyOrders map[string]int
+	rgdConfig   graph.RGDConfig
 }
 
 // FromGraph creates a new Runtime from a Graph and instance.
@@ -56,12 +62,17 @@ func FromGraph(g *graph.Graph, instance *unstructured.Unstructured, rgdConfig gr
 		metrics.RuntimeCreationDuration.Observe(duration.Seconds())
 		metrics.RuntimeCreationTotal.Inc()
 	}()
+	applyOrders, err := applyOrdersForDAG(g.DAG)
+	if err != nil {
+		return nil, fmt.Errorf("calculate apply-order waves: %w", err)
+	}
 	instanceObj := instance.DeepCopy()
 
 	rt := &Runtime{
-		order:     g.TopologicalOrder,
-		nodes:     make(map[string]*Node),
-		rgdConfig: rgdConfig,
+		order:       g.TopologicalOrder,
+		nodes:       make(map[string]*Node),
+		applyOrders: applyOrders,
+		rgdConfig:   rgdConfig,
 	}
 
 	// Expression cache for non-iteration expressions only.
@@ -188,4 +199,28 @@ func (r *Runtime) Nodes() []*Node {
 // Instance returns the instance node.
 func (r *Runtime) Instance() *Node {
 	return r.instance
+}
+
+// ApplyOrder returns the deletion-wave value to persist for a node.
+func (r *Runtime) ApplyOrder(nodeID string) (int, bool) {
+	order, ok := r.applyOrders[nodeID]
+	return order, ok
+}
+
+func applyOrdersForDAG(
+	dependencyGraph *dag.DirectedAcyclicGraph[string],
+) (map[string]int, error) {
+	layers, err := dependencyGraph.ReverseTopologicalLayers()
+	if err != nil {
+		return nil, err
+	}
+
+	orders := make(map[string]int, len(dependencyGraph.Vertices))
+	for i, layer := range layers {
+		order := len(layers) - i
+		for _, nodeID := range layer {
+			orders[nodeID] = order
+		}
+	}
+	return orders, nil
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,14 +15,12 @@
 package runtime
 
 import (
-	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
-	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 )
@@ -62,16 +60,12 @@ func FromGraph(g *graph.Graph, instance *unstructured.Unstructured, rgdConfig gr
 		metrics.RuntimeCreationDuration.Observe(duration.Seconds())
 		metrics.RuntimeCreationTotal.Inc()
 	}()
-	applyOrders, err := applyOrdersForDAG(g.DAG)
-	if err != nil {
-		return nil, fmt.Errorf("calculate apply-order waves: %w", err)
-	}
 	instanceObj := instance.DeepCopy()
 
 	rt := &Runtime{
 		order:       g.TopologicalOrder,
 		nodes:       make(map[string]*Node),
-		applyOrders: applyOrders,
+		applyOrders: g.ApplyOrders,
 		rgdConfig:   rgdConfig,
 	}
 
@@ -205,22 +199,4 @@ func (r *Runtime) Instance() *Node {
 func (r *Runtime) ApplyOrder(nodeID string) (int, bool) {
 	order, ok := r.applyOrders[nodeID]
 	return order, ok
-}
-
-func applyOrdersForDAG(
-	dependencyGraph *dag.DirectedAcyclicGraph[string],
-) (map[string]int, error) {
-	layers, err := dependencyGraph.ReverseTopologicalLayers()
-	if err != nil {
-		return nil, err
-	}
-
-	orders := make(map[string]int, len(dependencyGraph.Vertices))
-	for i, layer := range layers {
-		order := len(layers) - i
-		for _, nodeID := range layer {
-			orders[nodeID] = order
-		}
-	}
-	return orders, nil
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -15,6 +15,7 @@
 package runtime
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,7 @@ import (
 
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
+	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 )
 
@@ -227,6 +229,7 @@ func TestFromGraph(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			withTestDAG(tt.graph)
 			// Capture original state for mutation test
 			var origDeps []string
 			var origIncludeLen int
@@ -274,6 +277,7 @@ func TestFromGraph_InstanceWithDependencies(t *testing.T) {
 			},
 		},
 	}
+	withTestDAG(g)
 
 	rt, err := FromGraph(g, testInstance("test"), graph.RGDConfig{MaxCollectionSize: 1000})
 	require.NoError(t, err)
@@ -283,6 +287,51 @@ func TestFromGraph_InstanceWithDependencies(t *testing.T) {
 	assert.Same(t, rt.Nodes()[0], inst.deps["deployment"])
 	assert.Len(t, inst.templateVars, 1)
 	assert.Len(t, inst.templateExprs, 1)
+}
+
+func TestFromGraphComputesApplyOrderWaves(t *testing.T) {
+	g := &graph.Graph{
+		TopologicalOrder: []string{"a", "b", "c", "d"},
+		Nodes: map[string]*graph.Node{
+			"a": {Meta: graph.NodeMeta{ID: "a"}},
+			"b": {Meta: graph.NodeMeta{ID: "b", Dependencies: []string{"a"}}},
+			"c": {Meta: graph.NodeMeta{ID: "c", Dependencies: []string{"a"}}},
+			"d": {Meta: graph.NodeMeta{ID: "d", Dependencies: []string{"b", "c"}}},
+		},
+		Instance: &graph.Node{Meta: graph.NodeMeta{ID: graph.InstanceNodeID}},
+	}
+	withTestDAG(g)
+
+	rt, err := FromGraph(g, testInstance("test"), graph.RGDConfig{})
+	require.NoError(t, err)
+
+	for nodeID, want := range map[string]int{"a": 1, "b": 2, "c": 2, "d": 3} {
+		got, ok := rt.ApplyOrder(nodeID)
+		assert.True(t, ok)
+		assert.Equal(t, want, got)
+	}
+}
+
+func withTestDAG(g *graph.Graph) *graph.Graph {
+	dependencyGraph := dag.NewDirectedAcyclicGraph[string]()
+	for i, nodeID := range g.TopologicalOrder {
+		if err := dependencyGraph.AddVertex(nodeID, i); err != nil {
+			panic(fmt.Sprintf("adding test graph vertex %q: %v", nodeID, err))
+		}
+	}
+	for nodeID, node := range g.Nodes {
+		dependencies := make([]string, 0, len(node.Meta.Dependencies))
+		for _, dependency := range node.Meta.Dependencies {
+			if _, ok := dependencyGraph.Vertices[dependency]; ok {
+				dependencies = append(dependencies, dependency)
+			}
+		}
+		if err := dependencyGraph.AddDependencies(nodeID, dependencies); err != nil {
+			panic(fmt.Sprintf("adding test graph dependencies for %q: %v", nodeID, err))
+		}
+	}
+	g.DAG = dependencyGraph
+	return g
 }
 
 func testInstance(name string) *unstructured.Unstructured {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -289,29 +289,6 @@ func TestFromGraph_InstanceWithDependencies(t *testing.T) {
 	assert.Len(t, inst.templateExprs, 1)
 }
 
-func TestFromGraphComputesApplyOrderWaves(t *testing.T) {
-	g := &graph.Graph{
-		TopologicalOrder: []string{"a", "b", "c", "d"},
-		Nodes: map[string]*graph.Node{
-			"a": {Meta: graph.NodeMeta{ID: "a"}},
-			"b": {Meta: graph.NodeMeta{ID: "b", Dependencies: []string{"a"}}},
-			"c": {Meta: graph.NodeMeta{ID: "c", Dependencies: []string{"a"}}},
-			"d": {Meta: graph.NodeMeta{ID: "d", Dependencies: []string{"b", "c"}}},
-		},
-		Instance: &graph.Node{Meta: graph.NodeMeta{ID: graph.InstanceNodeID}},
-	}
-	withTestDAG(g)
-
-	rt, err := FromGraph(g, testInstance("test"), graph.RGDConfig{})
-	require.NoError(t, err)
-
-	for nodeID, want := range map[string]int{"a": 1, "b": 2, "c": 2, "d": 3} {
-		got, ok := rt.ApplyOrder(nodeID)
-		assert.True(t, ok)
-		assert.Equal(t, want, got)
-	}
-}
-
 func withTestDAG(g *graph.Graph) *graph.Graph {
 	dependencyGraph := dag.NewDirectedAcyclicGraph[string]()
 	for i, nodeID := range g.TopologicalOrder {

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -768,11 +768,12 @@ var _ = Describe("CRD", func() {
 				err := env.Client.Get(ctx, types.NamespacedName{Name: crdName}, recreatedCRD)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				if recreatedCRD.UID == originalUID {
-					g.Expect(recreatedCRD.DeletionTimestamp).ToNot(BeNil(),
-						"old CRD still exists without deletionTimestamp")
-					g.Expect(false).To(BeTrue(), "old CRD still terminating")
-				}
+				g.Expect(
+					recreatedCRD.UID != originalUID ||
+						recreatedCRD.DeletionTimestamp != nil,
+				).To(BeTrue(), "old CRD still present without deletionTimestamp — waiting for new CRD")
+				g.Expect(recreatedCRD.UID).ToNot(Equal(originalUID),
+					"old CRD still terminating (customresourcecleanup finalizer)")
 
 				g.Expect(metadata.IsKROOwned(&recreatedCRD.ObjectMeta)).To(BeTrue())
 				g.Expect(recreatedCRD.Labels[metadata.ResourceGraphDefinitionNameLabel]).To(Equal(rgdName))

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -185,12 +185,21 @@ var _ = Describe("CRD", func() {
 			// Delete ResourceGraphDefinition
 			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 
-			// Verify CRD is deleted
+			// Wait for the RGD to be fully gone — this proves the controller
+			// processed the deletion, removed its finalizer (which includes
+			// issuing the CRD Delete), and the object was garbage collected.
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+				g.Expect(err).To(MatchError(errors.IsNotFound, "rgd should be deleted"))
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+			// Now verify the CRD is also gone (may take a moment for the
+			// apiserver's customresourcecleanup finalizer to clear).
 			Eventually(func(g Gomega, ctx SpecContext) {
 				err := env.Client.Get(ctx, types.NamespacedName{Name: crdName},
 					&apiextensionsv1.CustomResourceDefinition{})
 				g.Expect(err).To(MatchError(errors.IsNotFound, "crd should be deleted"))
-			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 		})
 	})
 
@@ -751,16 +760,19 @@ var _ = Describe("CRD", func() {
 			// trigger a reconciliation of the owning RGD, which calls crdManager.Ensure()
 			// to recreate the CRD.
 			//
-			// Without the fix (DeleteFunc returning false in the CRD watch predicate),
-			// this would timeout because the delete event would be silently filtered
-			// out, leaving the CRD permanently deleted.
+			// The old CRD may linger briefly with a customresourcecleanup finalizer
+			// while the apiserver garbage-collects stored CR data; skip polls where
+			// the old UID is still present with a deletionTimestamp.
 			recreatedCRD := &apiextensionsv1.CustomResourceDefinition{}
 			Eventually(func(g Gomega, ctx SpecContext) {
 				err := env.Client.Get(ctx, types.NamespacedName{Name: crdName}, recreatedCRD)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				// A different UID proves this is a new object, not the original
-				g.Expect(recreatedCRD.UID).NotTo(Equal(originalUID))
+				if recreatedCRD.UID == originalUID {
+					g.Expect(recreatedCRD.DeletionTimestamp).ToNot(BeNil(),
+						"old CRD still exists without deletionTimestamp")
+					g.Expect(false).To(BeTrue(), "old CRD still terminating")
+				}
 
 				g.Expect(metadata.IsKROOwned(&recreatedCRD.ObjectMeta)).To(BeTrue())
 				g.Expect(recreatedCRD.Labels[metadata.ResourceGraphDefinitionNameLabel]).To(Equal(rgdName))

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -199,7 +199,7 @@ var _ = Describe("CRD", func() {
 				err := env.Client.Get(ctx, types.NamespacedName{Name: crdName},
 					&apiextensionsv1.CustomResourceDefinition{})
 				g.Expect(err).To(MatchError(errors.IsNotFound, "crd should be deleted"))
-			}, 10*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 		})
 	})
 

--- a/test/integration/suites/core/externalref_deletion_test.go
+++ b/test/integration/suites/core/externalref_deletion_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	krometadata "github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
@@ -136,37 +137,109 @@ var _ = Describe("ExternalRef Deletion", func() {
 					HaveKeyWithValue("state", "ACTIVE")))
 			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
-			By("verifying the managed ConfigMap was created with data derived from the external ref")
+			By("verifying the managed ConfigMap was created with persisted apply order")
+			managedCM := &corev1.ConfigMap{}
 			Eventually(func(g Gomega, ctx SpecContext) {
-				cm := &corev1.ConfigMap{}
 				err := env.Client.Get(ctx, types.NamespacedName{
 					Name: managedCMName, Namespace: ns.Name,
-				}, cm)
+				}, managedCM)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(cm.Data["inherited"]).To(Equal("from-external"))
+				g.Expect(managedCM.Data["inherited"]).To(Equal("from-external"))
+				g.Expect(managedCM.Labels[krometadata.ApplyOrderLabel]).To(Equal("2"))
 			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
-			By("deleting the instance")
+			By("holding the managed child in termination")
+			managedCM.Finalizers = append(managedCM.Finalizers, "test.kro.run/block-deletion")
+			Expect(env.Client.Update(ctx, managedCM)).To(Succeed())
+
+			By("deleting the external reference and the instance")
+			Expect(env.Client.Delete(ctx, extCM)).To(Succeed())
 			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
 
-			// Wait for the instance to be fully gone, then immediately check the
-			// managed CM — no retry window. The controller must delete managedcm
-			// before removing the finalizer, so when the instance is NotFound the
-			// CM must already be NotFound too.
-			By("waiting for instance to be fully deleted")
+			By("verifying deletion reaches the child without observing the missing external ref")
 			Eventually(func(g Gomega, ctx SpecContext) {
-				err := env.Client.Get(ctx, types.NamespacedName{
-					Name: instanceName, Namespace: ns.Name,
-				}, instance)
-				g.Expect(err).To(MatchError(errors.IsNotFound,
-					"instance should be fully deleted once all managed resources are cleaned up"))
+				current := &corev1.ConfigMap{}
+				err := env.Client.Get(ctx, types.NamespacedName{Name: managedCMName, Namespace: ns.Name}, current)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(current.DeletionTimestamp).ToNot(BeNil())
 			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
-			By("verifying managed ConfigMap was deleted before the instance finalizer was removed")
-			err := env.Client.Get(ctx, types.NamespacedName{
-				Name: managedCMName, Namespace: ns.Name,
-			}, &corev1.ConfigMap{})
-			Expect(err).To(MatchError(errors.IsNotFound,
-				"managed ConfigMap must already be gone when instance is deleted"))
+			By("unblocking child deletion")
+			current := &corev1.ConfigMap{}
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: managedCMName, Namespace: ns.Name}, current)).To(Succeed())
+			current.Finalizers = nil
+			Expect(env.Client.Update(ctx, current)).To(Succeed())
+
+			By("verifying the child and root both disappear")
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, types.NamespacedName{Name: managedCMName, Namespace: ns.Name}, &corev1.ConfigMap{})
+				g.Expect(err).To(MatchError(errors.IsNotFound, "managed child should be deleted"))
+				err = env.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: ns.Name}, instance)
+				g.Expect(err).To(MatchError(errors.IsNotFound, "instance should be deleted"))
+			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 		})
+
+	It("ordered deletion waits for the higher dependency wave", func(ctx SpecContext) {
+		rgdName := fmt.Sprintf("test-ordered-deletion-%s", rand.String(5))
+		const instanceName = "ordered-deletion"
+		rgd := generator.NewResourceGraphDefinition(rgdName,
+			generator.WithSchema("TestOrderedDeletion", "v1alpha1", map[string]interface{}{}, map[string]interface{}{}),
+			generator.WithResource("a", map[string]interface{}{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]interface{}{"name": instanceName + "-a"},
+			}, nil, nil),
+			generator.WithResource("b", map[string]interface{}{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]interface{}{"name": instanceName + "-b"},
+				"data":     map[string]interface{}{"dependency": "${a.metadata.name}"},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) { _ = env.Client.Delete(ctx, rgd) })
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgdName}, rgd)).To(Succeed())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		instance := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "kro.run/v1alpha1", "kind": "TestOrderedDeletion",
+			"metadata": map[string]interface{}{"name": instanceName, "namespace": ns.Name},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		aKey := types.NamespacedName{Name: instanceName + "-a", Namespace: ns.Name}
+		bKey := types.NamespacedName{Name: instanceName + "-b", Namespace: ns.Name}
+		b := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, aKey, &corev1.ConfigMap{})).To(Succeed())
+			g.Expect(env.Client.Get(ctx, bKey, b)).To(Succeed())
+			g.Expect(b.Labels[krometadata.ApplyOrderLabel]).To(Equal("2"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		b.Finalizers = append(b.Finalizers, "test.kro.run/block-deletion")
+		Expect(env.Client.Update(ctx, b)).To(Succeed())
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			current := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, bKey, current)).To(Succeed())
+			g.Expect(current.DeletionTimestamp).ToNot(BeNil())
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		Consistently(func(g Gomega, ctx SpecContext) {
+			a := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, aKey, a)).To(Succeed())
+			g.Expect(a.DeletionTimestamp).To(BeNil())
+		}, 3*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		Expect(env.Client.Get(ctx, bKey, b)).To(Succeed())
+		b.Finalizers = nil
+		Expect(env.Client.Update(ctx, b)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, bKey, &corev1.ConfigMap{})).To(MatchError(errors.IsNotFound))
+			g.Expect(env.Client.Get(ctx, aKey, &corev1.ConfigMap{})).To(MatchError(errors.IsNotFound))
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: ns.Name}, instance)).To(MatchError(errors.IsNotFound))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
 })

--- a/test/integration/suites/core/externalref_deletion_test.go
+++ b/test/integration/suites/core/externalref_deletion_test.go
@@ -239,7 +239,9 @@ var _ = Describe("ExternalRef Deletion", func() {
 		Eventually(func(g Gomega, ctx SpecContext) {
 			g.Expect(env.Client.Get(ctx, bKey, &corev1.ConfigMap{})).To(MatchError(errors.IsNotFound))
 			g.Expect(env.Client.Get(ctx, aKey, &corev1.ConfigMap{})).To(MatchError(errors.IsNotFound))
-			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: ns.Name}, instance)).To(MatchError(errors.IsNotFound))
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name: instanceName, Namespace: ns.Name,
+			}, instance)).To(MatchError(errors.IsNotFound))
 		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 	})
 })

--- a/test/integration/suites/core/externalref_deletion_test.go
+++ b/test/integration/suites/core/externalref_deletion_test.go
@@ -237,11 +237,15 @@ var _ = Describe("ExternalRef Deletion", func() {
 		Expect(env.Client.Update(ctx, b)).To(Succeed())
 
 		Eventually(func(g Gomega, ctx SpecContext) {
-			g.Expect(env.Client.Get(ctx, bKey, &corev1.ConfigMap{})).To(MatchError(errors.IsNotFound))
-			g.Expect(env.Client.Get(ctx, aKey, &corev1.ConfigMap{})).To(MatchError(errors.IsNotFound))
+			g.Expect(env.Client.Get(ctx, bKey, &corev1.ConfigMap{})).To(
+				MatchError(errors.IsNotFound, "managed B should be deleted"),
+			)
+			g.Expect(env.Client.Get(ctx, aKey, &corev1.ConfigMap{})).To(
+				MatchError(errors.IsNotFound, "managed A should be deleted"),
+			)
 			g.Expect(env.Client.Get(ctx, types.NamespacedName{
 				Name: instanceName, Namespace: ns.Name,
-			}, instance)).To(MatchError(errors.IsNotFound))
+			}, instance)).To(MatchError(errors.IsNotFound, "instance should be deleted"))
 		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 	})
 })

--- a/test/integration/suites/core/externalref_deletion_test.go
+++ b/test/integration/suites/core/externalref_deletion_test.go
@@ -145,7 +145,7 @@ var _ = Describe("ExternalRef Deletion", func() {
 				}, managedCM)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(managedCM.Data["inherited"]).To(Equal("from-external"))
-				g.Expect(managedCM.Labels[krometadata.ApplyOrderLabel]).To(Equal("2"))
+				g.Expect(managedCM.Annotations[krometadata.ApplyOrderAnnotation]).To(Equal("2"))
 			}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 			By("holding the managed child in termination")
@@ -214,7 +214,7 @@ var _ = Describe("ExternalRef Deletion", func() {
 		Eventually(func(g Gomega, ctx SpecContext) {
 			g.Expect(env.Client.Get(ctx, aKey, &corev1.ConfigMap{})).To(Succeed())
 			g.Expect(env.Client.Get(ctx, bKey, b)).To(Succeed())
-			g.Expect(b.Labels[krometadata.ApplyOrderLabel]).To(Equal("2"))
+			g.Expect(b.Annotations[krometadata.ApplyOrderAnnotation]).To(Equal("2"))
 		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		b.Finalizers = append(b.Finalizers, "test.kro.run/block-deletion")

--- a/test/integration/suites/core/readiness_test.go
+++ b/test/integration/suites/core/readiness_test.go
@@ -31,6 +31,7 @@ import (
 
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/controller/resourcegraphdefinition"
+	krometadata "github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
@@ -225,7 +226,10 @@ var _ = Describe("Readiness", func() {
 			// Verify deployment specs
 			g.Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			g.Expect(*deployment.Spec.Replicas).To(Equal(int32(replicas)))
-			g.Expect(deployment.Annotations).To(HaveLen(0))
+			g.Expect(deployment.Annotations).ToNot(HaveKey("app"))
+			g.Expect(deployment.Annotations).To(HaveKeyWithValue(
+				krometadata.ApplyOrderAnnotation, "1",
+			))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		// Verify Service is not created yet
@@ -273,8 +277,10 @@ var _ = Describe("Readiness", func() {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// validate service spec
-			g.Expect(service.Annotations).To(HaveLen(1))
 			g.Expect(service.Annotations["app"]).To(Equal("service"))
+			g.Expect(service.Annotations).To(HaveKeyWithValue(
+				krometadata.ApplyOrderAnnotation, "2",
+			))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
 
 		// Delete instance

--- a/website/docs/docs/advanced/06-instance-deletion.md
+++ b/website/docs/docs/advanced/06-instance-deletion.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 6
+---
+
+# Instance Deletion
+
+Deleting an instance also deletes the resources managed by that instance. kro
+keeps the instance finalizer until all managed resources are gone. Resources
+referenced through `externalRef` are read-only and are never deleted by kro.
+
+## Deletion Order
+
+kro deletes dependents before their dependencies. Resources that do not depend
+on each other share a deletion wave. A wave must disappear completely before
+the next wave starts, so a child finalizer can pause the rest of the deletion.
+
+kro stores each child's wave in the
+`internal.kro.run/apply-order` annotation. Children without a valid annotation,
+such as resources created before an upgrade, are deleted in a final unordered
+wave.
+
+## Resource Discovery
+
+kro discovers children from the instance's persisted ApplySet inventory. It
+does not need to evaluate the current graph or CEL expressions during deletion.
+Cleanup can therefore continue when an external reference is gone or desired
+state can no longer be resolved.
+
+## Troubleshooting
+
+While deletion is in progress, the instance has a `ResourcesReady` condition
+with status `Unknown` and reason `UnderDeletion`. Its message reports inventory,
+discovery, or delete errors. Also check managed children for finalizers that may
+be blocking the active wave.


### PR DESCRIPTION
## Summary

Fixes #1316.

Instance deletion must remain possible when desired-state projection, CEL evaluation, GraphRevision resolution, or external observation is unavailable. This change:

- Handles deletion before GraphRevision resolution through a dedicated runtime-free path.
- Discovers managed children from the instance's persisted ApplySet inventory rather than reconstructing identities from the current graph.
- Persists the `internal.kro.run/apply-order` annotation on regular resources and collection members, then deletes one highest-order wave at a time.
- Keeps terminating objects in their wave until they disappear, so lower dependency waves cannot advance early.
- Uses UID-preconditioned DELETEs to avoid deleting an object recreated between LIST and DELETE.
- Keeps `externalRef` resources read-only and excludes them from deletion inventory.

## Rollout and failure behavior

Normal reconciliation backfills apply-order annotations through SSA. Children with missing, malformed, zero, or negative order annotations share an unordered fallback wave that runs after every valid ordered wave. This prioritizes deletion liveness for instances deleted before annotation backfill completes.

Deletion validates the persisted ApplySet parent ID, kro tooling ownership, group-kind and namespace inventory, and an inventory checksum when present. Invalid inventory, LIST failures, DELETE failures, and UID conflicts retain the root finalizer and are surfaced through the instance's `ResourcesReady` condition rather than being treated as empty inventory.

## Release note

After upgrading, allow existing instances to reconcile once before deleting them. An instance deleted before that reconciliation may lack the ApplySet inventory required for safe cleanup and remain terminating. If this happens, manually delete or verify its managed resources before removing the kro finalizer. Do not replace unknown inventory with an empty inventory, because that can orphan children.

## Design

See [CEL-independent ordered instance deletion](https://github.com/kubernetes-sigs/kro/blob/fix/1316/deletion-with-externalref/docs/design/proposals/ordered-instance-deletion.md).

## Test plan

- [x] Apply-order annotations on regular resources and collection members.
- [x] External references remain unannotated and absent from ApplySet inventory.
- [x] Reserved-metadata validation and SSA backfill.
- [x] Persisted namespaced and cluster-scoped ApplySet discovery, including removed graph nodes.
- [x] Strict highest-wave deletion, terminating blockers, wave advancement, and same-wave collections.
- [x] Fallback deletion for missing or invalid order annotations.
- [x] Inventory validation and finalizer retention on invalid metadata.
- [x] UID conflicts and DELETE-error visibility.
- [x] Focused integration reproduction of #1316.
- [x] Integration coverage for `A -> B` ordered deletion.

Verified with:

```text
go test ./pkg/metadata ./pkg/graph ./pkg/controller/instance/... -count=1
golangci-lint run ./...
```
