### PR TITLE
fix(graph): key extended CEL env cache by schema, not just var name

### DIFF
--- a/pkg/graph/build_context.go
+++ b/pkg/graph/build_context.go
@@ -49,8 +49,8 @@ type buildContext struct {
 	// inference, then compile reuses the cached AST.
 	checkedASTs map[checkedASTKey]*cel.Ast
 
-	// (parent env, varName) → extended env. Deduplicates readyWhen on
-	// collection nodes that share the same schema.
+	// (parent env, varName, schema pointer) → extended env. Deduplicates
+	// readyWhen on collection nodes that share the same schema.
 	extendedEnvs map[extendedEnvKey]*cel.Env
 }
 
@@ -62,6 +62,7 @@ type checkedASTKey struct {
 type extendedEnvKey struct {
 	parent  *cel.Env
 	varName string
+	schema  *spec.Schema
 }
 
 // schemaDeclType returns a DeclType for the given schema, memoized by pointer.
@@ -124,7 +125,7 @@ func (bc *buildContext) compile(env *cel.Env, expr *krocel.Expression) (*cel.Ast
 // single typed variable declaration derived from the given schema. Uses
 // schemaDeclType for memoized schema→DeclType conversion.
 func (bc *buildContext) extendWithTypedVar(parent *cel.Env, varName string, s *spec.Schema) (*cel.Env, error) {
-	key := extendedEnvKey{parent: parent, varName: varName}
+	key := extendedEnvKey{parent: parent, varName: varName, schema: s}
 	if env, ok := bc.extendedEnvs[key]; ok {
 		return env, nil
 	}

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -2206,6 +2206,52 @@ func TestGraphBuilder_CELTypeChecking(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Regression test: readyWhen on multiple forEach collections must type-check
+			// "each" against each collection's own template kind, not whichever
+			// collection's schema happened to populate the cache first. VPC.status has
+			// vpcID but no subnetID, Subnet.status has subnetID but no vpcID, so neither
+			// is a superset of the other.
+			name: "readyWhen on multiple forEach collections with different template kinds",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"names": "[]string",
+					},
+					nil,
+				),
+				generator.WithResourceCollection("vpcs", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "VPC",
+					"metadata": map[string]interface{}{
+						"name": "${name}-vpc",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlocks": []interface{}{"10.0.0.0/16"},
+					},
+				},
+					[]krov1alpha1.ForEachDimension{
+						{"name": "${schema.spec.names}"},
+					},
+					[]string{"${each.status.vpcID != \"\"}"}, nil),
+				generator.WithResourceCollection("subnets", map[string]interface{}{
+					"apiVersion": "ec2.services.k8s.aws/v1alpha1",
+					"kind":       "Subnet",
+					"metadata": map[string]interface{}{
+						"name": "${name}-subnet",
+					},
+					"spec": map[string]interface{}{
+						"cidrBlock": "10.0.1.0/24",
+					},
+				},
+					[]krov1alpha1.ForEachDimension{
+						{"name": "${schema.spec.names}"},
+					},
+					[]string{"${each.status.subnetID != \"\"}"}, nil),
+			},
+			wantErr: false,
+		},
+		{
 			name: "ConfigMap.data type mismatch - list where string expected",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(


### PR DESCRIPTION
Motivation:
When a ResourceGraphDefinition has two or more forEach (collection)
resources that each reference `each` in readyWhen, the RGD randomly
failed to compile with a spurious "undefined field" error, flipping
between valid and invalid across reconciles with no input change.

Approach:
buildContext.extendWithTypedVar caches the CEL environment it builds
for a collection's `each` variable, keyed on (parent env, var name).
Every collection uses the same variable name "each" and the same
parent env, so all collections in one build collided on a single
cache entry: whichever collection populated it first "won", and every
other collection's readyWhen was then type-checked against the wrong
kind's status schema. Because Go map iteration order is randomized,
which collection won was nondeterministic across reconciles.

The fix adds the schema pointer to the cache key (extendedEnvKey),
matching the existing declTypes map in the same file which is already
keyed by schema pointer on the same rationale: buildContext is
documented as scoped to a single NewResourceGraphDefinition() call,
so schema pointers stay live and stable for the whole build.

Validation:
Added a regression test in pkg/graph/builder_test.go
(TestGraphBuilder_CELTypeChecking) with two forEach collections
templating VPC and Subnet, whose status schemas each have a field the
other lacks (vpcID vs subnetID) - mirroring the issue's Pod/Job repro.
Confirmed the test fails with the same "undefined field" error when
run against the pre-fix code (via git stash) and passes with the fix.

Ran the repo's documented unit test command and it passed:
  go test -race ./pkg/... -coverprofile unit-cover.out

Report: https://github.com/kubernetes-sigs/kro/issues/1339
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.

Fixes #1339

```release-note
fix(graph): key extended CEL env cache by schema, not just var name
```