### PR TITLE
test: raise coverage on pkg/cel/library and pkg/graph/crd/compat

### DIFF
--- a/pkg/cel/library/errors_coverage_test.go
+++ b/pkg/cel/library/errors_coverage_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every kro CEL function rejects bad arguments with a message naming the
+// function, because that message is what an RGD author sees when their
+// expression is wrong — a bare "no such overload" from cel-go would leave them
+// guessing which call failed.
+
+// assertCELErr asserts that val is a CEL error whose message contains want.
+func assertCELErr(t *testing.T, val ref.Val, want string) {
+	t.Helper()
+	require.True(t, types.IsError(val), "expected a CEL error, got %v", val)
+	assert.Contains(t, val.(*types.Err).String(), want)
+}
+
+func TestHashRejectsNonStringArguments(t *testing.T) {
+	t.Parallel()
+	cases := map[string]func(ref.Val) ref.Val{
+		"hash.fnv64a": fnv64aHash,
+		"hash.sha256": sha256Hash,
+		"hash.md5":    md5Hash,
+	}
+	for name, fn := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assertCELErr(t, fn(types.Bool(true)), name)
+			assertCELErr(t, fn(types.NewRefValList(
+				types.DefaultTypeAdapter, []ref.Val{types.String("a")})), name)
+		})
+	}
+}
+
+func TestJSONErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmarshal rejects a non-string argument", func(t *testing.T) {
+		t.Parallel()
+		assertCELErr(t, unmarshalJSON(types.Bool(true)), "json.unmarshal")
+	})
+
+	t.Run("unmarshal reports the parse failure", func(t *testing.T) {
+		t.Parallel()
+		assertCELErr(t, unmarshalJSON(types.String(`{"broken":`)), "failed to parse")
+	})
+
+	t.Run("unmarshal accepts valid JSON", func(t *testing.T) {
+		t.Parallel()
+		out := unmarshalJSON(types.String(`{"a":1}`))
+		require.False(t, types.IsError(out))
+	})
+
+	t.Run("marshal round-trips a list", func(t *testing.T) {
+		t.Parallel()
+		out := marshalJSON(types.NewRefValList(
+			types.DefaultTypeAdapter, []ref.Val{types.Int(1), types.Int(2)}))
+		require.False(t, types.IsError(out), "got %v", out)
+		assert.Equal(t, types.String("[1,2]"), out)
+	})
+}
+
+func TestMergeRejectsNonMaps(t *testing.T) {
+	t.Parallel()
+	m := types.NewStringStringMap(types.DefaultTypeAdapter, map[string]string{"a": "1"})
+
+	assertCELErr(t, mergeVals(types.String("not-a-map"), m), "no such overload")
+	assertCELErr(t, mergeVals(m, types.String("not-a-map")), "no such overload")
+}
+
+func TestSeededIntArgumentValidation(t *testing.T) {
+	t.Parallel()
+	seed := types.String("s")
+
+	assertCELErr(t, generateDeterministicInt(types.Int(0)), "exactly 3 arguments")
+	assertCELErr(t,
+		generateDeterministicInt(types.String("x"), types.Int(9), seed), "min must be an integer")
+	assertCELErr(t,
+		generateDeterministicInt(types.Int(0), types.String("x"), seed), "max must be an integer")
+	assertCELErr(t,
+		generateDeterministicInt(types.Int(0), types.Int(9), types.Int(1)), "seed must be a string")
+	assertCELErr(t,
+		generateDeterministicInt(types.Int(9), types.Int(9), seed), "min must be less than max")
+	assertCELErr(t,
+		generateDeterministicInt(types.Int(10), types.Int(9), seed), "min must be less than max")
+
+	// The same seed and bounds must always produce the same value; a seeded
+	// generator that drifted would make every dependent resource churn.
+	first := generateDeterministicInt(types.Int(0), types.Int(100), seed)
+	second := generateDeterministicInt(types.Int(0), types.Int(100), seed)
+	require.False(t, types.IsError(first), "got %v", first)
+	assert.Equal(t, first, second, "the same seed must yield the same value")
+}
+
+func TestSeededStringArgumentValidation(t *testing.T) {
+	t.Parallel()
+	seed := types.String("s")
+
+	assertCELErr(t, generateDeterministicString(types.String("8"), seed), "length must be an integer")
+	assertCELErr(t, generateDeterministicString(types.Int(0), seed), "length must be positive")
+	assertCELErr(t, generateDeterministicString(types.Int(-1), seed), "length must be positive")
+	assertCELErr(t, generateDeterministicString(types.Int(8), types.Int(1)), "seed must be a string")
+
+	first := generateDeterministicString(types.Int(8), seed)
+	require.False(t, types.IsError(first), "got %v", first)
+	assert.Equal(t, first, generateDeterministicString(types.Int(8), seed),
+		"the same seed must yield the same string")
+
+	// Longer than one sha256 digest can index, to exercise the rehash path.
+	long := generateDeterministicString(types.Int(64), seed)
+	require.False(t, types.IsError(long), "got %v", long)
+	assert.Len(t, string(long.(types.String)), 64)
+}
+
+func TestListIndexFunctionValidation(t *testing.T) {
+	t.Parallel()
+	list := types.NewRefValList(types.DefaultTypeAdapter,
+		[]ref.Val{types.String("a"), types.String("b")})
+
+	t.Run("setAtIndex", func(t *testing.T) {
+		t.Parallel()
+		assertCELErr(t, listsSetAtIndex(list, types.Int(0)), "expected 3 arguments")
+		assertCELErr(t, listsSetAtIndex(types.String("x"), types.Int(0), types.String("v")),
+			"must be a list")
+		assertCELErr(t, listsSetAtIndex(list, types.String("0"), types.String("v")),
+			"index must be an integer")
+		assertCELErr(t, listsSetAtIndex(list, types.Int(-1), types.String("v")), "out of bounds")
+		assertCELErr(t, listsSetAtIndex(list, types.Int(2), types.String("v")), "out of bounds")
+	})
+
+	t.Run("insertAtIndex", func(t *testing.T) {
+		t.Parallel()
+		assertCELErr(t, listsInsertAtIndex(list, types.Int(0)), "expected 3 arguments")
+		assertCELErr(t, listsInsertAtIndex(types.String("x"), types.Int(0), types.String("v")),
+			"must be a list")
+		assertCELErr(t, listsInsertAtIndex(list, types.String("0"), types.String("v")),
+			"index must be an integer")
+		assertCELErr(t, listsInsertAtIndex(list, types.Int(-1), types.String("v")), "out of bounds")
+		assertCELErr(t, listsInsertAtIndex(list, types.Int(3), types.String("v")), "out of bounds")
+
+		// Inserting at size() appends rather than erroring, unlike setAtIndex.
+		out := listsInsertAtIndex(list, types.Int(2), types.String("c"))
+		require.False(t, types.IsError(out), "got %v", out)
+		assert.Equal(t, types.Int(3), out.(traits.Lister).Size())
+	})
+
+	t.Run("removeAtIndex", func(t *testing.T) {
+		t.Parallel()
+		assertCELErr(t, listsRemoveAtIndex(types.String("x"), types.Int(0)), "must be a list")
+		assertCELErr(t, listsRemoveAtIndex(list, types.String("0")), "index must be an integer")
+		assertCELErr(t, listsRemoveAtIndex(list, types.Int(-1)), "out of bounds")
+		assertCELErr(t, listsRemoveAtIndex(list, types.Int(2)), "out of bounds")
+	})
+}
+
+// The version options select which function set a library exposes, so an
+// environment pinned to an older version keeps compiling expressions written
+// against it.
+func TestLibraryVersionOptions(t *testing.T) {
+	t.Parallel()
+
+	lists := &listsLibrary{}
+	assert.Equal(t, uint32(3), ListsVersion(3)(lists).version)
+
+	maps := &mapsLib{}
+	assert.Equal(t, uint32(2), MapsVersion(2)(maps).version)
+}
+
+// The Condition type is surfaced to CEL through a custom type provider, so the
+// provider has to report its field names and types and delegate everything else
+// to the wrapped provider.
+func TestConditionTypeProviderFieldNames(t *testing.T) {
+	t.Parallel()
+
+	p := &conditionTypeProvider{Provider: types.NewEmptyRegistry()}
+
+	names, found := p.FindStructFieldNames(ConditionTypeName)
+	require.True(t, found)
+	assert.ElementsMatch(t,
+		[]string{"type", "status", "reason", "message"}, names,
+		"the provider must report the wire field names authors write")
+
+	_, found = p.FindStructFieldNames("some.other.Type")
+	assert.False(t, found, "unknown types must fall through to the wrapped provider")
+
+	ft, found := p.FindStructFieldType(ConditionTypeName, "status")
+	require.True(t, found)
+	assert.Equal(t, types.StringType, ft.Type)
+
+	_, found = p.FindStructFieldType(ConditionTypeName, "nope")
+	assert.False(t, found, "an unknown Condition field must not resolve")
+}

