### PR TITLE
fix(cel): prevent panic when uint/bytes CEL values reach deep-copy

### DIFF
--- a/pkg/cel/conversion/conversions.go
+++ b/pkg/cel/conversion/conversions.go
@@ -17,6 +17,7 @@ package conversion
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"time"
 
@@ -44,13 +45,25 @@ func GoNativeType(v ref.Val) (interface{}, error) {
 	case types.IntType:
 		return v.Value().(int64), nil
 	case types.UintType:
-		return v.Value().(uint64), nil
+		// apimachinery's unstructured deep-copy only accepts int64 for
+		// integers (not uint64), so convert here rather than let a raw
+		// uint64 reach DeepCopyJSONValue and panic. Values that don't fit
+		// in an int64 have no JSON-safe representation, so surface an
+		// actionable error instead.
+		u := v.Value().(uint64)
+		if u > math.MaxInt64 {
+			return nil, fmt.Errorf("%w: uint value %d overflows int64; convert it explicitly, e.g. string(...)", ErrUnsupportedType, u)
+		}
+		return int64(u), nil
 	case types.DoubleType:
 		return v.Value().(float64), nil
 	case types.StringType:
 		return v.Value().(string), nil
 	case types.BytesType:
-		return v.Value().([]byte), nil
+		// Raw bytes have no JSON-safe representation and panic apimachinery's
+		// unstructured deep-copy (DeepCopyJSONValue). Require the author to
+		// encode explicitly rather than silently pick an encoding for them.
+		return nil, fmt.Errorf("%w: bytes value cannot be used directly in a resource template or status field; encode it explicitly, e.g. base64.encode(...)", ErrUnsupportedType)
 	case types.DurationType:
 		return v1.Duration{Duration: v.Value().(time.Duration)}.ToUnstructured(), nil
 	case types.TimestampType:

--- a/pkg/cel/conversion/conversions.go
+++ b/pkg/cel/conversion/conversions.go
@@ -45,25 +45,13 @@ func GoNativeType(v ref.Val) (interface{}, error) {
 	case types.IntType:
 		return v.Value().(int64), nil
 	case types.UintType:
-		// apimachinery's unstructured deep-copy only accepts int64 for
-		// integers (not uint64), so convert here rather than let a raw
-		// uint64 reach DeepCopyJSONValue and panic. Values that don't fit
-		// in an int64 have no JSON-safe representation, so surface an
-		// actionable error instead.
-		u := v.Value().(uint64)
-		if u > math.MaxInt64 {
-			return nil, fmt.Errorf("%w: uint value %d overflows int64; convert it explicitly, e.g. string(...)", ErrUnsupportedType, u)
-		}
-		return int64(u), nil
+		return v.Value().(uint64), nil
 	case types.DoubleType:
 		return v.Value().(float64), nil
 	case types.StringType:
 		return v.Value().(string), nil
 	case types.BytesType:
-		// Raw bytes have no JSON-safe representation and panic apimachinery's
-		// unstructured deep-copy (DeepCopyJSONValue). Require the author to
-		// encode explicitly rather than silently pick an encoding for them.
-		return nil, fmt.Errorf("%w: bytes value cannot be used directly in a resource template or status field; encode it explicitly, e.g. base64.encode(...)", ErrUnsupportedType)
+		return v.Value().([]byte), nil
 	case types.DurationType:
 		return v1.Duration{Duration: v.Value().(time.Duration)}.ToUnstructured(), nil
 	case types.TimestampType:
@@ -89,6 +77,50 @@ func GoNativeType(v ref.Val) (interface{}, error) {
 		}
 		// For types we can't convert, return as is with an error
 		return v.Value(), fmt.Errorf("%w: %v", ErrUnsupportedType, v.Type())
+	}
+}
+
+// EnsureJSONSafe recursively validates and normalizes the output of
+// GoNativeType for callers whose result flows into apimachinery's
+// unstructured deep-copy (runtime.DeepCopyJSONValue, used by
+// unstructured.Unstructured.DeepCopy() for resource templates and by
+// unstructured.NestedMap/DeepCopyJSON for status). That deep-copy only
+// accepts string, int64, bool, float64, nil, map[string]interface{} and
+// []interface{} - it panics on the uint64 and []byte values GoNativeType
+// returns for CEL uint and bytes. Other consumers of GoNativeType (e.g.
+// json.marshal, which goes through encoding/json) don't have this
+// restriction and should call GoNativeType directly instead.
+func EnsureJSONSafe(v interface{}) (interface{}, error) {
+	switch val := v.(type) {
+	case uint64:
+		if val > math.MaxInt64 {
+			return nil, fmt.Errorf("%w: uint value %d overflows int64; convert it explicitly, e.g. string(...)", ErrUnsupportedType, val)
+		}
+		return int64(val), nil
+	case []byte:
+		return nil, fmt.Errorf("%w: bytes value cannot be used directly in a resource template or status field; encode it explicitly, e.g. base64.encode(...)", ErrUnsupportedType)
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(val))
+		for k, elem := range val {
+			safe, err := EnsureJSONSafe(elem)
+			if err != nil {
+				return nil, err
+			}
+			result[k] = safe
+		}
+		return result, nil
+	case []interface{}:
+		result := make([]interface{}, len(val))
+		for i, elem := range val {
+			safe, err := EnsureJSONSafe(elem)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = safe
+		}
+		return result, nil
+	default:
+		return v, nil
 	}
 }
 

