### PR TITLE
log full condition objects on status transitions

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -125,6 +125,34 @@ func (c *Condition) GetStatus() metav1.ConditionStatus {
 	return c.Status
 }
 
+// MarshalLog implements logr.Marshaler so structured loggers render a
+// Condition with its optional pointer fields dereferenced. Without this,
+// loggers fall back to reflection over Reason, Message, and
+// LastTransitionTime, which are pointers. Unset optionals are omitted.
+//
+// The receiver is a value, not a pointer, because conditions are logged as
+// slice elements: a pointer receiver would leave Condition itself without
+// the method and silently fall back to reflection.
+func (c Condition) MarshalLog() any {
+	m := map[string]any{
+		"type":   string(c.Type),
+		"status": string(c.Status),
+	}
+	if c.Reason != nil {
+		m["reason"] = *c.Reason
+	}
+	if c.Message != nil {
+		m["message"] = *c.Message
+	}
+	if c.LastTransitionTime != nil {
+		m["lastTransitionTime"] = c.LastTransitionTime
+	}
+	if c.ObservedGeneration != 0 {
+		m["observedGeneration"] = c.ObservedGeneration
+	}
+	return m
+}
+
 // Conditions is a list of conditions.
 type Conditions []Condition
 

--- a/pkg/metrics/instance.go
+++ b/pkg/metrics/instance.go
@@ -147,20 +147,19 @@ func EmitConditionMetrics(
 			lastTransition,
 		)
 
-		oldCond, existed := initialByType[cond.Type]
-		if !existed || oldCond.Status != cond.Status {
-			oldStatus := "none"
+		initialCondition, existed := initialByType[cond.Type]
+		if !existed || initialCondition.Status != cond.Status {
+			// nil rather than a zero-value Condition when the type is
+			// appearing for the first time and so has no prior state.
+			var oldCondition any
 			if existed {
-				oldStatus = string(oldCond.Status)
+				oldCondition = initialCondition
 			}
-			log.V(2).Info("condition transitioned",
+			log.Info("condition transitioned",
 				"gvr", gvrKey,
-				"namespace", ns,
-				"name", name,
-				"condition_type", string(cond.Type),
-				"old_status", oldStatus,
-				"new_status", string(cond.Status),
-				"reason", reason,
+				"conditionType", string(cond.Type),
+				"oldCondition", oldCondition,
+				"newCondition", cond,
 			)
 		}
 	}


### PR DESCRIPTION
# Log full condition objects on status transitions

## Summary
KRO logs a line when an instance status condition changes status, but it reported only the condition type, old/new status, and reason. Log the whole old and new `Condition` instead — the remaining fields give useful context on a state transition.

The line also moves from `V(2)` to `V(0)`, so it is visible on a default install. A condition status transition is a low-frequency, high-signal event — it only fires on an actual status change.

Two smaller fixes: the duplicate `namespace` / `name` keys are dropped (the instance controller's logger already carries both via `WithValues`, and zap does not deduplicate, so they were printed twice on the same line), and `condition_type` is renamed to `conditionType` to match every other multi-word log key in the repo. The snake_case identifiers elsewhere in this file are Prometheus label names and are unchanged.

## Rationale

An RGD instance’s status contains only the current value of each condition; it does not retain a history of previous values. After a condition transitions again, its previous status, reason, message, observed generation, and transition time are no longer available from the instance.

Logging the old and new conditions preserves this transition context and helps operators:

* investigate transient failures after an instance has recovered;
* understand why an instance became ready, unready, or degraded;
* identify repeated transitions or condition flapping; and
* correlate a condition status transition with reconciliation activity and other controller events.

Making the transition visible at the default log level is important for retrospective debugging: increasing the verbosity after an incident cannot recover a transition that has already occurred.

A condition status transition is also a low-frequency event. The line is emitted only when the condition’s status actually changes, rather than during every reconciliation.

A similar observability pattern exists in operatorpkg, which is used by Karpenter. Its status controller emits Kubernetes Events when it observes condition status transitions, including the old and new statuses and the current reason and message.

## Behaviour

A log is emitted when a condition appears for the first time or when its status changes, as before. A reason-only or message-only change keeps its LastTransitionTime (see apis.ConditionSet.Set), so no transition log is emitted.

Before:

```
LEVEL(-2)  widgets-controller  condition transitioned  {"controller": "widgets", ..., "namespace": "team-a", "name": "my-widget", "gvr": "example.com/v1alpha1, Resource=widgets", "namespace": "team-a", "name": "my-widget", "condition_type": "ResourcesReady", "old_status": "False", "new_status": "True", "reason": "AllResourcesReady"}
```

After:

```
INFO  widgets-controller  condition transitioned  {"controller": "widgets", ..., "namespace": "team-a", "name": "my-widget", "gvr": "example.com/v1alpha1, Resource=widgets", "conditionType": "ResourcesReady", "oldCondition": {"lastTransitionTime":"2026-08-05T14:18:55Z","message":"2/3 resources ready","observedGeneration":7,"reason":"NotReady","status":"False","type":"ResourcesReady"}, "newCondition": {"lastTransitionTime":"2026-08-05T14:23:07Z","message":"all resources are created and ready","observedGeneration":7,"reason":"AllResourcesReady","status":"True","type":"ResourcesReady"}}
```

A condition appearing for the first time logs `"oldCondition": null`. Unset optional fields are omitted from the rendered condition, matching the type's `omitempty` JSON tags.

## Compatibility

The renamed and restructured keys are a breaking change for anyone querying `condition_type`, `old_status`, `new_status`, or the top-level `reason` on this line. Given it sat at `V(2)` — invisible on a default install and not exposed by `logLevel: debug` — that seems unlikely to affect anyone in practice.

Prometheus metrics are untouched.

## Testing

- `gofmt`, `go build ./...`, `go vet ./...` clean
- Unit tests pass for `api/v1alpha1`, `pkg/apis`, `pkg/metrics`, `pkg/controller/instance`
- The existing `EmitConditionMetrics` tests cover this code path unchanged; no new tests were added for a field-list change
- Rendered output verified against kro's real logger configuration (`zap.Options{Development: true}`) for four scenarios: built-in condition transition, first appearance, author-defined condition transition, and a reason-only change (correctly produces no output)