### PR TITLE
feat(cel): add deepMerge() for recursive nested map merging

### DIFF
--- a/pkg/cel/library/maps.go
+++ b/pkg/cel/library/maps.go
@@ -41,6 +41,19 @@ import (
 //	{'a': 1}.merge({}) == {'a': 1}`},
 //	{'a': 1}.merge({'b': 2}) == {'a': 1, 'b': 2}`},
 //	{'a': 1}.merge({'a': 2, 'b': 2}) == {'a': 2, 'b': 2}`},
+//
+// # DeepMerge
+//
+// Recursively merges two maps. Keys from the second map overwrite keys in the
+// first; nested maps are merged rather than replaced. Lists and scalars are
+// replaced. Unlike merge, accepts dyn/object-typed values.
+//
+//	dyn.deepMerge(dyn) -> dyn
+//
+// Examples:
+//
+//	{'a': {'x': 1}}.deepMerge({'a': {'y': 2}}) == {'a': {'x': 1, 'y': 2}}
+//	{'a': {'x': 1}}.deepMerge({'a': {'x': 9}}) == {'a': {'x': 9}}
 func Maps(options ...MapsOption) cel.EnvOption {
 	l := &mapsLib{version: math.MaxUint32}
 	for _, o := range options {
@@ -87,6 +100,13 @@ func (lib mapsLib) CompileOptions() []cel.EnvOption {
 				cel.BinaryBinding(mergeVals),
 			),
 		),
+		cel.Function("deepMerge",
+			cel.MemberOverload("dyn_deepmerge_dyn",
+				[]*cel.Type{cel.DynType, cel.DynType},
+				cel.DynType,
+				cel.BinaryBinding(deepMergeVals),
+			),
+		),
 	}
 	return opts
 }
@@ -116,6 +136,50 @@ func merge(self, other traits.Mapper) traits.Mapper {
 		}
 	}
 	return result.ToImmutableMap()
+}
+
+func deepMergeVals(lhs, rhs ref.Val) ref.Val {
+	lm, lok := lhs.(traits.Mapper)
+	if !lok {
+		return types.MaybeNoSuchOverloadErr(lhs)
+	}
+	rm, rok := rhs.(traits.Mapper)
+	if !rok {
+		return types.MaybeNoSuchOverloadErr(rhs)
+	}
+	return deepMerge(lm, rm)
+}
+
+// deepMerge merges other onto self. Nested maps are merged recursively;
+// otherwise other wins. Inputs are not modified.
+func deepMerge(self, other traits.Mapper) ref.Val {
+	// CEL maps are immutable, so empty-side results can share the other input.
+	if other.Size() == types.IntZero {
+		return self
+	}
+	if self.Size() == types.IntZero {
+		return other
+	}
+
+	merged := make(map[ref.Val]ref.Val, int(self.Size().(types.Int))+int(other.Size().(types.Int)))
+	for it := self.Iterator(); it.HasNext().(types.Bool); {
+		k := it.Next()
+		merged[k] = self.Get(k)
+	}
+	for it := other.Iterator(); it.HasNext().(types.Bool); {
+		k := it.Next()
+		ov := other.Get(k)
+		if sv, found := merged[k]; found {
+			if sm, ok1 := sv.(traits.Mapper); ok1 {
+				if om, ok2 := ov.(traits.Mapper); ok2 {
+					merged[k] = deepMerge(sm, om)
+					continue
+				}
+			}
+		}
+		merged[k] = ov
+	}
+	return types.NewRefValMap(types.DefaultTypeAdapter, merged)
 }
 
 // mapperTraitToMutableMapper copies a traits.Mapper into a MutableMap.