--- a/pkg/cel/conversion/conversions_test.go
+++ b/pkg/cel/conversion/conversions_test.go
@@ -108,6 +108,9 @@ func TestGoNativeType_ComplexNested(t *testing.T) {
 }
 
 func TestGoNativeType_Bytes(t *testing.T) {
+	// Raw bytes have no JSON-safe representation (apimachinery's unstructured
+	// deep-copy panics on []byte), so GoNativeType must reject them with an
+	// actionable error instead of returning a value that later panics.
 	env, err := cel.NewEnv()
 	require.NoError(t, err)
 
@@ -121,17 +124,54 @@ func TestGoNativeType_Bytes(t *testing.T) {
 	require.NoError(t, err)
 
 	native, err := GoNativeType(val)
+	require.ErrorIs(t, err, ErrUnsupportedType)
+	assert.Nil(t, native)
+}
+
+func TestGoNativeType_Uint(t *testing.T) {
+	env, err := cel.NewEnv()
 	require.NoError(t, err)
 
-	// Check type
-	bytes, ok := native.([]byte)
-	require.True(t, ok, "Expected []byte, got %T", native)
-	assert.Equal(t, []byte("hello world"), bytes)
+	ast, issues := env.Compile(`uint(42)`)
+	require.NoError(t, issues.Err())
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	val, _, err := prog.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+
+	native, err := GoNativeType(val)
+	require.NoError(t, err)
+
+	// GoNativeType converts uint to int64 so it survives apimachinery's
+	// unstructured deep-copy, which only accepts int64 (not uint64).
+	i, ok := native.(int64)
+	require.True(t, ok, "Expected int64, got %T", native)
+	assert.Equal(t, int64(42), i)
 
 	// Check JSON marshalling
 	marshalled, err := json.Marshal(native)
 	assert.NoError(t, err, "Should be JSON marshallable")
 	assert.NotEmpty(t, marshalled)
+}
+
+func TestGoNativeType_UintOverflow(t *testing.T) {
+	env, err := cel.NewEnv()
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`18446744073709551615u`) // math.MaxUint64
+	require.NoError(t, issues.Err())
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	val, _, err := prog.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+
+	native, err := GoNativeType(val)
+	require.ErrorIs(t, err, ErrUnsupportedType)
+	assert.Nil(t, native)
 }
 
 func TestConvertMap_DeepCopiesRawMap(t *testing.T) {

--- a/pkg/cel/conversion/conversions_test.go
+++ b/pkg/cel/conversion/conversions_test.go
@@ -108,9 +108,10 @@ func TestGoNativeType_ComplexNested(t *testing.T) {
 }
 
 func TestGoNativeType_Bytes(t *testing.T) {
-	// Raw bytes have no JSON-safe representation (apimachinery's unstructured
-	// deep-copy panics on []byte), so GoNativeType must reject them with an
-	// actionable error instead of returning a value that later panics.
+	// GoNativeType itself has no JSON-safety restriction: some callers (e.g.
+	// json.marshal, via encoding/json) can handle []byte directly. Callers
+	// that feed apimachinery's unstructured deep-copy must additionally call
+	// EnsureJSONSafe; see TestEnsureJSONSafe_Bytes.
 	env, err := cel.NewEnv()
 	require.NoError(t, err)
 
@@ -124,8 +125,8 @@ func TestGoNativeType_Bytes(t *testing.T) {
 	require.NoError(t, err)
 
 	native, err := GoNativeType(val)
-	require.ErrorIs(t, err, ErrUnsupportedType)
-	assert.Nil(t, native)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello world"), native)
 }
 
 func TestGoNativeType_Uint(t *testing.T) {
@@ -144,11 +145,12 @@ func TestGoNativeType_Uint(t *testing.T) {
 	native, err := GoNativeType(val)
 	require.NoError(t, err)
 
-	// GoNativeType converts uint to int64 so it survives apimachinery's
-	// unstructured deep-copy, which only accepts int64 (not uint64).
-	i, ok := native.(int64)
-	require.True(t, ok, "Expected int64, got %T", native)
-	assert.Equal(t, int64(42), i)
+	// GoNativeType returns the raw uint64; JSON-safety normalization (to
+	// int64, for callers that need it) is EnsureJSONSafe's job, not this
+	// function's - see TestEnsureJSONSafe_Uint.
+	u, ok := native.(uint64)
+	require.True(t, ok, "Expected uint64, got %T", native)
+	assert.Equal(t, uint64(42), u)
 
 	// Check JSON marshalling
 	marshalled, err := json.Marshal(native)
@@ -156,22 +158,50 @@ func TestGoNativeType_Uint(t *testing.T) {
 	assert.NotEmpty(t, marshalled)
 }
 
-func TestGoNativeType_UintOverflow(t *testing.T) {
-	env, err := cel.NewEnv()
-	require.NoError(t, err)
-
-	ast, issues := env.Compile(`18446744073709551615u`) // math.MaxUint64
-	require.NoError(t, issues.Err())
-
-	prog, err := env.Program(ast)
-	require.NoError(t, err)
-
-	val, _, err := prog.Eval(map[string]interface{}{})
-	require.NoError(t, err)
-
-	native, err := GoNativeType(val)
+func TestEnsureJSONSafe_Bytes(t *testing.T) {
+	// Raw bytes have no JSON-safe representation (apimachinery's unstructured
+	// deep-copy panics on []byte), so EnsureJSONSafe must reject them with an
+	// actionable error instead of returning a value that later panics.
+	_, err := EnsureJSONSafe([]byte("hello world"))
 	require.ErrorIs(t, err, ErrUnsupportedType)
-	assert.Nil(t, native)
+}
+
+func TestEnsureJSONSafe_Uint(t *testing.T) {
+	safe, err := EnsureJSONSafe(uint64(42))
+	require.NoError(t, err)
+
+	// EnsureJSONSafe converts uint64 to int64 so it survives apimachinery's
+	// unstructured deep-copy, which only accepts int64 (not uint64).
+	i, ok := safe.(int64)
+	require.True(t, ok, "Expected int64, got %T", safe)
+	assert.Equal(t, int64(42), i)
+
+	marshalled, err := json.Marshal(safe)
+	assert.NoError(t, err, "Should be JSON marshallable")
+	assert.NotEmpty(t, marshalled)
+}
+
+func TestEnsureJSONSafe_UintOverflow(t *testing.T) {
+	_, err := EnsureJSONSafe(uint64(18446744073709551615)) // math.MaxUint64
+	require.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+func TestEnsureJSONSafe_NestedList(t *testing.T) {
+	safe, err := EnsureJSONSafe([]interface{}{uint64(42), "ok"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{int64(42), "ok"}, safe)
+
+	_, err = EnsureJSONSafe([]interface{}{[]byte("bad")})
+	require.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+func TestEnsureJSONSafe_NestedMap(t *testing.T) {
+	safe, err := EnsureJSONSafe(map[string]interface{}{"n": uint64(42)})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"n": int64(42)}, safe)
+
+	_, err = EnsureJSONSafe(map[string]interface{}{"b": []byte("bad")})
+	require.ErrorIs(t, err, ErrUnsupportedType)
 }
 
 func TestConvertMap_DeepCopiesRawMap(t *testing.T) {

--- a/pkg/cel/expression.go
+++ b/pkg/cel/expression.go
@@ -102,5 +102,16 @@ func (e *Expression) Eval(ctx map[string]any) (any, error) {
 		return nil, fmt.Errorf("convert %q: %w", e.UserExpression(), err)
 	}
 
-	return native, nil
+	// The result of an expression evaluation is used to build resource
+	// templates and status fields via apimachinery's unstructured deep-copy,
+	// which cannot represent the uint64/[]byte values GoNativeType returns
+	// for CEL uint/bytes. Guard here, at the point where that constraint
+	// actually applies, rather than in GoNativeType itself (other callers,
+	// like json.marshal, don't have this restriction).
+	safe, err := conversion.EnsureJSONSafe(native)
+	if err != nil {
+		return nil, fmt.Errorf("convert %q: %w", e.UserExpression(), err)
+	}
+
+	return safe, nil
 }

--- a/pkg/cel/library/json_test.go
+++ b/pkg/cel/library/json_test.go
@@ -193,6 +193,23 @@ func TestJSONMarshal(t *testing.T) {
 			expr:     `json.marshal(json.unmarshal('{"name":"test","count":42}'))`,
 			expected: `{"count":42,"name":"test"}`,
 		},
+		{
+			// encoding/json base64-encodes []byte, so json.marshal can
+			// represent bytes directly even though they aren't safe to
+			// place in a resource template or status field (see
+			// conversion.EnsureJSONSafe, which only guards that path).
+			name:     "marshal bytes",
+			expr:     `json.marshal(b"hello")`,
+			expected: `"aGVsbG8="`,
+		},
+		{
+			// encoding/json represents uint64 natively, so json.marshal
+			// isn't limited to the int64 range apimachinery's unstructured
+			// deep-copy requires.
+			name:     "marshal uint beyond int64 range",
+			expr:     `json.marshal(18446744073709551615u)`,
+			expected: `18446744073709551615`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Motivation:
A ResourceGraphDefinition whose status or resource-template CEL
expression resolves to CEL uint or bytes (or a list/map/optional
containing them) crashed the kro instance controller on first
reconcile. GoNativeType (pkg/cel/conversion/conversions.go) converted
CEL uint to Go uint64 and CEL bytes to Go []byte, but apimachinery's
runtime.DeepCopyJSONValue - used by unstructured.Unstructured.DeepCopy()
for resource templates and unstructured.NestedMap/DeepCopyJSON for
status - only accepts string, int64, bool, float64, nil, json.Number,
map[string]interface{} and []interface{}. Anything else hits its
default case and panics ("cannot deep copy uint64" / "cannot deep copy
[]uint8"). The RGD is accepted and its CRD installed either way, so
the panic only surfaces once an instance is reconciled.

Approach:
This is a narrower, surgical fix, not the full build-time rejection of
non-representable RGD schemas that the report ultimately asks for
(GraphAccepted=False before a CRD is ever installed). That requires
reasoning about static CEL types versus actual runtime values and is a
larger, more invasive change. The report itself calls out a runtime
coercion/guard in the conversion path as an acceptable complementary
approach.

An earlier version of this PR put the guard directly inside
GoNativeType. A reviewer pointed out that GoNativeType is a shared
conversion function with more than one caller, and putting the guard
there was too broad: json.marshal() (pkg/cel/library/json.go) also
calls GoNativeType, but goes through encoding/json afterwards, which
*can* represent []byte (base64-encoded) and uint64 beyond the int64
range just fine. Guarding inside GoNativeType broke that legitimate
use case (verified with a failing test before this revision: bytes
and >int64 uint marshaled fine on main, and were incorrectly rejected
by the earlier version of this PR).

The fix now lives at the point where the JSON-safety constraint
actually applies: Expression.Eval (pkg/cel/expression.go), which is
the evaluation entrypoint whose result flows into apimachinery's
unstructured deep-copy for resource templates and status fields.
GoNativeType itself is unchanged (CEL uint -> Go uint64, CEL bytes ->
Go []byte, as before). A new conversion.EnsureJSONSafe function
recursively walks GoNativeType's output and:
  - converts uint64 -> int64 (JSON-safe), erroring instead of
    overflowing when the value exceeds math.MaxInt64.
  - errors on []byte, asking the author to encode explicitly (e.g.
    base64.encode(...)) rather than returning a value that panics
    downstream.
Expression.Eval calls EnsureJSONSafe after GoNativeType, so this
becomes an actionable error on the RGD/instance instead of a
controller crash for every caller that goes through Expression.Eval
(resource templates, status fields, readiness/include-when
conditions). json.marshal calls GoNativeType directly and is
unaffected by this guard, since encoding/json doesn't have the same
restriction.

This does not implement the build-time GraphAccepted=False rejection
the report describes as the ultimate expected behavior - it only
prevents the controller from panicking on values that would trigger
it, surfacing a clear error instead.

Validation:
- go build ./...
- go test ./pkg/... (all packages pass)
- go test -race ./pkg/cel/... (passes)
- go vet ./...
- gofmt -l on all changed files (no output)
- pkg/cel/conversion/conversions_test.go: TestGoNativeType_Bytes and
  TestGoNativeType_Uint now assert GoNativeType returns the raw
  []byte/uint64 unchanged (no guard); new
  TestEnsureJSONSafe_Bytes/Uint/UintOverflow/NestedList/NestedMap
  cover the guard itself, including nested lists/maps.
- pkg/cel/library/json_test.go: added "marshal bytes" and "marshal
  uint beyond int64 range" cases to TestJSONMarshal. Confirmed these
  are a real regression check for the reviewer's concern: with the
  guard still inside GoNativeType (prior revision), both cases failed
  with "unsupported type" errors; with the guard moved to
  Expression.Eval, both pass, matching pre-existing main-branch
  behavior for json.marshal.
- Did not run an envtest/integration reproduction of the actual
  controller panic (no envtest bringing up an RGD with the issue's
  `${uint(...)}`/`${hash.sha256(...)}` expressions and reconciling an
  instance). This repo's CONTRIBUTING.md only requires local tests to
  pass for a change at this scope; the panic's root cause is fully
  contained in the Expression.Eval -> GoNativeType/EnsureJSONSafe
  path, and the targeted unit tests reproduce and fix it directly.

Report: https://github.com/kubernetes-sigs/kro/issues/1308
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.

Fixes #1308

```release-note
fix(cel): prevent panic when uint/bytes CEL values reach deep-copy
```
