### PR TITLE
Use stdlib maps and slices instead of x/exp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948
 	golang.org/x/sync v0.19.0
 	golang.org/x/time v0.14.0
 	k8s.io/api v0.35.0
@@ -84,6 +83,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect

--- a/pkg/apis/condition_types.go
+++ b/pkg/apis/condition_types.go
@@ -17,7 +17,7 @@
 
 package apis
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // NewReadyConditions returns a ConditionTypes to hold the conditions for the
 // resource. ConditionReady is used as the root condition.
@@ -75,12 +75,7 @@ func (ct ConditionTypes) For(object Object) ConditionSet {
 
 // DependsOn is a helper function to determine if deps contains the provided condition type.
 func (ct ConditionTypes) DependsOn(d string) bool {
-	for i := range ct.dependents {
-		if ct.dependents[i] == d {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ct.dependents, d)
 }
 
 func newConditionTypes(root string, dependents ...string) ConditionTypes {

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/cel"
-	"golang.org/x/exp/maps"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -250,8 +249,11 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 	// Create a single expression inspector for all AST inspection operations.
 	// This uses a lightweight env that only declares identifier names (no full schemas) -
 	// sufficient for parsing and finding references, but NOT for type-checking or compilation.
-	nodeNames := maps.Keys(nodes)
-	allIdentifiers := append(nodeNames, SchemaVarName, EachVarName, library.RuntimeVarName)
+	nodeNames := make([]string, 0, len(nodes))
+	for name := range nodes {
+		nodeNames = append(nodeNames, name)
+	}
+	allIdentifiers := slices.Concat(nodeNames, []string{SchemaVarName, EachVarName, library.RuntimeVarName})
 	inspectorEnv, err := krocel.DefaultEnvironment(krocel.WithResourceIDs(allIdentifiers))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create inspector environment: %w", err)


### PR DESCRIPTION
## Summary

`golang.org/x/exp` was a direct dependency for exactly two calls, both
of which the standard library has covered since Go 1.21/1.23:

- `pkg/apis/condition_types.go` — `x/exp/slices` for one `slices.Contains`
- `pkg/graph/builder.go` — `x/exp/maps` for one `maps.Keys`

After the swap, `go mod tidy` moves `golang.org/x/exp` out of the direct require block. It remains an indirect dependency via cel-go, antlr, and the k8s libraries, so no `go.sum`.

Also collapses the hand-rolled loop in `ConditionTypes.DependsOn` to `slices.Contains`, since the import was already being touched.

The `maps.Keys` swap is not purely mechanical. `x/exp`'s `maps.Keys` returned a slice with `cap == len`, so `append` onto it always reallocated. Stdlib `slices.Collect(maps.Keys(m))` grows in powers of two and returns spare capacity, which makes the existing
```go
allIdentifiers := append(nodeNames, SchemaVarName, EachVarName, library.RuntimeVarName)
```
an aliasing hazard — it would write into nodeNames' backing array. This is a similar bug fixed in this file, so this follows that precedent and uses `slices.Concat`.

`slices.Sorted` over `slices.Collect` is free at the same line count and makes the identifier list deterministic. 