### PR TITLE
chore(deps): enable Dependabot version updates and widen module coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,3 +68,31 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # GitHub Actions. Every action in .github/workflows is pinned to a full commit
+  # SHA, which is the right supply-chain posture but makes a stale pin invisible
+  # — nobody reads a SHA and notices it is two years old. GitHub also retires
+  # action runtimes (node16 -> node20 -> ...), which breaks a frozen workflow
+  # outright rather than degrading it. Dependabot understands SHA pins and bumps
+  # the SHA along with its version comment.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      actions-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      actions-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,70 @@
 version: 2
 updates:
+  # Go modules. The repository contains four of them, and Dependabot only looks
+  # at the directories listed here — a module that is absent gets neither
+  # version nor security updates. /cmd/kro in particular builds a released
+  # binary.
   - package-ecosystem: "gomod"
     directories:
       - "/"
+      - "/cmd/kro"
+      - "/tools/krep-crawl"
+      - "/tools/lsp/server"
     schedule:
       interval: "weekly"
-    # Keep Go PR noise limited to grouped security fixes unless version updates
-    # are explicitly enabled later.
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
       go-security-updates:
         applies-to: security-updates
         patterns:
           - "*"
+      # Batch routine minor/patch bumps into one pull request. Majors are
+      # deliberately excluded so each arrives on its own and is reviewed on its
+      # own merits.
+      go-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # The Kubernetes libraries move as a set with each upstream release, and
+      # controller-runtime is pinned to a matching minor. Patch updates (CVE and
+      # bugfix backports) are welcome; minor and major bumps need to be a
+      # coordinated change across every module at once, not one bot PR at a time.
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
+  # npm: the documentation site and the LSP client extension.
   - package-ecosystem: "npm"
     directories:
       - "/tools/lsp/client"
       - "/website"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
       npm-security-updates:
         applies-to: security-updates
         patterns:
           - "*"
-
+      npm-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Config only; one file, two commits, no code changes.

## Context first: the current config is doing what it was built to do

Worth stating up front, because it changes what this PR is. `.github/dependabot.yml` was added in a single commit, `build: group Dependabot npm and Go security updates` (33d973ed, 2026-03-06). Its purpose was narrow and it has been serving it. The `open-pull-requests-limit: 0` is not an accident; it is the mechanism, and the inline comment says so directly:

> Keep Go PR noise limited to grouped security fixes unless version updates are explicitly enabled later.

So this is not a bug report. It is the "later" that comment anticipated, plus a scope question the original change did not set out to answer.

## Commit 1: enable version updates, cover every Go module

`open-pull-requests-limit: 0` disables version updates rather than throttling them, so for the last several months the only dependency PRs have been security fixes. This sets real limits.

Dependabot also only inspects the directories listed, and the repository has four Go modules where only the root was listed:

| module | dependencies | listed before |
|---|---|---|
| `/` | n/a | yes |
| `/cmd/kro` | 72 | no |
| `/tools/lsp/server` | 78 | no |
| `/tools/krep-crawl` | 2 | no |

On timing, since it affects how much of this was a decision: `/tools/krep-crawl` was added five days *after* the config landed, so it was never a candidate. The other two predate it by four and five months.

The consequence was larger than carrying stale transitive dependencies. Until #1356 landed, `cmd/kro` was pinned to `kro v0.8.1` and `tools/lsp/server` to `kro v0.4.1` with k8s 0.31; the CLI and the language server were validating ResourceGraphDefinitions against library semantics two and five minor versions behind the controller. Those are precisely the two modules nothing was watching.

To keep volume reasonable:

- Routine minor and patch bumps are grouped into one PR per ecosystem.
- Majors are excluded from the groups, so each arrives on its own and is reviewed on its own merits.
- `k8s.io/*` and `sigs.k8s.io/controller-runtime` are limited to patch updates only. They move as a set with each upstream Kubernetes release (`api`, `apimachinery` and `client-go` are all at `v0.36.3`, with controller-runtime at `v0.24.1` to match), so minor and major bumps want one coordinated change rather than a series of individual bot PRs.

Also sets an explicit conventional-commit prefix rather than relying on Dependabot inferring it from history.

## Commit 2: watch GitHub Actions versions (separate on purpose; drop it freely)

This one is a proposal, not a gap, and it is a separate commit so it can be dropped without touching commit 1. All three workflows in `.github/workflows` predate the config, so omitting the `github-actions` ecosystem was a choice made with them in view.

The case for watching them: every action is pinned to a full commit SHA, which is the right supply-chain posture but makes a stale pin invisible, since nobody reads a SHA and notices it is two years old. GitHub also retires action runtimes over time (node16 to node20, and so on), which breaks a frozen workflow outright rather than degrading it. Dependabot understands SHA pins and bumps the SHA along with its version comment.

The case against, which is real: a change confined to `.github/` triggers no Prow presubmit, since the presubmits are path-filtered to code. This PR is its own demonstration; it reports no checks. So an action bump would arrive with no CI signal, and one of the three workflows is `github-release.yaml`, where a bad bump would not surface until the next release. If that trade is not wanted, dropping this commit costs nothing and commit 1 stands alone as a valid two-ecosystem config.

## Not included

- **Helm charts.** Dependabot has no Helm ecosystem, so `helm/Chart.yaml` and the charts under `examples/` cannot be automated this way.
- **Docker.** No Dockerfiles in the tree, so no `docker` ecosystem is needed.

## Verification

GitHub validates this file only once it is on the default branch; errors then surface under Insights, Dependency graph, Dependabot. Verified locally that it parses as a version 2 config, that every listed directory contains the manifest its ecosystem expects, that every manifest in the tree is covered by some entry, that no limit is left at zero, and that commit 1 on its own is a valid config.

## Expected first run

Timing is good: #1356 has just brought every module current, so there is little for a first run to catch up on. Expect a small number of grouped PRs at most, bounded by the configured limits, then a steady state of roughly one or two grouped PRs a week.