--- a/pkg/cel/library/maps_test.go
+++ b/pkg/cel/library/maps_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMaps(t *testing.T) {
@@ -37,32 +39,357 @@ func TestMaps(t *testing.T) {
 	env := testMapsEnv(t)
 	for i, tc := range mapsTests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			asts := make([]*cel.Ast, 0, 2)
-			pAst, iss := env.Parse(tc.expr)
-			if iss.Err() != nil {
-				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
-			}
-			asts = append(asts, pAst)
-			cAst, iss := env.Check(pAst)
-			if iss.Err() != nil {
-				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
-			}
-			asts = append(asts, cAst)
-
-			for _, ast := range asts {
-				prg, err := env.Program(ast)
-				if err != nil {
-					t.Fatalf("env.Program() failed: %v", err)
-				}
-				out, _, err := prg.Eval(cel.NoVars())
-				if err != nil {
-					t.Fatal(err)
-				} else if out.Value() != true {
-					t.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
-				}
-			}
+			evalTrue(t, env, tc.expr)
 		})
 	}
+}
+
+func TestDeepMerge(t *testing.T) {
+	// expr is the call under test; want is the expected CEL value.
+	// Comparison uses CEL equality so nested map/list shapes stay consistent.
+	// notEqual=true asserts expr != want (negative expectation).
+	deepMergeTests := []struct {
+		name     string
+		expr     string
+		want     string
+		notEqual bool
+	}{
+		// empty maps (and empty-side fast paths)
+		{name: "both empty", expr: `{}.deepMerge({})`, want: `{}`},
+		{name: "empty rhs returns lhs", expr: `{'a': 1}.deepMerge({})`, want: `{'a': 1}`},
+		{name: "empty lhs returns rhs", expr: `{}.deepMerge({'a': 1})`, want: `{'a': 1}`},
+
+		// top-level shape
+		{name: "disjoint keys union", expr: `{'a': 1}.deepMerge({'b': 2})`, want: `{'a': 1, 'b': 2}`},
+		{name: "shallow leaf: rhs wins", expr: `{'a': 1}.deepMerge({'a': 2})`, want: `{'a': 2}`},
+		{name: "shallow leaf: lhs does not win", expr: `{'a': 1}.deepMerge({'a': 2})`, want: `{'a': 1}`, notEqual: true},
+		{name: "lhs-only key preserved", expr: `{'a': {'x': 1}, 'keep': 7}.deepMerge({'a': {'y': 2}})`, want: `{'a': {'x': 1, 'y': 2}, 'keep': 7}`},
+		{name: "rhs-only key added", expr: `{'a': 1}.deepMerge({'a': 1, 'b': 2})`, want: `{'a': 1, 'b': 2}`},
+
+		// nested maps — the core deepMerge behavior vs shallow merge
+		{
+			name: "nested merge keeps lhs-only and rhs-only leaves; rhs wins shared leaf",
+			expr: `{'a': {'x': 1, 'y': 2}}.deepMerge({'a': {'y': 3, 'z': 4}})`,
+			want: `{'a': {'x': 1, 'y': 3, 'z': 4}}`,
+		},
+		{
+			name: "nested merge is not shallow replace",
+			// shallow merge would yield this and drop x
+			expr:     `{'a': {'x': 1, 'y': 2}}.deepMerge({'a': {'y': 3, 'z': 4}})`,
+			want:     `{'a': {'y': 3, 'z': 4}}`,
+			notEqual: true,
+		},
+		{
+			name: "shallow merge still replaces nested maps wholesale",
+			expr: `{'a': {'x': 1, 'y': 2}}.merge({'a': {'y': 3, 'z': 4}})`,
+			want: `{'a': {'y': 3, 'z': 4}}`,
+		},
+		{
+			name: "3-level nesting rhs wins deepest shared leaf",
+			expr: `{'a': {'b': {'c': 1, 'd': 2}}}.deepMerge({'a': {'b': {'d': 9, 'e': 5}}})`,
+			want: `{'a': {'b': {'c': 1, 'd': 9, 'e': 5}}}`,
+		},
+
+		// type-crossing at a key: rhs always wins (no attempt to coerce)
+		{name: "scalar rhs replaces map lhs", expr: `{'a': {'x': 1}}.deepMerge({'a': 5})`, want: `{'a': 5}`},
+		{name: "map rhs replaces scalar lhs", expr: `{'a': 5}.deepMerge({'a': {'x': 1}})`, want: `{'a': {'x': 1}}`},
+		{name: "list rhs replaces list lhs wholesale", expr: `{'a': [1, 2]}.deepMerge({'a': [3]})`, want: `{'a': [3]}`},
+		{name: "list rhs does not concatenate", expr: `{'a': [1, 2]}.deepMerge({'a': [3]})`, want: `{'a': [1, 2, 3]}`, notEqual: true},
+		{
+			name: "list rhs does not deep-merge list elements",
+			expr: `{'a': [{'n': 'x', 'v': 1}]}.deepMerge({'a': [{'n': 'x', 'v': 2}]})`,
+			want: `{'a': [{'n': 'x', 'v': 2}]}`,
+		},
+
+		// key types
+		{name: "int keys merge with rhs leaf win", expr: `{1: 'a', 2: 'b'}.deepMerge({2: 'c', 3: 'd'})`, want: `{1: 'a', 2: 'c', 3: 'd'}`},
+
+		// inverse priority is just swapped operands (no deepMergeLeft)
+		{
+			name: "swapped operands invert leaf priority",
+			expr: `{'a': {'y': 3, 'z': 4}}.deepMerge({'a': {'x': 1, 'y': 2}})`,
+			want: `{'a': {'x': 1, 'y': 2, 'z': 4}}`,
+		},
+
+		// issue #1343 shape
+		{
+			name: "securedpod defaults under user podSpec",
+			expr: `{'securityContext': {'runAsNonRoot': true}}.deepMerge({'containers': [{'name': 'app'}], 'securityContext': {'fsGroup': 2000}})`,
+			want: `{'containers': [{'name': 'app'}], 'securityContext': {'runAsNonRoot': true, 'fsGroup': 2000}}`,
+		},
+	}
+
+	env := testMapsEnv(t)
+	for _, tc := range deepMergeTests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalCEL(t, env, tc.expr)
+			want := evalCEL(t, env, tc.want)
+			eq := got.Equal(want)
+			if tc.notEqual {
+				require.Equal(t, false, eq.Value(), "expr=%s\nwant(not)=%s\ngot=%v", tc.expr, tc.want, got)
+				return
+			}
+			require.Equal(t, true, eq.Value(), "expr=%s\nwant=%s\ngot=%v", tc.expr, tc.want, got)
+		})
+	}
+
+	// Immutability: deepMerge must not mutate the receiver literal's observable value.
+	t.Run("inputs are not mutated", func(t *testing.T) {
+		base := `{'a': {'x': 1}}`
+		merged := evalCEL(t, env, base+`.deepMerge({'a': {'y': 2}})`)
+		wantMerged := evalCEL(t, env, `{'a': {'x': 1, 'y': 2}}`)
+		require.Equal(t, true, merged.Equal(wantMerged).Value())
+
+		// Re-evaluate the original base expression; it must be unchanged.
+		baseVal := evalCEL(t, env, base)
+		wantBase := evalCEL(t, env, `{'a': {'x': 1}}`)
+		require.Equal(t, true, baseVal.Equal(wantBase).Value())
+	})
+}
+
+// TestDeepMergeNonMapArgErrors verifies runtime errors for non-map operands.
+// With a dyn overload, non-map args type-check but must fail at eval time.
+func TestDeepMergeNonMapArgErrors(t *testing.T) {
+	env := testMapsEnv(t)
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{name: "rhs list", expr: `{'a': 1}.deepMerge([1, 2, 3])`},
+		{name: "lhs list", expr: `[1, 2].deepMerge({'a': 1})`},
+		{name: "rhs string", expr: `{'a': 1}.deepMerge('nope')`},
+		{name: "lhs string", expr: `'nope'.deepMerge({'a': 1})`},
+		{name: "both non-map", expr: `1.deepMerge(2)`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			require.NoError(t, iss.Err(), "compile %q", tc.expr)
+			prg, err := env.Program(ast)
+			require.NoError(t, err)
+			_, _, err = prg.Eval(cel.NoVars())
+			require.Error(t, err, "expected eval error for %q", tc.expr)
+		})
+	}
+}
+
+// TestDeepMergeObjectTypeCompiles verifies the #1343 type-check regression:
+// deepMerge accepts an opaque object-typed RHS that plain merge rejects.
+func TestDeepMergeObjectTypeCompiles(t *testing.T) {
+	env := testMapsEnv(t, cel.Variable("podSpec", cel.ObjectType("podspec")))
+
+	deepExpr := `{"securityContext": {"runAsNonRoot": true}}.deepMerge(podSpec)`
+	pAst, iss := env.Parse(deepExpr)
+	require.NoError(t, iss.Err())
+	_, iss = env.Check(pAst)
+	require.NoError(t, iss.Err(), "deepMerge must type-check against object-typed field")
+
+	// Control: the same shape with merge must still fail type-checking.
+	mergeExpr := `{"securityContext": {"runAsNonRoot": true}}.merge(podSpec)`
+	mpAst, iss := env.Parse(mergeExpr)
+	require.NoError(t, iss.Err())
+	_, iss = env.Check(mpAst)
+	require.Error(t, iss.Err(), "expected merge to reject object-typed RHS")
+}
+
+// TestDeepMergeRuntimeUnstructured is the end-to-end regression test for
+// GitHub issue #1343. RHS is a dyn variable bound to native
+// map[string]interface{} — the shape kro gets from unstructured object fields.
+func TestDeepMergeRuntimeUnstructured(t *testing.T) {
+	env := testMapsEnv(t, cel.Variable("podSpec", cel.DynType))
+
+	const expr = `{"securityContext": {"runAsNonRoot": true}}.deepMerge(podSpec)`
+	const want = `{
+		"containers": [{"name": "app", "image": "nginx:latest"}],
+		"securityContext": {"runAsNonRoot": true, "fsGroup": 2000}
+	}`
+
+	podSpecVal := map[string]interface{}{
+		"containers": []interface{}{
+			map[string]interface{}{"name": "app", "image": "nginx:latest"},
+		},
+		"securityContext": map[string]interface{}{
+			"fsGroup": int64(2000),
+		},
+	}
+
+	got := evalCELWithVars(t, env, expr, map[string]interface{}{"podSpec": podSpecVal})
+	wantVal := evalCEL(t, env, want)
+	require.Equal(t, true, got.Equal(wantVal).Value(), "got=%v want=%v", got, wantVal)
+}
+
+// TestDeepMergeOperandOrder documents priority via operand order (no Left/Right API).
+//
+// deepMerge is always RHS-wins. The two common call patterns are:
+//
+//	defaults.deepMerge(user)  → user wins shared leaves; defaults fill gaps  (SecuredPod)
+//	user.deepMerge(defaults)  → defaults win shared leaves; user fills gaps
+//
+// Swapping operands inverts who wins on conflict; it is not a left-biased merge
+// of the original argument order.
+func TestDeepMergeOperandOrder(t *testing.T) {
+	env := testMapsEnv(t,
+		cel.Variable("podUser", cel.DynType),
+		cel.Variable("defaults", cel.DynType),
+	)
+
+	input := map[string]interface{}{
+		"podUser": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{"name": "app"},
+			},
+			"securityContext": map[string]interface{}{
+				"runAsNonRoot": false,
+				"fsGroup":      int64(2000),
+			},
+		},
+		"defaults": map[string]interface{}{
+			"securityContext": map[string]interface{}{
+				"runAsNonRoot": true,
+			},
+		},
+	}
+
+	cases := []struct {
+		name     string
+		expr     string
+		want     string
+		notEqual bool
+	}{
+		{
+			name: "defaults.deepMerge(user): user wins shared leaf",
+			expr: `defaults.deepMerge(podUser)`,
+			want: `{
+				"containers": [{"name": "app"}],
+				"securityContext": {"runAsNonRoot": false, "fsGroup": 2000}
+			}`,
+		},
+		{
+			name: "user.deepMerge(defaults): defaults win shared leaf",
+			expr: `podUser.deepMerge(defaults)`,
+			want: `{
+				"containers": [{"name": "app"}],
+				"securityContext": {"runAsNonRoot": true, "fsGroup": 2000}
+			}`,
+		},
+		{
+			name:     "the two call orders are not equal when a leaf conflicts",
+			expr:     `defaults.deepMerge(podUser)`,
+			want:     `podUser.deepMerge(defaults)`,
+			notEqual: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalCELWithVars(t, env, tc.expr, input)
+			want := evalCELWithVars(t, env, tc.want, input)
+			eq := got.Equal(want)
+			if tc.notEqual {
+				require.Equal(t, false, eq.Value(), "expr=%s\nwant(not)=%s\ngot=%v", tc.expr, tc.want, got)
+				return
+			}
+			require.Equal(t, true, eq.Value(), "expr=%s\nwant=%s\ngot=%v", tc.expr, tc.want, got)
+		})
+	}
+}
+
+// BenchmarkDeepMerge measures the cost of deepMerge on a ~3-level nested map
+// with ~20 keys to provide a stable baseline for future optimisation work.
+func BenchmarkDeepMerge(b *testing.B) {
+	env, err := cel.NewEnv(Maps())
+	require.NoError(b, err)
+	const expr = `{
+		'meta': {'name': 'foo', 'namespace': 'bar', 'labels': {'app': 'myapp', 'env': 'prod'}},
+		'spec': {
+			'replicas': 3,
+			'selector': {'matchLabels': {'app': 'myapp'}},
+			'template': {
+				'spec': {
+					'containers': [{'name': 'main', 'image': 'nginx:1'}],
+					'security': {'runAsNonRoot': true, 'fsGroup': 2000}
+				}
+			}
+		}
+	}.deepMerge({
+		'meta': {'name': 'foo', 'labels': {'tier': 'backend'}},
+		'spec': {
+			'replicas': 5,
+			'template': {
+				'spec': {
+					'security': {'runAsNonRoot': false, 'supplementalGroups': [1000, 2000]}
+				}
+			}
+		},
+		'status': {'phase': 'Running'}
+	})`
+	ast, iss := env.Compile(expr)
+	require.NoError(b, iss.Err())
+	prg, err := env.Program(ast)
+	require.NoError(b, err)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := prg.Eval(cel.NoVars())
+		require.NoError(b, err)
+	}
+}
+
+// evalCEL compiles and evaluates a CEL expression with no variables.
+func evalCEL(t *testing.T, env *cel.Env, expr string) ref.Val {
+	t.Helper()
+	return evalCELWithVars(t, env, expr, cel.NoVars())
+}
+
+// evalCELWithVars compiles and evaluates a CEL expression against vars.
+func evalCELWithVars(t *testing.T, env *cel.Env, expr string, vars any) ref.Val {
+	t.Helper()
+	ast, iss := env.Compile(expr)
+	require.NoError(t, iss.Err(), "compile %q", expr)
+	prg, err := env.Program(ast)
+	require.NoError(t, err, "program %q", expr)
+	out, _, err := prg.Eval(vars)
+	require.NoError(t, err, "eval %q", expr)
+	return out
+}
+
+// evalTrue parses, type-checks, and evaluates expr, requiring the result to be true
+// under both the parse-only and checked programs.
+func evalTrue(t *testing.T, env *cel.Env, expr string) {
+	t.Helper()
+	evalTrueWithVars(t, env, expr, nil)
+}
+
+// evalTrueWithVars compiles expr and requires it to evaluate to true against vars.
+// When vars is nil, both parse-only and type-checked programs are evaluated.
+func evalTrueWithVars(t *testing.T, env *cel.Env, expr string, vars any) {
+	t.Helper()
+
+	if vars == nil {
+		vars = cel.NoVars()
+		pAst, iss := env.Parse(expr)
+		require.NoError(t, iss.Err(), "parse %q", expr)
+		cAst, iss := env.Check(pAst)
+		require.NoError(t, iss.Err(), "check %q", expr)
+
+		for _, tc := range []struct {
+			label string
+			ast   *cel.Ast
+		}{
+			{label: "parse", ast: pAst},
+			{label: "check", ast: cAst},
+		} {
+			prg, err := env.Program(tc.ast)
+			require.NoError(t, err, "program(%s) %q", tc.label, expr)
+			out, _, err := prg.Eval(vars)
+			require.NoError(t, err, "eval(%s) %q", tc.label, expr)
+			require.Equal(t, true, out.Value(), "eval(%s) %q", tc.label, expr)
+		}
+		return
+	}
+
+	out := evalCELWithVars(t, env, expr, vars)
+	require.Equal(t, true, out.Value(), "eval %q", expr)
 }
 
 func testMapsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
