### PR TITLE
helm: add extraEnv support to deployment template

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -117,6 +117,9 @@ spec:
               value: {{ .Values.config.leaderElectionRenewDeadline | quote }}
             - name: KRO_LEADER_ELECTION_RETRY_PERIOD
               value: {{ .Values.config.leaderElectionRetryPeriod | quote }}
+          {{- with .Values.deployment.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             {{- if .Values.config.allowCRDDeletion }}
             - --allow-crd-deletion

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -96,6 +96,8 @@ deployment:
   extraVolumes: []
   # Additional volume mount settings for Pods
   extraVolumeMounts: []
+  # Additional environment variables for the kro container
+  extraEnv: []
 
 # Debugging configuration settings
 # WARNING: pprof profiling endpoints expose sensitive performance data.


### PR DESCRIPTION
## Why

The chart declares `deployment.extraVolumes` and `deployment.extraVolumeMounts` in values.yaml and templates them (added recently), but there is no equivalent `deployment.extraEnv` for injecting additional environment variables into the kro container.

This is needed for use cases like pointing kro at a remote API server via `KUBECONFIG` env var when deploying kro on a separate cluster from the one it manages.

## What changed

- `helm/templates/deployment.yaml`: render `deployment.extraEnv` after the built-in env vars
- `helm/values.yaml`: add `deployment.extraEnv: []` default