### PR TITLE
feat(chart): add user role aggregation to view, edit and admin ClusterRole

### DIFF
--- a/helm/templates/user-cluster-role.yaml
+++ b/helm/templates/user-cluster-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This ClusterRole grants read/write access to kro resources by aggregating into the admin and edit ClusterRoles.
+  name: {{ include "kro.fullname" . }}-edit
+  labels:
+    {{- include "kro.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - kro.run
+  resources: ["*"]
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This ClusterRole grants read access to kro resources by aggregating into the view, edit, and admin ClusterRoles.
+  name: {{ include "kro.fullname" . }}-view
+  labels:
+    {{- include "kro.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - kro.run
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Kubernetes deploys the standard cluster roles `admin`, `edit` and `view`.
These cluster roles can be extended by role aggregation. In the context of Kro, users and service accounts that are bound to `admin`, `edit` or `view` ClusterRole do automatically get access to Kro resource kinds.

Open points:
* I have created a new template file `user-cluster-role.yaml` as I didn't want to mix it with the controller ClusterRoles.
* The added ClusterRoles use the `*` wildcard for resources. Is this ok or should it explicitely mention the resources?