@@ -71,8 +398,6 @@ func testMapsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 		Maps(),
 	}
 	env, err := cel.NewEnv(append(baseOpts, opts...)...)
-	if err != nil {
-		t.Fatalf("cel.NewEnv(Maps()) failed: %v", err)
-	}
+	require.NoError(t, err)
 	return env
 }

--- a/website/docs/docs/concepts/rgd/04-cel-libraries.md
+++ b/website/docs/docs/concepts/rgd/04-cel-libraries.md
@@ -28,7 +28,6 @@ kro includes a rich set of CEL function libraries from three sources: kro's own 
 | CIDR                        | kubernetes | [kro](#cidr), [Go doc](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#CIDR), [k8s.io](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-cidr-library) |
 | Semver                      | kubernetes | [kro](#semver), [Go doc](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#SemverLib), [k8s.io](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-semver-library) |
 
-
 ## kro Libraries
 
 ### Hash
@@ -36,7 +35,7 @@ kro includes a rich set of CEL function libraries from three sources: kro's own 
 Cryptographic and non-cryptographic hash functions. All return raw bytes; use `"%x".format(...)` for hex or `base64.encode()` for base64.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `hash.fnv64a(string)` | `bytes` | FNV-1a 64-bit hash. Fast, non-cryptographic. Recommended for most use cases. |
 | `hash.sha256(string)` | `bytes` | SHA-256 cryptographic hash. |
 | `hash.md5(string)` | `bytes` | MD5 hash. |
@@ -59,7 +58,7 @@ encoded: ${base64.encode(hash.fnv64a(schema.metadata.uid))}
 Parse and serialize JSON strings.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `json.unmarshal(string)` | `dyn` | Parse a JSON string into a CEL value (map, list, string, number, bool, or null). |
 | `json.marshal(dyn)` | `string` | Serialize a CEL value to a JSON string. |
 
@@ -81,7 +80,7 @@ configJson: ${json.marshal({"name": schema.spec.name, "replicas": schema.spec.re
 Deterministic random generation seeded by a stable value (e.g. resource UID), so results are reproducible across reconcile loops.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `random.seededString(int, string)` | `string` | Random alphanumeric string of given length, seeded by the second argument. |
 | `random.seededInt(int, int, string)` | `int` | Random integer in `[min, max)`, seeded by the third argument. |
 
@@ -100,8 +99,9 @@ port: ${random.seededInt(30000, 32768, schema.metadata.uid)}
 Map manipulation functions.
 
 | Function | Returns | Description |
-|---|---|---|
-| `<map>.merge(map)` | `map` | Merge two maps. Keys from the second map overwrite keys in the first. Keys must be strings. |
+| --- | --- | --- |
+| `<map>.merge(map)` | `map` | Merge two maps. Keys from the second map overwrite keys in the first. Keys must be strings; value types must match. |
+| `<map>.deepMerge(map)` | `dyn` | Like `merge`, but nested maps are merged recursively. Lists and scalars are replaced. Accepts `object`-typed values. |
 
 **Examples:**
 
@@ -111,6 +111,10 @@ labels: ${{"app": schema.spec.name, "managed-by": "kro"}.merge(schema.spec.extra
 
 # Layer overrides on top of defaults
 config: ${{"timeout": "30s", "retries": "3"}.merge(schema.spec.overrides)}
+
+# Layer nested defaults under a user-supplied object.
+# Preserves securityContext.fsGroup from podSpec and adds runAsNonRoot.
+spec: ${{"securityContext": {"runAsNonRoot": true}}.deepMerge(schema.spec.podSpec)}
 ```
 
 ### Index Mutation
@@ -118,7 +122,7 @@ config: ${{"timeout": "30s", "retries": "3"}.merge(schema.spec.overrides)}
 Pure list functions that return a new list without modifying the input.
 
 | Function | Signature | Description |
-|---|---|---|
+| --- | --- | --- |
 | `lists.setAtIndex` | `list(T), int, T -> list(T)` | Replace the element at `index`. Index must be in `[0, size(list))`. |
 | `lists.insertAtIndex` | `list(T), int, T -> list(T)` | Insert `value` before `index`. Use `index == size(list)` to append. Index must be in `[0, size(list)]`. |
 | `lists.removeAtIndex` | `list(T), int -> list(T)` | Remove the element at `index`. Index must be in `[0, size(list))`. |
@@ -164,7 +168,7 @@ The `runtime` variable builds and reads instance status conditions. It is only
 available in the schema's `status.conditions` block.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `runtime.newCondition({type, status, reason, message})` | `Condition` | Builds a condition. `type` and `status` are required; `status` must be `True`, `False`, or `Unknown`. |
 | `runtime.condition(schema, type)` | `Condition` | Reads kro's internal value for a built-in condition type (`Ready`, `InstanceManaged`, `GraphResolved`, `ResourcesReady`). |
 
@@ -180,7 +184,6 @@ available in the schema's `status.conditions` block.
 
 See [Custom Status Conditions](./06-status-conditions.md) for details.
 
-
 ## cel-go Libraries
 
 ### Strings
@@ -188,7 +191,7 @@ See [Custom Status Conditions](./06-status-conditions.md) for details.
 Extended string manipulation functions from [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `<string>.charAt(int)` | `string` | Character at position. |
 | `<string>.indexOf(string)` | `int` | Index of first occurrence, or `-1`. |
 | `<string>.indexOf(string, int)` | `int` | Same, starting search from offset. |
@@ -246,7 +249,7 @@ checksum: ${"%x".format([hash.sha256(schema.spec.data)])}
 Extended list manipulation functions from [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Lists).
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `<list>.slice(int, int)` | `list` | Sub-list from start (inclusive) to end (exclusive). |
 | `<list>.flatten()` | `list` | Flatten nested lists one level deep. |
 | `<list>.flatten(int)` | `list` | Flatten up to N levels. |
@@ -280,7 +283,7 @@ flat: ${schema.spec.nestedPorts.flatten()}
 Base64 encoding and decoding from [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Encoders).
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `base64.encode(bytes)` | `string` | Encode bytes to base64 string. |
 | `base64.decode(string)` | `bytes` | Decode base64 string to bytes. |
 
@@ -302,7 +305,7 @@ decoded: ${string(base64.decode(schema.spec.encodedValue))}
 Two-variable versions of list/map comprehension macros from [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#TwoVarComprehensions). These provide access to both the key/index and value in each iteration.
 
 | Macro | Description |
-|---|---|
+| --- | --- |
 | `<list\|map>.all(k, v, predicate)` | True if all entries satisfy the predicate. |
 | `<list\|map>.exists(k, v, predicate)` | True if any entry satisfies the predicate. |
 | `<list\|map>.existsOne(k, v, predicate)` | True if exactly one entry satisfies the predicate. |
@@ -340,7 +343,6 @@ envVars: ${{ "APP": "nginx", "PORT": "8080" }.transformList(k, v, k + "=" + v)}
 allDifferent: ${{ "hello": "world", "taco": "bell" }.all(k, v, k != v)}
 ```
 
-
 ## Kubernetes Libraries
 
 ### URLs
@@ -348,7 +350,7 @@ allDifferent: ${{ "hello": "world", "taco": "bell" }.all(k, v, k != v)}
 Parse and inspect URLs. The URL must be an absolute URI or an absolute path.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `url(string)` | `URL` | Parse a string into a URL. Errors if invalid. |
 | `isURL(string)` | `bool` | Returns true if the string is a valid URL. |
 | `<URL>.getScheme()` | `string` | Returns the URL scheme (e.g. `https`). Empty string if absent. |
@@ -376,7 +378,7 @@ port: ${url(database.status.endpoint).getPort()}
 Regular expression matching and extraction via [k8s.io/apiserver/pkg/cel/library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Regex).
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `<string>.find(string)` | `string` | Returns the first regex match, or empty string. |
 | `<string>.findAll(string)` | `list(string)` | Returns all non-overlapping matches. |
 | `<string>.findAll(string, int)` | `list(string)` | Returns up to N matches. |
@@ -403,7 +405,7 @@ version: ${schema.spec.image.find('[0-9]+\\.[0-9]+\\.[0-9]+')}
 Work with [Kubernetes resource quantities](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity) (e.g. `100m`, `1Gi`, `500Mi`).
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `quantity(string)` | `Quantity` | Parse a Kubernetes quantity string. |
 | `isQuantity(string)` | `bool` | True if the string is a valid quantity. |
 | `<Quantity>.add(Quantity\|int)` | `Quantity` | Sum of two quantities. |
@@ -438,7 +440,7 @@ megabytes: ${quantity(schema.spec.storageSize).asInteger()}
 Kubernetes-specific list utility functions from [k8s.io/apiserver/pkg/cel/library](https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Lists).
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `<list>.isSorted()` | `bool` | True if elements are in sorted order. |
 | `<list>.sum()` | `T` | Sum of numeric or duration elements. Returns `0` for empty lists. |
 | `<list>.min()` | `T` | Minimum element. Errors on empty list. |
@@ -468,7 +470,7 @@ idx: ${schema.spec.tags.indexOf("production")}
 Parse and inspect IPv4 and IPv6 addresses. IPv4-mapped IPv6 addresses and addresses with zones are not allowed.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `ip(string)` | `IP` | Parse a string into an IP address. Errors if invalid. |
 | `isIP(string)` | `bool` | Returns true if the string is a valid IPv4 or IPv6 address. |
 | `ip.isCanonical(string)` | `bool` | Returns true if the string is in canonical IP form. |
@@ -501,7 +503,7 @@ canonical: ${ip.isCanonical(schema.spec.ipv6Addr)}
 Parse and inspect CIDR subnet notation. Works with both IPv4 and IPv6.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `cidr(string)` | `CIDR` | Parse a CIDR string (e.g. `192.168.0.0/24`). Errors if invalid. |
 | `isCIDR(string)` | `bool` | Returns true if the string is valid CIDR notation. |
 | `<CIDR>.containsIP(string\|IP)` | `bool` | True if the CIDR contains the given IP. |
@@ -532,7 +534,7 @@ isSubnet: ${cidr('10.0.0.0/8').containsCIDR(schema.spec.vpcCIDR)}
 Parse and compare [semantic versions](https://semver.org). Supports optional normalization to handle common non-strict formats like `v1.0` or `01.02.03`.
 
 | Function | Returns | Description |
-|---|---|---|
+| --- | --- | --- |
 | `semver(string)` | `Semver` | Parse a strict semver string (e.g. `1.2.3`). |
 | `semver(string, bool)` | `Semver` | Parse with normalization (strips `v` prefix, fills missing parts, removes leading zeros). |
 | `isSemver(string)` | `bool` | Returns true if the string is a valid semver. |


### PR DESCRIPTION
## Summary

Adds `deepMerge` to the CEL maps library so nested defaults can be layered over user-supplied `object` fields (fixes #1343).

```cel
{"securityContext": {"runAsNonRoot": true}}.deepMerge(schema.spec.podSpec)
```

- Recursive nested-map merge; second map wins on leaf conflict (same bias as `merge`)
- Lists/scalars replaced wholesale
- `dyn` overload so it type-checks against schema `object` fields (unlike `merge`)
- Docs + unit tests (including the SecuredPod/unstructured runtime case)

## Test plan

- [x] `go test ./pkg/cel/library/ -count=1`
- [x] `go build ./...`
