### PR TITLE
Allow custom status conditions to reference each other

### DIFF
--- a/pkg/controller/instance/status_test.go
+++ b/pkg/controller/instance/status_test.go
@@ -172,12 +172,12 @@ func TestUpdateStatusMirrorsPersistedConditionsOntoInstance(t *testing.T) {
 		Template: &unstructured.Unstructured{
 			Object: map[string]interface{}{"status": map[string]interface{}{}},
 		},
-		Conditions: []*krocel.Expression{
+		Conditions: conditionEntries(
 			mustCompileControllerExpr(t,
 				`runtime.newCondition({type: 'PrimaryReady', status: 'True', reason: 'Healthy', message: 'all good'})`,
 				library.RuntimeVarName,
 			),
-		},
+		),
 	}
 
 	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraphWithInstance(instanceNode))
@@ -314,6 +314,14 @@ func TestStampAuthorConditionsEmptyReasonAndMessage(t *testing.T) {
 	assert.Nil(t, stamped[0].Message, "empty message should serialize as nil pointer")
 }
 
+func conditionEntries(exprs ...*krocel.Expression) []graph.ConditionEntry {
+	entries := make([]graph.ConditionEntry, len(exprs))
+	for i, e := range exprs {
+		entries[i] = graph.ConditionEntry{Expr: e}
+	}
+	return entries
+}
+
 // authorConditionsInstanceNode returns an instance node declaring the given
 // author condition expressions.
 func authorConditionsInstanceNode(t *testing.T, exprs ...*krocel.Expression) *graph.Node {
@@ -328,7 +336,7 @@ func authorConditionsInstanceNode(t *testing.T, exprs ...*krocel.Expression) *gr
 		Template: &unstructured.Unstructured{
 			Object: map[string]interface{}{"status": map[string]interface{}{}},
 		},
-		Conditions: exprs,
+		Conditions: conditionEntries(exprs...),
 	}
 }
 

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -724,7 +724,7 @@ func buildInstanceNode(
 	namespaced bool,
 	statusVariables []variable.FieldDescriptor,
 	statusTemplate map[string]interface{},
-	conditions []*krocel.Expression,
+	conditionEntries []ConditionEntry,
 	inspector *ast.Inspector,
 ) (*Node, error) {
 	gvr := metadata.GetResourceGraphDefinitionInstanceGVR(group, apiVersion, kind)
@@ -763,8 +763,8 @@ func buildInstanceNode(
 	// Fold condition dependencies into instanceDeps so the instance reconciles
 	// after the resources its conditions read. References were populated by
 	// buildConditions; schema and runtime are not resource dependencies.
-	for _, expr := range conditions {
-		for _, ref := range expr.References {
+	for _, entry := range conditionEntries {
+		for _, ref := range entry.Expr.References {
 			if ref == SchemaVarName || ref == library.RuntimeVarName {
 				continue
 			}
@@ -790,7 +790,7 @@ func buildInstanceNode(
 			},
 		},
 		Variables:  instanceStatusVariables,
-		Conditions: conditions,
+		Conditions: conditionEntries,
 	}
 
 	return instance, nil
@@ -951,31 +951,33 @@ func buildConditions(
 	inspector *ast.Inspector,
 	inspectorEnv *cel.Env,
 	nodeNames []string,
-) ([]*krocel.Expression, error) {
+) ([]ConditionEntry, error) {
 	if len(conditionExprStrings) == 0 {
 		return nil, nil
 	}
 
 	// Strip the ${...} wrappers; References and Program are filled in below.
-	conditions, err := parser.UnwrapExpressions(conditionExprStrings)
+	conditionExprs, err := parser.UnwrapExpressions(conditionExprStrings)
 	if err != nil {
 		return nil, fmt.Errorf("invalid conditions block: %w", err)
 	}
 
-	// Enforce the self-reference and literal-value rules. The structural
-	// rules for runtime.newCondition are handled by its parse-time macro.
-	stripped := make([]string, len(conditions))
-	for i, c := range conditions {
+	// Enforce the cross-reference, duplicate, and literal-value rules, and
+	// compute the evaluation order. The structural rules for
+	// runtime.newCondition are handled by its parse-time macro.
+	stripped := make([]string, len(conditionExprs))
+	for i, c := range conditionExprs {
 		stripped[i] = c.Original
 	}
-	if err := validateConditionExpressions(inspectorEnv, stripped); err != nil {
+	condEvalPlan, err := validateAndOrderConditions(inspectorEnv, stripped)
+	if err != nil {
 		return nil, err
 	}
 
 	// Record each expression's references (resources, schema, runtime) so the
 	// runtime keeps them in the eval activation.
-	allowedRefs := append(slices.Clone(nodeNames), SchemaVarName, library.RuntimeVarName)
-	for _, expr := range conditions {
+	allowedRefs := slices.Concat(nodeNames, []string{SchemaVarName, library.RuntimeVarName})
+	for _, expr := range conditionExprs {
 		result, err := inspectExpressionRestricted(inspector, expr.Original, allowedRefs)
 		if err != nil {
 			return nil, fmt.Errorf("condition %q: %w", expr.UserExpression(), err)
@@ -987,7 +989,7 @@ func buildConditions(
 		}
 	}
 
-	for _, expr := range conditions {
+	for _, expr := range conditionExprs {
 		checkedAST, err := bc.parseAndCheck(bc.env, expr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to type-check condition %q: %w", expr.UserExpression(), err)
@@ -1000,7 +1002,15 @@ func buildConditions(
 		}
 	}
 
-	return conditions, nil
+	conditionEntries := make([]ConditionEntry, len(conditionExprs))
+	for i, expr := range conditionExprs {
+		conditionEntries[i] = ConditionEntry{
+			Expr:      expr,
+			EvalRank:  condEvalPlan.Ranks[i],
+			DependsOn: condEvalPlan.DependsOn[i],
+		}
+	}
+	return conditionEntries, nil
 }
 
 // validateConditionOutputType verifies that a condition expression returns a

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -4613,13 +4613,18 @@ func TestBuildConditionsHappyPath(t *testing.T) {
 	require.Len(t, got, 2)
 
 	for _, e := range got {
-		assert.NotNil(t, e.Program, "expression %q should have a compiled Program", e.Original)
+		assert.NotNil(t, e.Expr.Program, "expression %q should have a compiled Program", e.Expr.Original)
 	}
 
-	assert.Contains(t, got[0].References, "runtime")
-	assert.NotContains(t, got[0].References, "resource")
-	assert.Contains(t, got[1].References, "runtime")
-	assert.Contains(t, got[1].References, "resource")
+	assert.Contains(t, got[0].Expr.References, "runtime")
+	assert.NotContains(t, got[0].Expr.References, "resource")
+	assert.Contains(t, got[1].Expr.References, "runtime")
+	assert.Contains(t, got[1].Expr.References, "resource")
+
+	assert.Equal(t, 0, got[0].EvalRank)
+	assert.Equal(t, 1, got[1].EvalRank)
+	assert.Empty(t, got[0].DependsOn)
+	assert.Empty(t, got[1].DependsOn)
 }
 
 func TestBuildConditionsRejectsInvalid(t *testing.T) {
@@ -4656,17 +4661,51 @@ func TestBuildConditionsRejectsInvalid(t *testing.T) {
 	}
 }
 
-func TestBuildConditionsSelfReference(t *testing.T) {
+func TestBuildConditionsCrossReferenceOrdered(t *testing.T) {
 	bc, inspectorEnv, inspector := newConditionsBuildContext(t)
 
 	exprs := []string{
-		`${runtime.newCondition({type: 'PrimaryReady', status: 'True', reason: '', message: ''})}`,
 		`${runtime.newCondition({type: 'Ready', status: runtime.condition(schema, 'PrimaryReady').status, reason: '', message: ''})}`,
+		`${runtime.newCondition({type: 'PrimaryReady', status: 'True', reason: '', message: ''})}`,
+	}
+
+	got, err := buildConditions(bc, exprs, inspector, inspectorEnv, []string{"resource"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, 1, got[0].EvalRank, "Ready evaluates second")
+	assert.Equal(t, 0, got[1].EvalRank, "PrimaryReady evaluates first")
+	require.Len(t, got[0].DependsOn, 1)
+	assert.Equal(t, "PrimaryReady", got[0].DependsOn[0].Type)
+	assert.Equal(t, []int{1}, got[0].DependsOn[0].DeclaredBy, "PrimaryReady comes from entry 1")
+	assert.Empty(t, got[1].DependsOn)
+}
+
+func TestBuildConditionsSelfReadRejected(t *testing.T) {
+	bc, inspectorEnv, inspector := newConditionsBuildContext(t)
+
+	exprs := []string{
+		`${runtime.newCondition({type: 'Loop', status: runtime.condition(schema, 'Loop').status, reason: '', message: ''})}`,
 	}
 
 	_, err := buildConditions(bc, exprs, inspector, inspectorEnv, []string{"resource"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "custom conditions cannot reference each other")
+	assert.Contains(t, err.Error(), "cannot depend on a condition type it may itself declare")
+}
+
+func TestBuildConditionsCycleRejected(t *testing.T) {
+	bc, inspectorEnv, inspector := newConditionsBuildContext(t)
+
+	exprs := []string{
+		`${runtime.newCondition({type: 'A', status: runtime.condition(schema, 'B').status, reason: '', message: ''})}`,
+		`${runtime.newCondition({type: 'B', status: runtime.condition(schema, 'A').status, reason: '', message: ''})}`,
+	}
+
+	_, err := buildConditions(bc, exprs, inspector, inspectorEnv, []string{"resource"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reference cycle")
+	assert.Contains(t, err.Error(), "entry 0 (A)")
+	assert.Contains(t, err.Error(), "entry 1 (B)")
 }
 
 func TestBuildInstanceNodeFoldsConditionDeps(t *testing.T) {

--- a/pkg/graph/conditions.go
+++ b/pkg/graph/conditions.go
@@ -16,31 +16,268 @@ package graph
 
 import (
 	"fmt"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/cel/library"
+	"github.com/kubernetes-sigs/kro/pkg/graph/dag"
 )
 
-// validateConditionExpressions applies build-time rules to the author's
-// condition expressions:
+// conditionTypePattern is copied from the +kubebuilder:validation:Pattern
+// annotation on metav1.Condition.Type (k8s.io/apimachinery meta/v1/types.go).
+const conditionTypePattern = `^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+
+var conditionTypeRegex = regexp.MustCompile(conditionTypePattern)
+
+// opaqueRegex matches a subexpression whose value is not statically known.
+const opaqueRegex = `.*`
+
+// maxConditionTypeValues caps how many values one `type:` expression may produce.
+// Concatenation multiplies the operand counts, so chained ternaries would
+// otherwise grow exponentially.
+const maxConditionTypeValues = 32
+
+var opaqueShape = []string{opaqueRegex}
+
+// conditionPattern is the set of condition types one conditions entry could emit.
+// A pattern rather than a name because the RGD compiles before any instance
+// exists, so a computed `type:` is only known by its shape.
+type conditionPattern struct {
+	EntryIndex int
+	matcher    *regexp.Regexp
+}
+
+func (p conditionPattern) matches(typ string) bool {
+	return p.matcher != nil && p.matcher.MatchString(typ)
+}
+
+// typeRegexes splits the matcher back into one regex per condition type.
+func (p conditionPattern) typeRegexes() []string {
+	if p.matcher == nil {
+		return nil
+	}
+	src := strings.TrimSuffix(strings.TrimPrefix(p.matcher.String(), "^(?:"), ")$")
+
+	var out []string
+	start := 0
+	for i := 0; i < len(src); i++ {
+		switch src[i] {
+		case '\\':
+			i++
+		case '|':
+			out = append(out, src[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, src[start:])
+}
+
+// literalTypes returns the pattern's condition types, or ok=false if any has a
+// computed segment. All-or-nothing over the whole set: in `cond ? "a" : (x + y)`
+// the literal "a" is only reached when cond holds, so a sibling entry may own it.
+func (p conditionPattern) literalTypes() (types []string, ok bool) {
+	regexes := p.typeRegexes()
+	types = make([]string, 0, len(regexes))
+	for _, re := range regexes {
+		if !isStaticType(re) {
+			return nil, false
+		}
+		types = append(types, unquoteMeta(re))
+	}
+	return types, true
+}
+
+// String renders the pattern as an author-readable glob, with "*" for each
+// computed segment ("a-*", "*-b").
+func (p conditionPattern) String() string {
+	regexes := p.typeRegexes()
+	globs := make([]string, len(regexes))
+	for i, re := range regexes {
+		if isStaticType(re) {
+			globs[i] = unquoteMeta(re)
+			continue
+		}
+		globs[i] = unquoteMeta(strings.ReplaceAll(re, opaqueRegex, "*"))
+	}
+	return strings.Join(globs, "|")
+}
+
+// isStaticType reports whether a type regex is a plain literal.
+func isStaticType(re string) bool { return !strings.Contains(re, opaqueRegex) }
+
+// unquoteMeta drops the escaping backslashes from a regex, recovering the plain
+// string it matches.
+func unquoteMeta(re string) string {
+	if !strings.ContainsRune(re, '\\') {
+		return re
+	}
+	var b strings.Builder
+	b.Grow(len(re))
+	for i := 0; i < len(re); i++ {
+		if re[i] == '\\' && i+1 < len(re) {
+			i++
+		}
+		b.WriteByte(re[i])
+	}
+	return b.String()
+}
+
+// typeShape returns the regexes the `type:` expression could evaluate to, or nil
+// when the alternation cap is exceeded.
+func typeShape(e celast.Expr) []string {
+	switch e.Kind() {
+	case celast.LiteralKind:
+		if s, ok := e.AsLiteral().Value().(string); ok {
+			// QuoteMeta so "a.b" does not match a lookup of "aXb".
+			return []string{regexp.QuoteMeta(s)}
+		}
+		return opaqueShape // non-string literal; the type checker rejects it
+
+	case celast.CallKind:
+		call := e.AsCall()
+		if call.IsMemberFunction() {
+			return opaqueShape // .join(), .format(), .replace()
+		}
+		switch call.FunctionName() {
+		case operators.Add: // a + b -> cross product
+			a, b := typeShape(call.Args()[0]), typeShape(call.Args()[1])
+			if a == nil || b == nil || len(a)*len(b) > maxConditionTypeValues {
+				return nil
+			}
+			out := make([]string, 0, len(a)*len(b))
+			for _, x := range a {
+				for _, y := range b {
+					out = append(out, x+y)
+				}
+			}
+			return out
+
+		case operators.Conditional: // c ? t : f -> union of the branches
+			t, f := typeShape(call.Args()[1]), typeShape(call.Args()[2])
+			if t == nil || f == nil || len(t)+len(f) > maxConditionTypeValues {
+				return nil
+			}
+			return append(t, f...)
+
+		default:
+			return opaqueShape // unknown global call, including indexing
+		}
+
+	default:
+		return opaqueShape // field access (s.metadata.name), ident, list...
+	}
+}
+
+// patternFromTypeExpr builds the declaration pattern for one newCondition's
+// `type:` value.
+func patternFromTypeExpr(entry int, typeExpr celast.Expr, exprText string) (conditionPattern, error) {
+	frags := typeShape(typeExpr)
+	if frags == nil {
+		return conditionPattern{}, fmt.Errorf(
+			"conditions[%d]: condition type expression has more than %d possible values; "+
+				"split it across separate conditions entries, in expression %q",
+			entry, maxConditionTypeValues, exprText)
+	}
+
+	slices.Sort(frags)
+	frags = slices.Compact(frags)
+
+	return conditionPattern{
+		EntryIndex: entry,
+		matcher:    regexp.MustCompile("^(?:" + strings.Join(frags, "|") + ")$"),
+	}, nil
+}
+
+// conditionDeclarations returns one pattern per runtime.newCondition call under
+// root: the types this entry could emit.
+func conditionDeclarations(entry int, root celast.Expr, exprText string) ([]conditionPattern, error) {
+	var out []conditionPattern
+	var firstErr error
+	celast.PreOrderVisit(root, celast.NewExprVisitor(func(e celast.Expr) {
+		if firstErr != nil || !isRuntimeCall(e, "newCondition") {
+			return
+		}
+		args := e.AsCall().Args()
+		if len(args) != 1 {
+			return // Wrong arity is a CEL type-checker concern.
+		}
+		typeExpr, ok := mapLiteralEntryValue(args[0], "type")
+		if !ok {
+			return // The parse-time macro requires a map literal with `type`.
+		}
+		p, err := patternFromTypeExpr(entry, typeExpr, exprText)
+		if err != nil {
+			firstErr = err
+			return
+		}
+		out = append(out, p)
+	}))
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+// conditionDependencyTypes returns the literal type names entry root looks up via
+// runtime.condition(schema, 'X'), sorted for stable diagnostics.
 //
-//   - runtime.condition(schema, 'X') with a literal X must name a kro
-//     built-in type: an author-declared type is a self-reference, anything
-//     else is unknown. Child-resource and non-literal lookups are
-//     unrestricted.
+// Lookups on child resources are excluded: those come from observed state and are
+// already sequenced by the resource DAG. Non-literal names are excluded because
+// they are not known until evaluation, by which point the order is fixed.
+func conditionDependencyTypes(root celast.Expr) []string {
+	seen := map[string]struct{}{}
+	celast.PreOrderVisit(root, celast.NewExprVisitor(func(e celast.Expr) {
+		if !isRuntimeCall(e, "condition") {
+			return
+		}
+		args := e.AsCall().Args()
+		if len(args) != 2 {
+			return
+		}
+		if obj := args[0]; obj.Kind() != celast.IdentKind || obj.AsIdent() != SchemaVarName {
+			return
+		}
+		if typ, ok := literalString(args[1]); ok {
+			seen[typ] = struct{}{}
+		}
+	}))
+	return slices.Sorted(maps.Keys(seen))
+}
+
+// conditionEvalPlan is the build-time evaluation plan for one conditions block.
+// Both slices are indexed by DECLARATION position. A rule violation is returned
+// as an error instead, so holding a plan means the block is valid.
+type conditionEvalPlan struct {
+	// Ranks[i] is entry i's rank; entries are evaluated in ascending rank.
+	Ranks []int
+
+	// DependsOn[i] is what entry i must have available before it is evaluated.
+	DependsOn [][]ConditionDependency
+}
+
+// validateAndOrderConditions applies build-time rules to the author's condition
+// expressions and ranks each so an entry is evaluated after every entry that
+// could declare a type it reads:
+//
+//   - runtime.condition(schema, 'X') with a literal X must name a kro built-in
+//     type or a type another entry could declare; a self-reference or a
+//     reference cycle is rejected, anything else is unknown. Child-resource and
+//     non-literal lookups are unrestricted.
 //   - Literal newCondition values: status must be True/False/Unknown and
 //     type must not be empty. Computed values are checked at evaluation.
 //   - No two entries may declare the same literal type; a type may repeat
-//     within one entry (ternary branches). This check is not branch-aware:
-//     two entries that could only emit the shared type in mutually
-//     exclusive branches are still rejected.
+//     within one entry (ternary branches).
 //
 // newCondition's key rules are enforced by its parse-time macro. Unparsable
 // expressions are skipped; the regular compile step reports those errors.
-func validateConditionExpressions(env *cel.Env, expressions []string) error {
+func validateAndOrderConditions(env *cel.Env, expressions []string) (*conditionEvalPlan, error) {
 	asts := make([]celast.Expr, len(expressions))
 	for i, expr := range expressions {
 		parsed, iss := env.Parse(expr)
@@ -50,50 +287,176 @@ func validateConditionExpressions(env *cel.Env, expressions []string) error {
 		asts[i] = parsed.NativeRep().Expr()
 	}
 
-	// Collect the literal types each entry declares via newCondition so the
-	// second pass can detect self-references, rejecting types declared by
-	// more than one entry along the way.
-	declared := map[string]struct{}{}
-	for _, root := range asts {
+	var patterns []conditionPattern
+	declares := make([][]conditionPattern, len(asts))
+	dependencyTypes := make([][]string, len(asts))
+	for i, root := range asts {
 		if root == nil {
 			continue
 		}
-		for typ := range literalConditionTypes(root) {
-			if _, dup := declared[typ]; dup {
-				return fmt.Errorf("condition type %q is declared by more than one conditions entry", typ)
-			}
-			declared[typ] = struct{}{}
+		ps, err := conditionDeclarations(i, root, expressions[i])
+		if err != nil {
+			return nil, err
 		}
+		declares[i] = ps
+		patterns = append(patterns, ps...)
+		dependencyTypes[i] = conditionDependencyTypes(root)
+	}
+
+	// Reject invalid type names and types declared by more than one entry.
+	exactBy := map[string]int{}
+	for _, p := range patterns {
+		// A computed pattern claims no single name; the runtime's collision check
+		// covers it.
+		names, ok := p.literalTypes()
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			// Empty is left to validateConditionAST, which reports it plainly.
+			if name == "" {
+				continue
+			}
+			if !conditionTypeRegex.MatchString(name) {
+				return nil, fmt.Errorf(
+					"conditions[%d]: %q is not a valid condition type", p.EntryIndex, name)
+			}
+			// A repeat within one entry is legitimate: the mutually exclusive
+			// branches of a ternary may declare the same name.
+			if prev, dup := exactBy[name]; dup && prev != p.EntryIndex {
+				return nil, fmt.Errorf(
+					"condition type %q is declared by more than one conditions entry (%d and %d)",
+					name, prev, p.EntryIndex)
+			}
+			exactBy[name] = p.EntryIndex
+		}
+	}
+
+	for i, types := range dependencyTypes {
+		for _, typ := range types {
+			if _, builtin := v1alpha1.KROBuiltinConditionTypes[typ]; builtin {
+				continue
+			}
+			for _, p := range declares[i] {
+				if p.matches(typ) {
+					return nil, fmt.Errorf(
+						"runtime.condition(schema, %q): a conditions entry cannot depend on a "+
+							"condition type it may itself declare (matches %s) in expression %q",
+						typ, p, expressions[i])
+				}
+			}
+		}
+	}
+
+	dependsOn := make([][]ConditionDependency, len(asts))
+	for i, types := range dependencyTypes {
+		dependsOn[i] = resolveDependencies(i, types, patterns)
+	}
+	ranks, err := conditionEvalRanks(dependsOn)
+	if err != nil {
+		if ce := dag.AsCycleError[int](err); ce != nil {
+			return nil, fmt.Errorf("conditions entries form a reference cycle: %s",
+				describeCycle(ce.Cycle, declares))
+		}
+		return nil, err
 	}
 
 	for i, root := range asts {
 		if root == nil {
 			continue
 		}
-		if err := validateConditionAST(root, declared, expressions[i]); err != nil {
-			return err
+		if err := validateConditionAST(root, patterns, expressions[i]); err != nil {
+			return nil, err
 		}
 	}
-	return nil
+
+	return &conditionEvalPlan{Ranks: ranks, DependsOn: dependsOn}, nil
 }
 
-// literalConditionTypes returns the literal type values of every
-// runtime.newCondition call under root.
-func literalConditionTypes(root celast.Expr) map[string]struct{} {
-	out := map[string]struct{}{}
-	celast.PreOrderVisit(root, celast.NewExprVisitor(func(e celast.Expr) {
-		if isRuntimeCall(e, "newCondition") && len(e.AsCall().Args()) == 1 {
-			if typ, ok := mapLiteralEntryStringValue(e.AsCall().Args()[0], "type"); ok {
-				out[typ] = struct{}{}
+// resolveDependencies pairs each of entryIndex's dependencyTypes with the entries
+// that could declare it. allPatterns is every entry's declarations, so a
+// dependency can resolve to an entry declared later in the block.
+//
+// A built-in resolves to an empty DeclaredBy: it is bound before the eval loop, so
+// there is nothing to order against.
+func resolveDependencies(
+	entryIndex int,
+	dependencyTypes []string,
+	allPatterns []conditionPattern,
+) []ConditionDependency {
+	if len(dependencyTypes) == 0 {
+		return nil
+	}
+	out := make([]ConditionDependency, 0, len(dependencyTypes))
+	for _, typ := range dependencyTypes {
+		d := ConditionDependency{Type: typ}
+		if _, builtin := v1alpha1.KROBuiltinConditionTypes[typ]; !builtin {
+			for _, p := range allPatterns {
+				if p.matches(typ) && p.EntryIndex != entryIndex {
+					d.DeclaredBy = append(d.DeclaredBy, p.EntryIndex)
+				}
 			}
+			slices.Sort(d.DeclaredBy)
+			d.DeclaredBy = slices.Compact(d.DeclaredBy)
 		}
-	}))
+		out = append(out, d)
+	}
 	return out
+}
+
+// conditionEvalRanks ranks each entry after every entry it depends on. Entries
+// with no reference relationship keep their declaration order.
+func conditionEvalRanks(dependsOn [][]ConditionDependency) ([]int, error) {
+	n := len(dependsOn)
+	g := dag.NewDirectedAcyclicGraph[int]()
+	for i := range n {
+		if err := g.AddVertex(i, i); err != nil {
+			return nil, err
+		}
+	}
+
+	for j, jDeps := range dependsOn {
+		var deps []int
+		for _, d := range jDeps {
+			deps = append(deps, d.DeclaredBy...)
+		}
+		slices.Sort(deps)
+		deps = slices.Compact(deps)
+		if err := g.AddDependencies(j, deps); err != nil {
+			return nil, err
+		}
+	}
+
+	order, err := g.TopologicalSort() // order[position] = entry index
+	if err != nil {
+		return nil, err
+	}
+
+	ranks := make([]int, n)
+	for pos, entry := range order {
+		ranks[entry] = pos
+	}
+	return ranks, nil
+}
+
+// describeCycle renders a cycle as a path of declaration patterns, sorted for
+// stable output.
+func describeCycle(cycle []int, declares [][]conditionPattern) string {
+	parts := make([]string, len(cycle))
+	for k, idx := range cycle {
+		names := make([]string, 0, len(declares[idx]))
+		for _, p := range declares[idx] {
+			names = append(names, p.String())
+		}
+		slices.Sort(names)
+		parts[k] = fmt.Sprintf("entry %d (%s)", idx, strings.Join(names, "/"))
+	}
+	return strings.Join(parts, " -> ")
 }
 
 // validateConditionAST applies the lookup and literal-value rules to every
 // runtime call under expr, returning the first error found.
-func validateConditionAST(expr celast.Expr, authorTypes map[string]struct{}, exprText string) error {
+func validateConditionAST(expr celast.Expr, patterns []conditionPattern, exprText string) error {
 	var firstErr error
 	celast.PreOrderVisit(expr, celast.NewExprVisitor(func(e celast.Expr) {
 		if firstErr != nil {
@@ -101,7 +464,7 @@ func validateConditionAST(expr celast.Expr, authorTypes map[string]struct{}, exp
 		}
 		switch {
 		case isRuntimeCall(e, "condition"):
-			firstErr = validateConditionLookup(e, authorTypes, exprText)
+			firstErr = validateConditionLookup(e, patterns, exprText)
 		case isRuntimeCall(e, "newCondition"):
 			firstErr = validateNewConditionLiterals(e, exprText)
 		}
@@ -116,26 +479,28 @@ func validateNewConditionLiterals(call celast.Expr, exprText string) error {
 	if len(args) != 1 {
 		return nil // Wrong arity is a CEL type-checker concern.
 	}
-	if status, ok := mapLiteralEntryStringValue(args[0], "status"); ok {
-		if !library.IsValidConditionStatus(status) {
+	if v, ok := mapLiteralEntryValue(args[0], "status"); ok {
+		if status, ok := literalString(v); ok && !library.IsValidConditionStatus(status) {
 			return fmt.Errorf(
 				"runtime.newCondition: status must be one of True, False, Unknown (got %q) in expression %q",
 				status, exprText,
 			)
 		}
 	}
-	if typeVal, ok := mapLiteralEntryStringValue(args[0], "type"); ok && typeVal == "" {
-		return fmt.Errorf("runtime.newCondition: type must not be empty in expression %q", exprText)
+	if v, ok := mapLiteralEntryValue(args[0], "type"); ok {
+		if typeVal, ok := literalString(v); ok && typeVal == "" {
+			return fmt.Errorf("runtime.newCondition: type must not be empty in expression %q", exprText)
+		}
 	}
 	return nil
 }
 
 // validateConditionLookup enforces the lookup rules for
-// runtime.condition(schema, 'X') calls: X must be a kro built-in type, not
-// an author-declared type (self-reference) or an unknown name (typo).
+// runtime.condition(schema, 'X') calls: X must be a kro built-in type or a type
+// some conditions entry could declare, anything else is an unknown name (typo).
 // Lookups on other objects (child resources) and non-literal lookups are
 // unrestricted.
-func validateConditionLookup(call celast.Expr, authorTypes map[string]struct{}, exprText string) error {
+func validateConditionLookup(call celast.Expr, patterns []conditionPattern, exprText string) error {
 	args := call.AsCall().Args()
 	if len(args) != 2 {
 		return nil // Wrong arity is a CEL type-checker concern.
@@ -151,15 +516,16 @@ func validateConditionLookup(call celast.Expr, authorTypes map[string]struct{}, 
 	if _, isBuiltin := v1alpha1.KROBuiltinConditionTypes[typeName]; isBuiltin {
 		return nil
 	}
-	if _, isAuthor := authorTypes[typeName]; isAuthor {
-		return fmt.Errorf(
-			"runtime.condition(schema, %q): custom conditions cannot reference each other in expression %q",
-			typeName, exprText,
-		)
+
+	for _, p := range patterns {
+		if p.matches(typeName) {
+			return nil
+		}
 	}
 	return fmt.Errorf(
-		"runtime.condition(schema, %q): unknown condition type; only kro's built-in types "+
-			"(InstanceManaged, GraphResolved, ResourcesReady, Ready) can be read from schema in expression %q",
+		"runtime.condition(schema, %q): unknown condition type; expected a kro built-in type "+
+			"(InstanceManaged, GraphResolved, ResourcesReady, Ready) or a type declared by "+
+			"another conditions entry, in expression %q",
 		typeName, exprText,
 	)
 }
@@ -187,17 +553,17 @@ func literalString(expr celast.Expr) (string, bool) {
 	return s, ok
 }
 
-// mapLiteralEntryStringValue looks up key in a map literal's entries and
-// returns the entry's value if it's a literal string.
-func mapLiteralEntryStringValue(expr celast.Expr, key string) (string, bool) {
+// mapLiteralEntryValue looks up key in a map literal's entries and
+// returns the entry's value expression.
+func mapLiteralEntryValue(expr celast.Expr, key string) (celast.Expr, bool) {
 	if expr.Kind() != celast.MapKind {
-		return "", false
+		return nil, false
 	}
 	for _, entry := range expr.AsMap().Entries() {
 		me := entry.AsMapEntry()
 		if k, ok := literalString(me.Key()); ok && k == key {
-			return literalString(me.Value())
+			return me.Value(), true
 		}
 	}
-	return "", false
+	return nil, false
 }

--- a/pkg/graph/conditions_test.go
+++ b/pkg/graph/conditions_test.go
@@ -92,14 +92,62 @@ func TestValidateConditionExpressions(t *testing.T) {
 			},
 		},
 		{
-			name: "self-reference rejected",
+			name: "cross-reference between entries is allowed",
 			exprs: []string{
 				`runtime.newCondition({type: 'PrimaryReady', status: 'True', reason: '', message: ''})`,
 				`runtime.newCondition({type: 'Ready',
 					status: runtime.condition(schema, 'PrimaryReady').status,
 					reason: '', message: ''})`,
 			},
-			wantErrs: []string{"custom conditions cannot reference each other", `"PrimaryReady"`},
+		},
+		{
+			name: "an entry reading a type it declares itself is rejected",
+			exprs: []string{
+				`runtime.newCondition({type: 'Loop',
+					status: runtime.condition(schema, 'Loop').status,
+					reason: '', message: ''})`,
+			},
+			wantErrs: []string{"cannot depend on a condition type it may itself declare", `"Loop"`},
+		},
+		{
+			name: "reference cycle between two entries is rejected",
+			exprs: []string{
+				`runtime.newCondition({type: 'A',
+					status: runtime.condition(schema, 'B').status, reason: '', message: ''})`,
+				`runtime.newCondition({type: 'B',
+					status: runtime.condition(schema, 'A').status, reason: '', message: ''})`,
+			},
+			wantErrs: []string{"reference cycle", "entry 0 (A)", "entry 1 (B)"},
+		},
+		{
+			name: "a read matched by a dynamic type pattern is allowed",
+			exprs: []string{
+				`schema.spec.servers.map(s,
+					runtime.newCondition({type: 'Shard-' + s.name, status: 'True', reason: '', message: ''}))`,
+				`runtime.newCondition({type: 'Summary',
+					status: runtime.condition(schema, 'Shard-web').status, reason: '', message: ''})`,
+			},
+		},
+		{
+			name: "type expression with too many alternatives is rejected",
+			exprs: []string{
+				`runtime.newCondition({type:
+					(schema.spec.a ? 'a0' : 'b0') + (schema.spec.b ? 'a1' : 'b1') +
+					(schema.spec.c ? 'a2' : 'b2') + (schema.spec.d ? 'a3' : 'b3') +
+					(schema.spec.e ? 'a4' : 'b4') + (schema.spec.f ? 'a5' : 'b5'),
+					status: 'True', reason: '', message: ''})`,
+			},
+			wantErrs: []string{"more than 32 possible values", "split it across separate conditions entries"},
+		},
+		{
+			name: "duplicate type across ternary branches of different entries is rejected",
+			exprs: []string{
+				`schema.spec.p
+					? runtime.newCondition({type: 'Primary', status: 'True', reason: '', message: ''})
+					: runtime.newCondition({type: 'Replica', status: 'True', reason: '', message: ''})`,
+				`runtime.newCondition({type: 'Primary', status: 'False', reason: '', message: ''})`,
+			},
+			wantErrs: []string{`condition type "Primary" is declared by more than one conditions entry`},
 		},
 		{
 			name: "invalid literal status rejected",
@@ -139,11 +187,41 @@ func TestValidateConditionExpressions(t *testing.T) {
 			},
 			wantErrs: []string{"unknown condition type", `"ResourcesRaedy"`},
 		},
+		{
+			name: "literal type held to the Kubernetes condition-type format",
+			exprs: []string{
+				`runtime.newCondition({type: 'Ready Set', status: 'True', reason: '', message: ''})`,
+			},
+			wantErrs: []string{"is not a valid condition type", `"Ready Set"`},
+		},
+		{
+			name: "invalid type in a ternary branch is rejected",
+			exprs: []string{
+				`runtime.newCondition({type: schema.spec.ha ? 'Primary' : 'Bad|Name',
+					status: 'True', reason: '', message: ''})`,
+			},
+			wantErrs: []string{"is not a valid condition type", `"Bad|Name"`},
+		},
+		{
+			name: "dotted and path-prefixed type names are accepted",
+			exprs: []string{
+				`runtime.newCondition({type: 'Ready.v2', status: 'True', reason: '', message: ''})`,
+				`runtime.newCondition({type: 'app.kubernetes.io/Ready', status: 'True', reason: '', message: ''})`,
+				`runtime.newCondition({type: 'acme.io/db-ready', status: 'True', reason: '', message: ''})`,
+			},
+		},
+		{
+			name: "computed type names are not format-checked",
+			exprs: []string{
+				`resource.items.map(i, runtime.newCondition({type: 'Shard-' + i.name,
+					status: 'True', reason: '', message: ''}))`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateConditionExpressions(env, tt.exprs)
+			_, err := validateAndOrderConditions(env, tt.exprs)
 			if len(tt.wantErrs) == 0 {
 				assert.NoError(t, err)
 				return
@@ -151,6 +229,70 @@ func TestValidateConditionExpressions(t *testing.T) {
 			require.Error(t, err)
 			for _, want := range tt.wantErrs {
 				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}
+
+func TestDescribeCycleEntriesAlwaysHavePatterns(t *testing.T) {
+	env, err := krocel.DefaultEnvironment(krocel.WithResourceIDs(
+		[]string{"shards", SchemaVarName, library.RuntimeVarName},
+	))
+	require.NoError(t, err)
+
+	link := func(typ, dep string) string {
+		return `runtime.newCondition({type: ` + typ +
+			`, status: runtime.condition(schema, '` + dep + `').status, reason: '', message: ''})`
+	}
+
+	tests := []struct {
+		name  string
+		exprs []string
+	}{
+		{
+			name:  "two entries, exact types",
+			exprs: []string{link(`'A'`, "B"), link(`'B'`, "A")},
+		},
+		{
+			name:  "three entries",
+			exprs: []string{link(`'A'`, "C"), link(`'B'`, "A"), link(`'C'`, "B")},
+		},
+		{
+			name:  "four entries",
+			exprs: []string{link(`'A'`, "D"), link(`'B'`, "A"), link(`'C'`, "B"), link(`'D'`, "C")},
+		},
+		{
+			name: "fan-out entry in the cycle",
+			exprs: []string{
+				`shards.map(s, ` + link(`'Shard-' + s.metadata.name`, "Rollup") + `)`,
+				link(`'Rollup'`, "Shard-web"),
+			},
+		},
+		{
+			name: "ternary entry in the cycle",
+			exprs: []string{
+				`schema.spec.ha ? ` + link(`'Primary'`, "Rollup") + ` : ` + link(`'Standalone'`, "Rollup"),
+				link(`'Rollup'`, "Primary"),
+			},
+		},
+		{
+			name: "entries outside the cycle do not appear in it",
+			exprs: []string{
+				link(`'A'`, "B"),
+				link(`'B'`, "A"),
+				`runtime.newCondition({type: 'Bystander', status: 'True', reason: '', message: ''})`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for range 50 {
+				_, err := validateAndOrderConditions(env, tt.exprs)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "reference cycle")
+				assert.NotContains(t, err.Error(), "()",
+					"a cycle segment rendered with no pattern name: %s", err)
 			}
 		})
 	}

--- a/pkg/graph/node.go
+++ b/pkg/graph/node.go
@@ -113,6 +113,31 @@ type ForEachDimension struct {
 	Expression *krocel.Expression
 }
 
+// ConditionDependency is one condition type an entry looks up via
+// runtime.condition(schema, 'X'), with the entries that could declare it
+type ConditionDependency struct {
+	Type string
+
+	// DeclaredBy is empty for a kro built-in and for an unknown type, so it never
+	// blocks evaluation. The build cannot tell which computed type will produce a
+	// given name, so every entry that could is listed.
+	DeclaredBy []int
+}
+
+// ConditionEntry is one entry of the author-defined `conditions:` block.
+type ConditionEntry struct {
+	Expr *krocel.Expression
+
+	// EvalRank orders evaluation, ascending and stable within equal ranks. Slice
+	// order stays declaration order, which is what reaches status.conditions[].
+	// Evaluation order does not leak onto the wire. All-zero ranks sort to
+	// declaration order, so the zero value is safe.
+	EvalRank int
+
+	// DependsOn is what this entry must have available before it is evaluated.
+	DependsOn []ConditionDependency
+}
+
 // Node is the immutable node spec produced by the builder.
 // It contains the template, variables, and conditions for a resource.
 // No CRD/schema references are kept here - schemas are only used
@@ -140,9 +165,9 @@ type Node struct {
 	// nil or empty means this is not a collection.
 	ForEach []ForEachDimension
 
-	// Conditions holds the compiled expressions of the author-defined
-	// `conditions:` block (NodeTypeInstance only; nil for resource nodes).
-	Conditions []*krocel.Expression
+	// Conditions holds the entries of the author-defined `conditions:` block
+	// (NodeTypeInstance only; nil for resource nodes).
+	Conditions []ConditionEntry
 }
 
 // DeepCopy creates a deep copy of the Node.
@@ -164,7 +189,21 @@ func (n *Node) DeepCopy() *Node {
 		IncludeWhen: slices.Clone(n.IncludeWhen),
 		ReadyWhen:   slices.Clone(n.ReadyWhen),
 		ForEach:     slices.Clone(n.ForEach),
-		Conditions:  slices.Clone(n.Conditions),
+	}
+
+	if n.Conditions != nil {
+		cp.Conditions = make([]ConditionEntry, len(n.Conditions))
+		for i, e := range n.Conditions {
+			deps := make([]ConditionDependency, len(e.DependsOn))
+			for j, d := range e.DependsOn {
+				deps[j] = ConditionDependency{Type: d.Type, DeclaredBy: slices.Clone(d.DeclaredBy)}
+			}
+			cp.Conditions[i] = ConditionEntry{
+				Expr:      e.Expr,
+				EvalRank:  e.EvalRank,
+				DependsOn: deps,
+			}
+		}
 	}
 
 	if n.Template != nil {

--- a/pkg/runtime/conditions.go
+++ b/pkg/runtime/conditions.go
@@ -17,7 +17,8 @@ package runtime
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -64,66 +65,148 @@ func (n *Node) EvaluateConditions(logger logr.Logger, kroBuiltins []v1alpha1.Con
 	ctx := n.buildContext()
 	// The instance is not its own graph dependency, so buildContext provides
 	// neither schema nor runtime; bind them here.
-	ctx[graph.SchemaVarName] = n.schemaForConditions(kroBuiltins)
 	ctx[library.RuntimeVarName] = library.RuntimeSingleton
 
-	var out []library.Condition
+	// visible is what runtime.condition(schema, _) can see, growing as each entry
+	// publishes, so a later entry reads this reconcile's value. filterContext
+	// reads ctx[ref] at call time, so rebinding needs no recompilation.
+	visible := kroBuiltinsAsList(kroBuiltins)
+	ctx[graph.SchemaVarName] = n.schemaForConditions(visible)
+
+	results := make([][]library.Condition, len(n.conditionExprs))
+	noOutputEntries := make([]bool, len(n.conditionExprs))
+	duplicatedTypes := map[string]struct{}{}
+	publishedBy := map[string]int{}
 	var failures []string
-	for _, expr := range n.conditionExprs {
+
+	// Ordering is what makes the dependency check sound: by the time an entry runs,
+	// every entry that could declare what it depends on has been decided.
+	for _, i := range n.conditionEvalOrder {
+		entry := n.Spec.Conditions[i]
+		exprText := entry.Expr.UserExpression()
+
+		if reason, missing := missingDependency(entry.DependsOn, noOutputEntries, duplicatedTypes); missing {
+			logger.V(1).Info("skipping author condition: a condition it depends on is unavailable",
+				"expression", exprText, "reason", reason)
+			noOutputEntries[i] = true
+			incomplete = true
+			continue
+		}
+
+		expr := n.conditionExprs[i]
 		// Evaluate the Program directly: krocel.Expression.Eval converts to
 		// Go-native values, which cannot represent the typed Condition.
 		filteredCtx := filterContext(ctx, expr.Expression.References)
 		raw, _, evalErr := expr.Expression.Program.Eval(filteredCtx)
 		if evalErr != nil {
+			noOutputEntries[i] = true
 			if isCELDataPending(evalErr) {
 				incomplete = true
 				continue
 			}
 			logger.Error(evalErr, "skipping author condition expression with fatal evaluation error",
-				"expression", expr.Expression.UserExpression())
-			failures = append(failures, fmt.Sprintf("%q: %v", expr.Expression.UserExpression(), evalErr))
+				"expression", exprText)
+			failures = append(failures, fmt.Sprintf("%q: %v", exprText, evalErr))
 			continue
 		}
 
-		conds, flattenErr := flattenCelConditionValue(raw, expr.Expression.UserExpression())
+		conds, flattenErr := flattenCelConditionValue(raw, exprText)
 		if flattenErr != nil {
+			noOutputEntries[i] = true
 			logger.Error(flattenErr, "skipping author condition expression with malformed result",
-				"expression", expr.Expression.UserExpression())
-			failures = append(failures, fmt.Sprintf("%q: %v", expr.Expression.UserExpression(), flattenErr))
+				"expression", exprText)
+			failures = append(failures, fmt.Sprintf("%q: %v", exprText, flattenErr))
 			continue
 		}
-		out = append(out, conds...)
+		results[i] = conds
+
+		// Publish immediately so the next entry reads these values, and withdraw a
+		// duplicated type at the moment of collision, before a later entry can read
+		// an ambiguous value.
+		changed := false
+		for _, c := range conds {
+			if _, dup := publishedBy[c.ConditionType]; dup {
+				duplicatedTypes[c.ConditionType] = struct{}{}
+				visible = removeConditionEntry(visible, c.ConditionType)
+				changed = true
+				continue
+			}
+			publishedBy[c.ConditionType] = i
+			// An override of a built-in type must not shadow it for lookups. The
+			// override still reaches the wire via results[i].
+			if _, builtin := v1alpha1.KROBuiltinConditionTypes[c.ConditionType]; builtin {
+				continue
+			}
+			visible = upsertConditionEntry(visible, c)
+			changed = true
+		}
+		if changed {
+			ctx[graph.SchemaVarName] = n.schemaForConditions(visible)
+		}
 	}
 
-	out, dups := dedupConditionTypes(out)
-	if len(dups) > 0 {
+	// Emit in declaration order. A duplicated type is dropped even from the entry
+	// that published it; dropping rather than blanking lets the caller keep the
+	// last good value.
+	for i := range results {
+		for _, c := range results[i] {
+			if _, bad := duplicatedTypes[c.ConditionType]; bad {
+				continue
+			}
+			conditions = append(conditions, c)
+		}
+	}
+
+	if len(duplicatedTypes) > 0 {
+		dups := slices.Sorted(maps.Keys(duplicatedTypes))
 		logger.Info("dropping author conditions with duplicate types", "types", dups)
 		failures = append(failures, fmt.Sprintf("duplicate condition type(s) %v dropped", dups))
 	}
-
 	if len(failures) > 0 {
-		return out, true, fmt.Errorf("%w: %s", ErrConditionEvaluationDegraded, strings.Join(failures, "; "))
+		return conditions, true, fmt.Errorf("%w: %s", ErrConditionEvaluationDegraded, strings.Join(failures, "; "))
 	}
-	return out, incomplete, nil
+	return conditions, incomplete, nil
+}
+
+// missingDependency reports why a dependency is missing. A type is
+// missing if a collision withdrew it or if an entry that could
+// declare it produced no output. A built-in has no declaring entry
+// and is never withdrawn, so it is never missing.
+func missingDependency(
+	dependsOn []graph.ConditionDependency,
+	noOutputEntries []bool,
+	duplicatedTypes map[string]struct{},
+) (string, bool) {
+	for _, d := range dependsOn {
+		if _, bad := duplicatedTypes[d.Type]; bad {
+			return fmt.Sprintf("condition type %q was withdrawn", d.Type), true
+		}
+		for _, e := range d.DeclaredBy {
+			if noOutputEntries[e] {
+				return fmt.Sprintf("condition type %q comes from entry %d, which did not run", d.Type, e), true
+			}
+		}
+	}
+	return "", false
 }
 
 // schemaForConditions builds the value bound to the `schema` CEL variable
 // when evaluating author conditions: the instance's spec/metadata (status
 // stripped, matching every other CEL eval path) plus a synthesized
-// status.conditions[] holding kro's built-in conditions for
+// status.conditions[] holding the conditions visible so far for
 // runtime.condition(schema, _) lookups.
-func (n *Node) schemaForConditions(kroBuiltins []v1alpha1.Condition) any {
+func (n *Node) schemaForConditions(entries []any) any {
 	if len(n.observed) == 0 {
 		return map[string]any{
 			"status": map[string]any{
-				"conditions": kroBuiltinsAsList(kroBuiltins),
+				"conditions": entries,
 			},
 		}
 	}
 
 	obj := withStatusOmitted(n.observed[0].Object)
 	obj["status"] = map[string]any{
-		"conditions": kroBuiltinsAsList(kroBuiltins),
+		"conditions": entries,
 	}
 
 	if n.resourceSchema == nil {
@@ -156,33 +239,39 @@ func kroBuiltinsAsList(conds []v1alpha1.Condition) []any {
 	return out
 }
 
-// dedupConditionTypes removes every occurrence of any condition type that
-// appears more than once, returning the kept conditions and the sorted list
-// of dropped types. Uniqueness is enforced at runtime because collection
-// expansion can produce types that are not known until evaluation.
-func dedupConditionTypes(conds []library.Condition) ([]library.Condition, []string) {
-	counts := make(map[string]int, len(conds))
-	for _, c := range conds {
-		counts[c.ConditionType]++
+// conditionEntry renders a condition in the plain-map shape conditionFromMap
+// expects.
+func conditionEntry(c library.Condition) map[string]any {
+	return map[string]any{
+		"type":    c.ConditionType,
+		"status":  c.Status,
+		"reason":  c.Reason,
+		"message": c.Message,
 	}
-	kept := make([]library.Condition, 0, len(conds))
-	dupSet := make(map[string]struct{})
-	for _, c := range conds {
-		if counts[c.ConditionType] > 1 {
-			dupSet[c.ConditionType] = struct{}{}
+}
+
+// upsertConditionEntry replaces the entry of c's type if present, else appends.
+func upsertConditionEntry(entries []any, c library.Condition) []any {
+	for i, e := range entries {
+		if m, ok := e.(map[string]any); ok && m["type"] == c.ConditionType {
+			entries[i] = conditionEntry(c)
+			return entries
+		}
+	}
+	return append(entries, conditionEntry(c))
+}
+
+// removeConditionEntry drops the given type, so a reader of a duplicated type sees
+// the empty condition rather than an ambiguous value.
+func removeConditionEntry(entries []any, typ string) []any {
+	out := make([]any, 0, len(entries))
+	for _, e := range entries {
+		if m, ok := e.(map[string]any); ok && m["type"] == typ {
 			continue
 		}
-		kept = append(kept, c)
+		out = append(out, e)
 	}
-	if len(dupSet) == 0 {
-		return kept, nil
-	}
-	dups := make([]string, 0, len(dupSet))
-	for t := range dupSet {
-		dups = append(dups, t)
-	}
-	sort.Strings(dups)
-	return kept, dups
+	return out
 }
 
 // flattenCelConditionValue extracts Condition values from a CEL result: a

--- a/pkg/runtime/conditions_test.go
+++ b/pkg/runtime/conditions_test.go
@@ -48,12 +48,20 @@ func compileConditionExpr(t *testing.T, expr string) *krocel.Expression {
 }
 
 func graphWithConditions(conditions []*krocel.Expression) *graph.Graph {
+	entries := make([]graph.ConditionEntry, len(conditions))
+	for i, expr := range conditions {
+		entries[i] = graph.ConditionEntry{Expr: expr}
+	}
+	return graphWithConditionEntries(entries)
+}
+
+func graphWithConditionEntries(entries []graph.ConditionEntry) *graph.Graph {
 	return &graph.Graph{
 		TopologicalOrder: []string{},
 		Nodes:            map[string]*graph.Node{},
 		Instance: &graph.Node{
 			Meta:       graph.NodeMeta{ID: graph.InstanceNodeID, Type: graph.NodeTypeInstance},
-			Conditions: conditions,
+			Conditions: entries,
 		},
 	}
 }
@@ -387,4 +395,129 @@ func TestEvaluateConditions_FatalErrorInOneExpressionSkippedNotAborted(t *testin
 	require.Len(t, conds, 1)
 	assert.Equal(t, "Good", conds[0].ConditionType,
 		"the well-formed condition must still surface even when a sibling expression fails")
+}
+
+func entryWithRank(expr *krocel.Expression, rank int, deps ...graph.ConditionDependency) graph.ConditionEntry {
+	return graph.ConditionEntry{Expr: expr, EvalRank: rank, DependsOn: deps}
+}
+
+func dependsOn(typ string, declaredBy ...int) graph.ConditionDependency {
+	return graph.ConditionDependency{Type: typ, DeclaredBy: declaredBy}
+}
+
+func TestEvaluateConditions_CrossReferenceReadsThisReconcile(t *testing.T) {
+	summary := compileConditionExpr(t, `runtime.newCondition({
+		type: 'Summary', status: runtime.condition(schema, 'ShardReady').status,
+		reason: '', message: ''})`)
+	shardReady := compileConditionExpr(t, `runtime.newCondition({
+		type: 'ShardReady', status: 'True', reason: '', message: ''})`)
+
+	entries := []graph.ConditionEntry{
+		entryWithRank(summary, 1, dependsOn("ShardReady", 1)),
+		entryWithRank(shardReady, 0),
+	}
+	rt, err := FromGraph(graphWithConditionEntries(entries), testInstance("demo"), graph.RGDConfig{})
+	require.NoError(t, err)
+
+	conds, incomplete, err := rt.Instance().EvaluateConditions(logr.Discard(), nil)
+	require.NoError(t, err)
+	assert.False(t, incomplete)
+	require.Len(t, conds, 2)
+
+	assert.Equal(t, "Summary", conds[0].ConditionType)
+	assert.Equal(t, "ShardReady", conds[1].ConditionType)
+	assert.Equal(t, "True", conds[0].Status,
+		"Summary must observe the ShardReady value published this reconcile")
+}
+
+func TestEvaluateConditions_EmissionOrderIndependentOfEvalRank(t *testing.T) {
+	mk := func() []*krocel.Expression {
+		return []*krocel.Expression{
+			compileConditionExpr(t, `runtime.newCondition({type: 'A', status: 'True', reason: '', message: ''})`),
+			compileConditionExpr(t, `runtime.newCondition({type: 'B', status: 'True', reason: '', message: ''})`),
+			compileConditionExpr(t, `runtime.newCondition({type: 'C', status: 'True', reason: '', message: ''})`),
+		}
+	}
+
+	for _, ranks := range [][]int{{0, 1, 2}, {2, 1, 0}, {1, 2, 0}} {
+		exprs := mk()
+		entries := make([]graph.ConditionEntry, len(exprs))
+		for i, e := range exprs {
+			entries[i] = entryWithRank(e, ranks[i])
+		}
+		rt, err := FromGraph(graphWithConditionEntries(entries), testInstance("demo"), graph.RGDConfig{})
+		require.NoError(t, err)
+
+		conds, _, err := rt.Instance().EvaluateConditions(logr.Discard(), nil)
+		require.NoError(t, err)
+		require.Len(t, conds, 3)
+
+		got := []string{conds[0].ConditionType, conds[1].ConditionType, conds[2].ConditionType}
+		assert.Equal(t, []string{"A", "B", "C"}, got,
+			"ranks %v must not change wire order", ranks)
+	}
+}
+
+func TestEvaluateConditions_FailedDependencyPropagates(t *testing.T) {
+	a := compileConditionExpr(t, `runtime.newCondition({
+		type: 'A', status: string(schema.spec.missing.deep), reason: '', message: ''})`)
+	b := compileConditionExpr(t, `runtime.newCondition({
+		type: 'B', status: runtime.condition(schema, 'A').status == 'True' ? 'True' : 'False',
+		reason: '', message: ''})`)
+	c := compileConditionExpr(t, `runtime.newCondition({
+		type: 'C', status: runtime.condition(schema, 'B').status == 'True' ? 'True' : 'False',
+		reason: '', message: ''})`)
+
+	entries := []graph.ConditionEntry{
+		entryWithRank(a, 0),
+		entryWithRank(b, 1, dependsOn("A", 0)),
+		entryWithRank(c, 2, dependsOn("B", 1)),
+	}
+	rt, err := FromGraph(graphWithConditionEntries(entries), testInstance("demo"), graph.RGDConfig{})
+	require.NoError(t, err)
+
+	conds, incomplete, _ := rt.Instance().EvaluateConditions(logr.Discard(), nil)
+	assert.True(t, incomplete, "a failed dependency must mark the result incomplete")
+	assert.Empty(t, conds, "B depends on failed A, and C on dropped B, so both drop transitively")
+}
+
+func TestEvaluateConditions_DuplicatedTypeBlocksDependent(t *testing.T) {
+	dup1 := compileConditionExpr(t, `runtime.newCondition({type: 'X', status: 'True', reason: '', message: ''})`)
+	dup2 := compileConditionExpr(t, `runtime.newCondition({type: 'X', status: 'False', reason: '', message: ''})`)
+	dependsOnX := compileConditionExpr(t, `runtime.newCondition({
+		type: 'DependsOnX', status: runtime.condition(schema, 'X').status, reason: '', message: ''})`)
+
+	entries := []graph.ConditionEntry{
+		entryWithRank(dup1, 0),
+		entryWithRank(dup2, 1),
+		entryWithRank(dependsOnX, 2, dependsOn("X", 0, 1)),
+	}
+	rt, err := FromGraph(graphWithConditionEntries(entries), testInstance("demo"), graph.RGDConfig{})
+	require.NoError(t, err)
+
+	conds, incomplete, err := rt.Instance().EvaluateConditions(logr.Discard(), nil)
+	require.Error(t, err, "a duplicate type is a degraded result")
+	assert.ErrorIs(t, err, ErrConditionEvaluationDegraded)
+	assert.True(t, incomplete)
+	assert.Empty(t, conds, "both copies of X and the entry depending on X are dropped")
+}
+
+func TestEvaluateConditions_PendingDependencyDropsDependentNotBlanks(t *testing.T) {
+	pending := compileConditionExpr(t, `runtime.newCondition({
+		type: 'Pending', status: schema.spec.missing.value == 'X' ? 'True' : 'False',
+		reason: '', message: ''})`)
+	dependsOnPending := compileConditionExpr(t, `runtime.newCondition({
+		type: 'DependsOnPending', status: runtime.condition(schema, 'Pending').status, reason: '', message: ''})`)
+
+	entries := []graph.ConditionEntry{
+		entryWithRank(pending, 0),
+		entryWithRank(dependsOnPending, 1, dependsOn("Pending", 0)),
+	}
+	rt, err := FromGraph(graphWithConditionEntries(entries), testInstance("demo"), graph.RGDConfig{})
+	require.NoError(t, err)
+
+	conds, incomplete, err := rt.Instance().EvaluateConditions(logr.Discard(), nil)
+	require.NoError(t, err, "data-pending is not a degraded error")
+	assert.True(t, incomplete)
+	assert.Empty(t, conds, "neither the pending entry nor the entry depending on it is emitted")
 }

--- a/pkg/runtime/node.go
+++ b/pkg/runtime/node.go
@@ -50,9 +50,14 @@ type Node struct {
 	templateVars     []*variable.ResourceField
 
 	// conditionExprs are the per-reconcile evaluation states for the
-	// instance's author-defined `conditions:` expressions. Only the
-	// instance node populates this; resource nodes leave it nil.
+	// instance's author-defined `conditions:` expressions, in declaration
+	// order (index-aligned with Spec.Conditions). Only the instance node
+	// populates this; resource nodes leave it nil.
 	conditionExprs []*expressionEvaluationState
+
+	// conditionEvalOrder lists declaration indices in evaluation order, so an
+	// entry reading another's output runs after it.
+	conditionEvalOrder []int
 
 	rgdConfig graph.RGDConfig
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,6 +15,8 @@
 package runtime
 
 import (
+	"cmp"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -168,10 +170,20 @@ func FromGraph(g *graph.Graph, instance *unstructured.Unstructured, rgdConfig gr
 	}
 
 	// Each condition Expression carries its own References, populated by the builder.
-	for _, expr := range instNode.Spec.Conditions {
-		state := getOrCreateExpr(expr, variable.ResourceVariableKindDynamic, expr.References)
+	for _, entry := range instNode.Spec.Conditions {
+		state := getOrCreateExpr(entry.Expr, variable.ResourceVariableKindDynamic, entry.Expr.References)
 		instNode.conditionExprs = append(instNode.conditionExprs, state)
 	}
+
+	// Sorting conditionEvalOrder leaves Spec.Conditions in declaration order.
+	// Evaluation follows the sorted indices, emission follows Spec.Conditions.
+	instNode.conditionEvalOrder = make([]int, len(instNode.conditionExprs))
+	for i := range instNode.conditionEvalOrder {
+		instNode.conditionEvalOrder[i] = i
+	}
+	slices.SortStableFunc(instNode.conditionEvalOrder, func(a, b int) int {
+		return cmp.Compare(instNode.Spec.Conditions[a].EvalRank, instNode.Spec.Conditions[b].EvalRank)
+	})
 
 	return rt, nil
 }


### PR DESCRIPTION
## Summary

Lets one author-defined condition read another. `runtime.condition(schema, 'X')`
where `X` is declared by a `runtime.newCondition({type: 'X', ...})` in the same
RGD is now legal, and kro evaluates entries in dependency order so the reader
observes the value published this reconcile.

## Why

The custom-conditions feature registered `runtime.condition(obj, type)` for
reading conditions, but a lookup of an author's own type was rejected at build
time:

```
runtime.condition(schema, "PrimaryReady"): custom conditions cannot reference
each other
```

Authors could read kro's four built-ins but not compose their own conditions.
That forces duplication: an aggregate like `Ready` has to restate every
sub-expression it depends on, and the two copies drift.

```yaml
# before: the primary check is written twice
status:
  conditions:
    - ${runtime.newCondition({
        type: 'PrimaryReady',
        status: primary.status.phase == 'Running' ? 'True' : 'False',
        reason: 'PrimaryPhase', message: ''})}
    - ${runtime.newCondition({
        type: 'Ready',
        status: primary.status.phase == 'Running'
          && replicas.status.readyReplicas > 0 ? 'True' : 'False',
        reason: 'Aggregate', message: ''})}
```

```yaml
# after: Ready composes the condition it depends on
status:
  conditions:
    - ${runtime.newCondition({
        type: 'PrimaryReady',
        status: primary.status.phase == 'Running' ? 'True' : 'False',
        reason: 'PrimaryPhase', message: ''})}
    - ${runtime.newCondition({
        type: 'Ready',
        status: runtime.condition(schema, 'PrimaryReady').status == 'True'
          && replicas.status.readyReplicas > 0 ? 'True' : 'False',
        reason: 'Aggregate', message: ''})}
```

## How it works

Declaration order does not have to match dependency order. An entry that reads
`PrimaryReady` may be declared before the entry that declares it; the build
computes an evaluation rank per entry from a topological sort over the reference
edges, and the runtime evaluates in rank order.

**Emission stays in declaration order.** Evaluation order is derived at runtime
construction and never reaches `status.conditions[]`, so a future change to how
ranks are computed cannot rewrite status on every instance in the cluster.

The RGD compiles once at admission, before any instance exists, so a `type:`
expression is only statically knowable when fully literal. A computed name like
`'Shard-' + s.metadata.name` is known only by its shape and is matched as a
pattern, which is why a literal read of `Shard-web` resolves against a fan-out
entry. A pattern matches more names than the expression will produce; that is
the safe direction, since a spurious edge costs a false cycle at build time
while a missing edge would cause silent staleness at runtime.

### Rejected at build time

A `type:` expression with more than 32 possible values, rather than widening to
match every name (which would disable typo detection for the whole RGD):

```
conditions[0]: condition type expression has more than 32 possible values;
split it across separate conditions entries
```

Self-references, with the type named rather than surfacing as an opaque cycle:

```
runtime.condition(schema, "Loop"): a conditions entry cannot depend on a
condition type it may itself declare (matches Loop)
```

Reference cycles, attributed to both entries. Fan-out entries are rendered by
pattern, since two of them can produce the same glob and only the index tells
them apart:

```
conditions entries form a reference cycle: entry 0 (A) -> entry 1 (B) -> entry 0 (A)
conditions entries form a reference cycle: entry 0 (Alpha-*) -> entry 1 (Beta-*) -> entry 0 (Alpha-*)
```

### Unavailable dependencies

An entry whose dependency did not resolve is skipped rather than evaluated
against an empty read, which would publish a confident wrong value. Two cases
propagate to dependents, transitively:

- a producer entry that failed to evaluate, so the type was never published
- a type withdrawn because two entries published it with different values

The result is marked incomplete, so the caller preserves the last persisted
value for the affected types instead of blanking them.

## Test plan

- `go test ./pkg/graph/... ./pkg/runtime/... ./pkg/controller/...` passes.
- Build-time cases: a cross-reference is accepted whichever order the two
  entries are declared in; a self-reference is rejected; cycles spanning two,
  three, and four entries are rejected; a cycle through a fan-out or ternary
  entry names the pattern rather than an opaque index; a literal read resolves
  against a computed type; the alternation cap is enforced.
- Runtime cases: an entry declared before the one it reads still observes this
  reconcile's value; emission order is unchanged across three different
  evaluation orders; a failed producer propagates to its dependents
  transitively; a withdrawn type drops the entries depending on it; a pending
  dependency preserves the last persisted value rather than blanking it; an
  override of a built-in type does not shadow it for lookups.