--- a/pkg/cel/library/refval_coverage_test.go
+++ b/pkg/cel/library/refval_coverage_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
+)
+
+// The ref.Val protocol methods on kro's custom CEL values are called by cel-go
+// itself, not by kro, whenever an author's expression compares, converts, or
+// otherwise handles one of these values. They are easy to leave untested
+// precisely because nothing in kro calls them directly.
+
+func testCondition() *Condition {
+	return &Condition{
+		ConditionType: "Ready",
+		Status:        "True",
+		Reason:        "ResourcesReady",
+		Message:       "all resources applied",
+	}
+}
+
+func TestConditionConvertToNative(t *testing.T) {
+	t.Parallel()
+	c := testCondition()
+
+	t.Run("a map target yields the wire field names", func(t *testing.T) {
+		t.Parallel()
+		out, err := c.ConvertToNative(reflect.TypeOf(map[string]any{}))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"type":    "Ready",
+			"status":  "True",
+			"reason":  "ResourcesReady",
+			"message": "all resources applied",
+		}, out, "the map keys are the wire condition field names, not the Go field names")
+	})
+
+	t.Run("a pointer target yields the same instance", func(t *testing.T) {
+		t.Parallel()
+		out, err := c.ConvertToNative(reflect.TypeOf((*Condition)(nil)))
+		require.NoError(t, err)
+		assert.Same(t, c, out)
+	})
+
+	t.Run("a value target yields a copy", func(t *testing.T) {
+		t.Parallel()
+		out, err := c.ConvertToNative(reflect.TypeOf(Condition{}))
+		require.NoError(t, err)
+		copied, ok := out.(Condition)
+		require.True(t, ok)
+		assert.Equal(t, *c, copied)
+	})
+
+	t.Run("an unsupported target is an error, not a panic", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.ConvertToNative(reflect.TypeOf(""))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ConditionTypeName)
+	})
+}
+
+func TestConditionConvertToType(t *testing.T) {
+	t.Parallel()
+	c := testCondition()
+
+	assert.Same(t, c, c.ConvertToType(c.Type()),
+		"converting to its own type returns the value unchanged")
+
+	asType := c.ConvertToType(types.TypeType)
+	require.NotNil(t, asType)
+	assert.Equal(t, ConditionTypeName, asType.(*cel.Type).TypeName(),
+		"converting to type yields the Condition type itself")
+
+	assert.True(t, types.IsError(c.ConvertToType(types.StringType)),
+		"an unsupported conversion is a CEL error value")
+}
+
+func TestConditionEqual(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, types.True, testCondition().Equal(testCondition()),
+		"conditions with identical fields are equal")
+
+	other := testCondition()
+	other.Status = "False"
+	assert.Equal(t, types.False, testCondition().Equal(other),
+		"a differing field makes them unequal")
+
+	other = testCondition()
+	other.Message = "different"
+	assert.Equal(t, types.False, testCondition().Equal(other),
+		"equality covers message, not just type and status")
+
+	assert.True(t, types.IsError(testCondition().Equal(types.String("Ready"))),
+		"comparing a Condition to a non-Condition is a no-such-overload error")
+}
+
+func TestConditionTypeAndValue(t *testing.T) {
+	t.Parallel()
+	c := testCondition()
+	assert.Equal(t, ConditionTypeName, c.Type().TypeName())
+	assert.Same(t, c, c.Value())
+}
+
+// Get backs dot-notation field access in author expressions (cond.status).
+func TestConditionGet(t *testing.T) {
+	t.Parallel()
+	c := testCondition()
+
+	for key, want := range map[string]string{
+		"type":    "Ready",
+		"status":  "True",
+		"reason":  "ResourcesReady",
+		"message": "all resources applied",
+	} {
+		got := c.Get(types.String(key))
+		assert.Equal(t, types.String(want), got, "cond.%s", key)
+	}
+
+	assert.True(t, types.IsError(c.Get(types.String("nope"))),
+		"an unknown field is a CEL error naming the field")
+	assert.True(t, types.IsError(c.Get(types.Int(0))),
+		"a non-string key is a CEL error rather than a panic")
+}
+
+func TestRuntimeSingletonRefVal(t *testing.T) {
+	t.Parallel()
+
+	_, err := RuntimeSingleton.ConvertToNative(reflect.TypeOf(map[string]any{}))
+	require.Error(t, err, "the runtime singleton has no native representation")
+	assert.Contains(t, err.Error(), RuntimeTypeName)
+
+	assert.Same(t, RuntimeSingleton, RuntimeSingleton.ConvertToType(RuntimeSingleton.Type()),
+		"converting to its own type returns the singleton")
+
+	asType := RuntimeSingleton.ConvertToType(types.TypeType)
+	assert.Equal(t, RuntimeTypeName, asType.(*cel.Type).TypeName())
+
+	assert.True(t, types.IsError(RuntimeSingleton.ConvertToType(types.StringType)))
+
+	assert.Equal(t, types.True, RuntimeSingleton.Equal(RuntimeSingleton),
+		"the singleton equals itself")
+	assert.Equal(t, types.False, RuntimeSingleton.Equal(types.String("runtime")),
+		"and is not equal to an unrelated value")
+
+	assert.Equal(t, RuntimeTypeName, RuntimeSingleton.Type().TypeName())
+	assert.NotNil(t, RuntimeSingleton.Value())
+}
+
+// omit() is a field-removal sentinel, not a value. It deliberately refuses
+// comparison: if `omit() == omit()` returned true, an author could branch on it
+// and the resolver's remove-this-field contract would leak into expression
+// semantics.
+func TestOmitValRefVal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it converts to the sentinel struct", func(t *testing.T) {
+		t.Parallel()
+		out, err := omitInstance.ConvertToNative(reflect.TypeOf(sentinels.Omit{}))
+		require.NoError(t, err)
+		assert.Equal(t, sentinels.Omit{}, out)
+	})
+
+	t.Run("an interface target also yields the sentinel", func(t *testing.T) {
+		t.Parallel()
+		var iface any
+		out, err := omitInstance.ConvertToNative(reflect.TypeOf(&iface).Elem())
+		require.NoError(t, err)
+		assert.Equal(t, sentinels.Omit{}, out)
+	})
+
+	t.Run("any other native target is an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := omitInstance.ConvertToNative(reflect.TypeOf(""))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "omit")
+	})
+
+	t.Run("it converts to its type but not to others", func(t *testing.T) {
+		t.Parallel()
+		asType := omitInstance.ConvertToType(types.TypeType)
+		require.NotNil(t, asType)
+		assert.True(t, types.IsError(omitInstance.ConvertToType(types.StringType)))
+	})
+
+	t.Run("it refuses comparison", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, types.IsError(omitInstance.Equal(omitInstance)),
+			"omit() must not be comparable, even to itself")
+		assert.True(t, types.IsError(omitInstance.Equal(types.String("omit"))))
+	})
+
+	t.Run("its type and value are the sentinel", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "kro.omit", omitInstance.Type().TypeName())
+		assert.Equal(t, sentinels.Omit{}, omitInstance.Value())
+	})
+}
+
+// IsConditionType is how callers decide whether a checked expression's output
+// is a Condition, which gates author-condition handling.
+func TestIsConditionType(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsConditionType(nil), "a nil type must not be reported as a Condition")
+	assert.True(t, IsConditionType(conditionType))
+	assert.False(t, IsConditionType(cel.StringType))
+	assert.False(t, IsConditionType(runtimeType),
+		"the runtime singleton's type is not a Condition type")
+}

