### PR TITLE
fix: use background propagation when deleting managed resources

### DIFF
--- a/pkg/controller/instance/applyset/applyset.go
+++ b/pkg/controller/instance/applyset/applyset.go
@@ -467,8 +467,12 @@ func (a *ApplySet) ListOrphans(ctx context.Context, opts PruneOptions) ([]Orphan
 // to avoid deleting a resource that was recreated since listing.
 func (a *ApplySet) DeleteOrphan(ctx context.Context, candidate OrphanCandidate) (DeleteOrphanResult, error) {
 	uid := candidate.Object.GetUID()
+	// An unspecified propagation policy would fall back to the type's default
+	// GC policy, which orphans dependents for some types (e.g. batch/v1 Job).
+	propagationPolicy := metav1.DeletePropagationBackground
 	deleteOpts := metav1.DeleteOptions{
-		Preconditions: &metav1.Preconditions{UID: &uid},
+		Preconditions:     &metav1.Preconditions{UID: &uid},
+		PropagationPolicy: &propagationPolicy,
 	}
 
 	var err error

--- a/pkg/controller/instance/applyset/applyset_test.go
+++ b/pkg/controller/instance/applyset/applyset_test.go
@@ -779,6 +779,57 @@ func TestPrune_UIDPrecondition(t *testing.T) {
 	})
 }
 
+func TestDeleteOrphan_BackgroundPropagation(t *testing.T) {
+	ctx := t.Context()
+	mapper := newTestRESTMapper()
+	parent := newTestParent(schema.GroupVersionKind{
+		Group: "kro.run", Version: "v1alpha1", Kind: "TestKind",
+	})
+	applySetID := ID(parent)
+
+	orphan := newConfigMap("orphan-cm", "default")
+	orphan.SetLabels(map[string]string{
+		ApplysetPartOfLabel: applySetID,
+	})
+	orphan.SetUID(types.UID("orphan-uid"))
+
+	client := newFakeDynamicClient(orphan)
+
+	var deleteOptions *metav1.DeleteOptions
+	client.PrependReactor("delete", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		if !ok {
+			return false, nil, nil
+		}
+		opts := deleteAction.GetDeleteOptions()
+		deleteOptions = &opts
+		return false, nil, nil
+	})
+
+	applier := New(Config{
+		Client:          client,
+		RESTMapper:      mapper,
+		Log:             logr.Discard(),
+		ParentNamespace: "default",
+	}, parent)
+
+	cmGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	_, err := applier.DeleteOrphan(ctx, OrphanCandidate{Object: orphan, GVR: cmGVR})
+	if err != nil {
+		t.Fatalf("DeleteOrphan() error = %v", err)
+	}
+
+	if deleteOptions == nil {
+		t.Fatal("delete reactor was not invoked")
+	}
+	if deleteOptions.PropagationPolicy == nil {
+		t.Fatal("delete options must set an explicit propagation policy")
+	}
+	if got := *deleteOptions.PropagationPolicy; got != metav1.DeletePropagationBackground {
+		t.Errorf("delete propagation policy = %q, want %q", got, metav1.DeletePropagationBackground)
+	}
+}
+
 func TestErrors_ShouldPreventPrune(t *testing.T) {
 	ctx := t.Context()
 	mapper := newTestRESTMapper()

--- a/pkg/controller/instance/deletion.go
+++ b/pkg/controller/instance/deletion.go
@@ -181,12 +181,16 @@ func (c *Controller) deleteTarget(
 		return nil
 	}
 
+	// Background must be explicit: an unspecified policy falls back to the
+	// type's default GC policy, which for batch/v1 Jobs orphans their Pods.
+	propagationPolicy := metav1.DeletePropagationBackground
+
 	// Track whether any delete request was accepted. a successful Delete does NOT
 	// mean the object is gone yet, just that deletion is in progress.
 	anyDeleted := false
 	for _, target := range targets {
 		rc := resourceClientFor(rcx, node.Spec.Meta, target.GetNamespace())
-		err := rc.Delete(rcx.Ctx, target.GetName(), metav1.DeleteOptions{})
+		err := rc.Delete(rcx.Ctx, target.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 		if apierrors.IsNotFound(err) {
 			// Already gone: leave anyDeleted as is and keep checking others.
 			continue

--- a/pkg/controller/instance/deletion_test.go
+++ b/pkg/controller/instance/deletion_test.go
@@ -254,6 +254,39 @@ func TestDeleteTarget(t *testing.T) {
 	}
 }
 
+func TestDeleteTargetUsesBackgroundPropagation(t *testing.T) {
+	instance := newInstanceObject("demo", "default")
+	resourceNode := &graph.Node{
+		Meta: graph.NodeMeta{
+			ID:         "deploy",
+			Type:       graph.NodeTypeResource,
+			GVR:        controllerTestDeployGVR,
+			Namespaced: true,
+		},
+		Template: newDeploymentObject("demo", ""),
+	}
+
+	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph(resourceNode))
+	node := rcx.Runtime.Nodes()[0]
+	node.SetObserved([]*unstructured.Unstructured{newDeploymentObject("demo", "default")})
+
+	var deleteOptions *metav1.DeleteOptions
+	raw.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		require.True(t, ok)
+		opts := deleteAction.GetDeleteOptions()
+		deleteOptions = &opts
+		return true, nil, nil
+	})
+
+	state := rcx.StateManager.NewNodeState("deploy")
+	require.NoError(t, controller.deleteTarget(rcx, node, state))
+
+	require.NotNil(t, deleteOptions, "delete reactor was not invoked")
+	require.NotNil(t, deleteOptions.PropagationPolicy, "delete options must set an explicit propagation policy")
+	assert.Equal(t, metav1.DeletePropagationBackground, *deleteOptions.PropagationPolicy)
+}
+
 func TestReconcileDeletionRequeuesWhileChildDeletionInFlight(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	node := &graph.Node{


### PR DESCRIPTION
Fixes #1330 .

I confirmed that the Pods are deleted when running the "Reproduction Steps" in #1330 with this fix applied.

The cause is that `propagationPolicy` has not been specified when deleting resources.
When `propagationPolicy` is not specified, the `defaultGCPolicy` of the resource is used, and for Job (and ReplicationController) it is `OrphanDependents`. In this case, the child resources (Pods, in the case of Job) become orphans and remain.
Therefore, setting `propagationPolicy` to `Background` fixes this problem.

The `defaultGCPolicy` of resources other than Job and ReplicationController is equivalent to `Background`, so setting `propagationPolicy` to `Background` has no impact on them.

- Implementation showing that `defaultGCPolicy` is used when `propagationPolicy` is not specified, and that orphaning happens only when `defaultGCPolicy` is `OrphanDependents` (`shouldOrphanDependents`)
    - https://github.com/kubernetes/kubernetes/blob/v1.36.0/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L891-L932
- Job's `defaultGCPolicy` is `OrphanDependents` for batch/v1 (`DefaultGarbageCollectionPolicy`)
    - https://github.com/kubernetes/kubernetes/blob/v1.36.0/pkg/registry/batch/job/strategy.go#L60-L74
- ReplicationController's `defaultGCPolicy` is `OrphanDependents` for core/v1 (`DefaultGarbageCollectionPolicy`)
    - https://github.com/kubernetes/kubernetes/blob/v1.36.0/pkg/registry/core/replicationcontroller/strategy.go#L59-L73