--- a/pkg/graph/crd/compat/changes_coverage_test.go
+++ b/pkg/graph/crd/compat/changes_coverage_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The Report predicates decide whether an RGD update is allowed through, and
+// the Description strings are the only explanation an author gets for a
+// rejection. Both were uncovered: a wrong predicate silently permits a breaking
+// update or blocks a safe one, and a wrong description leaves the author unable
+// to tell which field is at fault.
+
+func TestReportPredicates(t *testing.T) {
+	t.Parallel()
+
+	empty := &Report{}
+	assert.True(t, empty.IsCompatible())
+	assert.False(t, empty.HasBreakingChanges())
+	assert.False(t, empty.HasChanges())
+
+	nonBreaking := &Report{}
+	nonBreaking.AddNonBreakingChange("spec.replicas", PropertyAdded, "", "optional")
+	assert.True(t, nonBreaking.IsCompatible(),
+		"a non-breaking change must not block the update")
+	assert.False(t, nonBreaking.HasBreakingChanges())
+	assert.True(t, nonBreaking.HasChanges(),
+		"HasChanges must see non-breaking changes too, or a no-op update is indistinguishable")
+
+	breaking := &Report{}
+	breaking.AddBreakingChange("spec.name", PropertyRemoved, "string", "")
+	assert.False(t, breaking.IsCompatible())
+	assert.True(t, breaking.HasBreakingChanges())
+	assert.True(t, breaking.HasChanges())
+}
+
+func TestReportString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a compatible report says so explicitly", func(t *testing.T) {
+		t.Parallel()
+		r := &Report{}
+		r.AddNonBreakingChange("spec.a", PropertyAdded, "", "optional")
+		assert.Equal(t, "no breaking changes", r.String(),
+			"non-breaking changes must not be reported as breaking")
+	})
+
+	t.Run("changes are joined in order", func(t *testing.T) {
+		t.Parallel()
+		r := &Report{}
+		r.AddBreakingChange("spec.a", PropertyRemoved, "", "")
+		r.AddBreakingChange("spec.b", PropertyRemoved, "", "")
+		out := r.String()
+		assert.Equal(t, "Property a was removed; Property b was removed", out)
+	})
+
+	t.Run("exactly the summary limit is not truncated", func(t *testing.T) {
+		t.Parallel()
+		r := &Report{}
+		for _, p := range []string{"spec.a", "spec.b", "spec.c"} {
+			r.AddBreakingChange(p, PropertyRemoved, "", "")
+		}
+		out := r.String()
+		assert.NotContains(t, out, "more changes",
+			"a report at the limit must list every change")
+		assert.Equal(t, 3, strings.Count(out, "was removed"))
+	})
+
+	t.Run("beyond the limit the remainder is counted", func(t *testing.T) {
+		t.Parallel()
+		r := &Report{}
+		for _, p := range []string{"spec.a", "spec.b", "spec.c", "spec.d", "spec.e"} {
+			r.AddBreakingChange(p, PropertyRemoved, "", "")
+		}
+		out := r.String()
+		assert.Contains(t, out, "Property a was removed")
+		assert.Contains(t, out, "and 2 more changes",
+			"the count must cover every change past the limit")
+		assert.NotContains(t, out, "Property d",
+			"changes past the limit are summarised, not listed")
+	})
+}
+
+// lastPathComponent is what turns a JSON path into the property name an author
+// recognises, so it must never return an empty description for a real path.
+func TestLastPathComponent(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "replicas", lastPathComponent("spec.template.replicas"))
+	assert.Equal(t, "replicas", lastPathComponent("replicas"))
+	assert.Equal(t, "", lastPathComponent(""))
+}
+
+// Every ChangeType must produce a description that names what changed. A type
+// that fell through to the unknown-change fallback would tell the author
+// nothing useful, so each is asserted individually.
+func TestChangeDescriptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		change   Change
+		contains []string
+	}{
+		{"property removed", Change{Path: "spec.name", ChangeType: PropertyRemoved},
+			[]string{"Property", "name", "removed"}},
+		{"required property added", Change{Path: "spec.name", ChangeType: PropertyAdded, NewValue: "required"},
+			[]string{"Required property", "name", "added"}},
+		{"optional property added", Change{Path: "spec.name", ChangeType: PropertyAdded, NewValue: "optional"},
+			[]string{"Optional property", "name", "added"}},
+		{"type changed", Change{Path: "spec.n", ChangeType: TypeChanged, OldValue: "string", NewValue: "integer"},
+			[]string{"Type changed", "string", "integer"}},
+		{"required added", Change{Path: "spec", ChangeType: RequiredAdded, NewValue: "name"},
+			[]string{"name", "newly required"}},
+		{"required removed", Change{Path: "spec", ChangeType: RequiredRemoved, OldValue: "name"},
+			[]string{"name", "no longer required"}},
+		{"enum restricted", Change{Path: "spec.e", ChangeType: EnumRestricted, OldValue: "blue"},
+			[]string{"Enum value", "blue", "removed"}},
+		{"enum expanded", Change{Path: "spec.e", ChangeType: EnumExpanded, NewValue: "green"},
+			[]string{"Enum value", "green", "added"}},
+		{"pattern changed", Change{Path: "spec.p", ChangeType: PatternChanged, OldValue: "^a", NewValue: "^b"},
+			[]string{"pattern changed", "^a", "^b"}},
+		{"pattern added", Change{Path: "spec.p", ChangeType: PatternAdded, NewValue: "^b"},
+			[]string{"pattern", "^b", "added"}},
+		{"pattern removed", Change{Path: "spec.p", ChangeType: PatternRemoved, OldValue: "^a"},
+			[]string{"pattern", "^a", "removed"}},
+		{"required default removed", Change{Path: "spec.d", ChangeType: RequiredDefaultRemoved, OldValue: "d"},
+			[]string{"Default value removed", "required field"}},
+		{"description changed", Change{Path: "spec.d", ChangeType: DescriptionChanged, OldValue: "a", NewValue: "b"},
+			[]string{"Description", "changed"}},
+		{"default changed", Change{Path: "spec.d", ChangeType: DefaultChanged, OldValue: "1", NewValue: "2"},
+			[]string{"Default value was changed", "1", "2"}},
+
+		{"minimum added", Change{ChangeType: MinimumAdded, NewValue: "1"}, []string{"Minimum constraint", "added"}},
+		{"minimum removed", Change{ChangeType: MinimumRemoved, OldValue: "1"}, []string{"Minimum constraint", "removed"}},
+		{"minimum increased", Change{ChangeType: MinimumIncreased, OldValue: "1", NewValue: "2"}, []string{"Minimum was increased"}},
+		{"minimum decreased", Change{ChangeType: MinimumDecreased, OldValue: "2", NewValue: "1"}, []string{"Minimum was decreased"}},
+		{"maximum added", Change{ChangeType: MaximumAdded, NewValue: "9"}, []string{"Maximum constraint", "added"}},
+		{"maximum removed", Change{ChangeType: MaximumRemoved, OldValue: "9"}, []string{"Maximum constraint", "removed"}},
+		{"maximum increased", Change{ChangeType: MaximumIncreased, OldValue: "8", NewValue: "9"}, []string{"Maximum was increased"}},
+		{"maximum decreased", Change{ChangeType: MaximumDecreased, OldValue: "9", NewValue: "8"}, []string{"Maximum was decreased"}},
+
+		{"minlength added", Change{ChangeType: MinLengthAdded, NewValue: "1"}, []string{"MinLength constraint", "added"}},
+		{"minlength removed", Change{ChangeType: MinLengthRemoved, OldValue: "1"}, []string{"MinLength constraint", "removed"}},
+		{"minlength increased", Change{ChangeType: MinLengthIncreased, OldValue: "1", NewValue: "2"}, []string{"MinLength was increased"}},
+		{"minlength decreased", Change{ChangeType: MinLengthDecreased, OldValue: "2", NewValue: "1"}, []string{"MinLength was decreased"}},
+		{"maxlength added", Change{ChangeType: MaxLengthAdded, NewValue: "9"}, []string{"MaxLength constraint", "added"}},
+		{"maxlength removed", Change{ChangeType: MaxLengthRemoved, OldValue: "9"}, []string{"MaxLength constraint", "removed"}},
+		{"maxlength increased", Change{ChangeType: MaxLengthIncreased, OldValue: "8", NewValue: "9"}, []string{"MaxLength was increased"}},
+		{"maxlength decreased", Change{ChangeType: MaxLengthDecreased, OldValue: "9", NewValue: "8"}, []string{"MaxLength was decreased"}},
+
+		{"minitems added", Change{ChangeType: MinItemsAdded, NewValue: "1"}, []string{"MinItems constraint", "added"}},
+		{"minitems removed", Change{ChangeType: MinItemsRemoved, OldValue: "1"}, []string{"MinItems constraint", "removed"}},
+		{"minitems increased", Change{ChangeType: MinItemsIncreased, OldValue: "1", NewValue: "2"}, []string{"MinItems was increased"}},
+		{"minitems decreased", Change{ChangeType: MinItemsDecreased, OldValue: "2", NewValue: "1"}, []string{"MinItems was decreased"}},
+		{"maxitems added", Change{ChangeType: MaxItemsAdded, NewValue: "9"}, []string{"MaxItems constraint", "added"}},
+		{"maxitems removed", Change{ChangeType: MaxItemsRemoved, OldValue: "9"}, []string{"MaxItems constraint", "removed"}},
+		{"maxitems increased", Change{ChangeType: MaxItemsIncreased, OldValue: "8", NewValue: "9"}, []string{"MaxItems was increased"}},
+		{"maxitems decreased", Change{ChangeType: MaxItemsDecreased, OldValue: "9", NewValue: "8"}, []string{"MaxItems was decreased"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.change.Description()
+			require.NotEmpty(t, got)
+			assert.NotContains(t, got, "Unknown change",
+				"every declared ChangeType must have its own description")
+			for _, want := range tt.contains {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
+}
+
+// An unrecognised ChangeType still has to say something actionable, naming the
+// path so the author can find the field even when kro cannot classify it.
+func TestChangeDescriptionUnknownType(t *testing.T) {
+	t.Parallel()
+	got := Change{Path: "spec.mystery", ChangeType: ChangeType("SOMETHING_NEW")}.Description()
+	assert.Contains(t, got, "Unknown change")
+	assert.Contains(t, got, "spec.mystery",
+		"the fallback must still name the path")
+}


### PR DESCRIPTION
Additive tests only, no production code changes. Three new files, no existing file touched.

| package | before | after |
|---|---|---|
| `pkg/cel/library` | 75.7% | **92.1%** |
| `pkg/graph/crd/compat` | 73.7% | **97.9%** |

Both packages are pure logic with no cluster dependency, so this is all fast unit coverage.

## What's covered and why it matters

**`pkg/cel/library`, the ref.Val protocol (was mostly 0%).** `ConvertToNative`, `ConvertToType`, `Equal`, `Type`, `Value` and `Get` on `Condition`, the `runtime` singleton, and the `omit()` sentinel. These are invoked by cel-go itself whenever an author's expression compares or converts one of these values. Nothing in kro calls them directly, which is exactly why they were untested. An author expression reaching an unhandled branch surfaces as a confusing CEL error rather than a clear message.

Two behaviours worth calling out as now-pinned:
- `Condition.ConvertToNative` to a map yields the **wire** field names (`type`/`status`/`reason`/`message`), not the Go field names.
- `omit()` deliberately **refuses comparison**, including to itself. If `omit() == omit()` were true, an author could branch on it and the resolver's remove-this-field contract would leak into expression semantics.

**`pkg/cel/library`, argument validation.** Every kro CEL function rejects bad arguments with a message naming the function, because that message is what an RGD author sees when an expression is wrong; a bare "no such overload" from cel-go leaves them guessing which call failed. Covers `hash.{fnv64a,sha256,md5}`, `json.{marshal,unmarshal}`, map `merge`, `random.{seededInt,seededString}`, and `lists.{setAtIndex,insertAtIndex,removeAtIndex}`.

The seeded generators also assert determinism for a fixed seed, because a seeded generator that drifted would make every dependent resource churn on every reconcile. `seededString` is exercised past one sha256 digest to reach the rehash path. `insertAtIndex` at `size()` appends rather than erroring, unlike `setAtIndex`, so that asymmetry is pinned explicitly.

**`pkg/graph/crd/compat`, the breaking-change report.** The `Report` predicates decide whether an RGD update is allowed through, and the `Change` descriptions are the only explanation an author gets when one is rejected. A wrong predicate silently permits a breaking update or blocks a safe one; a wrong description leaves the author unable to tell which field is at fault.

All 36 declared `ChangeType` values are asserted to produce their own description, and each case also asserts it does *not* fall through to the unknown-change fallback, which is how a newly added `ChangeType` with no description arm gets caught. `Report.String`'s summary truncation is covered at, and past, the limit.

## Two dead-code observations

Not changed here, since they're behaviour-neutral cleanups better done deliberately.

1. In `pkg/cel/library/random.go`, `generateDeterministicString` validates `length` and `seed` twice. The second `length.(types.Int)` and `seed.(types.String)` assertions cannot fail after the earlier `Type()` checks, so three branches are unreachable. They are the only remaining uncovered lines in that function.

2. `pkg/cel/library/hash.go` and `json.go` share a shape: after `ConvertToNative` to a string type succeeds, the following `native.(string)` assertion cannot fail. Defensive, but dead, and it is why those functions cap below 100%.

## Verification

- `go test ./pkg/...` green.
- `golangci-lint run ./pkg/cel/... ./pkg/graph/...` with the repo's pinned `v2.11.4`: 0 issues.

