### PR TITLE
fix(simpleschema): sort synthesized CRD required fields for deterministic output

### DIFF
--- a/pkg/simpleschema/required_order_test.go
+++ b/pkg/simpleschema/required_order_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simpleschema
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The required list is collected by ranging over a map, so without an explicit
+// sort its order varies between processes. A synthesized CRD that differs only
+// in required[] ordering still produces a server-side-apply diff on every
+// reconcile, so the order has to be deterministic rather than merely
+// self-consistent.
+//
+// Asserting sortedness rather than comparing against a sorted copy is the point
+// here: the existing table tests sort both sides before comparing, so they pass
+// whether or not the implementation sorts.
+func TestToOpenAPISpecSortsRequiredFields(t *testing.T) {
+	// Field names deliberately not in alphabetical order in the source map, and
+	// enough of them that map iteration is unlikely to produce sorted output by
+	// chance.
+	obj := map[string]interface{}{
+		"zebra":    "string | required=true",
+		"alpha":    "string | required=true",
+		"mike":     "integer | required=true",
+		"bravo":    "boolean | required=true",
+		"yankee":   "string | required=true",
+		"charlie":  "integer | required=true",
+		"optional": "string",
+	}
+
+	schema, err := ToOpenAPISpec(obj, nil)
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	want := []string{"alpha", "bravo", "charlie", "mike", "yankee", "zebra"}
+	assert.Equal(t, want, schema.Required,
+		"required[] must be sorted so the synthesized CRD is byte-stable across builds")
+	assert.True(t, sort.StringsAreSorted(schema.Required))
+	assert.NotContains(t, schema.Required, "optional",
+		"a field without required=true must not appear in required[]")
+}
+
+// Nested objects synthesize their own required list, so the guarantee has to
+// hold at every level rather than only at the root.
+func TestToOpenAPISpecSortsNestedRequiredFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"config": map[string]interface{}{
+			"zulu":     "string | required=true",
+			"alpha":    "string | required=true",
+			"november": "integer | required=true",
+		},
+	}
+
+	schema, err := ToOpenAPISpec(obj, nil)
+	require.NoError(t, err)
+
+	nested, ok := schema.Properties["config"]
+	require.True(t, ok, "nested object must be present")
+	assert.Equal(t, []string{"alpha", "november", "zulu"}, nested.Required,
+		"a nested object's required[] must be sorted too")
+}
+
+// Repeated builds of the same input must agree. This is the property the e2e
+// suite depends on, and it is what fails in the field when the sort is missing,
+// since map iteration order varies per process rather than per call.
+func TestToOpenAPISpecRequiredIsStableAcrossBuilds(t *testing.T) {
+	obj := map[string]interface{}{
+		"delta":   "string | required=true",
+		"echo":    "string | required=true",
+		"foxtrot": "string | required=true",
+		"golf":    "string | required=true",
+		"hotel":   "string | required=true",
+	}
+
+	first, err := ToOpenAPISpec(obj, nil)
+	require.NoError(t, err)
+
+	for i := 0; i < 20; i++ {
+		again, err := ToOpenAPISpec(obj, nil)
+		require.NoError(t, err)
+		require.Equal(t, first.Required, again.Required,
+			"build %d produced a different required[] ordering", i)
+	}
+}

--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -17,6 +17,7 @@ package simpleschema
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -156,6 +157,11 @@ func (t *transformer) buildSchema(spec map[string]interface{}) (*extv1.JSONSchem
 	if len(schema.Required) == 0 && childHasDefault && schema.Default == nil {
 		schema.Default = &extv1.JSON{Raw: []byte("{}")}
 	}
+
+	// Field iteration above ranges over a map, so the required list is built in
+	// nondeterministic order. Sort it to keep the synthesized CRD stable across
+	// builds (avoids spurious server-side-apply diffs on re-reconcile).
+	sort.Strings(schema.Required)
 
 	return schema, nil
 }


### PR DESCRIPTION
Cherry-picked out of #1355, plus a regression test. The fix is authored by @jakobmoellerdev and authorship is preserved; the test commit is new.

This is a pre-existing bug with nothing to do with the Graph work, worth landing on its own rather than at file 150 of a 189-file review.

## The bug

`buildSchema` collects an object's required fields by ranging over a map, so `required[]` came out in arbitrary order. A synthesized instance CRD that differs only in `required[]` ordering still produces a server-side-apply diff, so kro rewrites the CRD on reconcile for no reason. It also flaked the `check-required-default-interactions` e2e, whose assertion compares `required[]` positionally.

The fix is `sort.Strings(schema.Required)` at the end of `buildSchema`, six lines including the comment.

## One refinement to the diagnosis

The original commit message describes the ordering as "stable within a controller process but flipping across restarts/deploys". Writing the test showed that is more forgiving than reality: Go randomizes map iteration order per range statement, not once per process, so two successive calls in the same process disagree. One of the new tests demonstrates it directly by building the same input twenty times.

So the spurious apply diff is reachable on any reconcile rather than only after a restart. That makes the fix more valuable than the flaking e2e alone suggested.

## Why there was no test

From the original commit message: "unit tests already sorted before comparing". The existing table tests in `transform_test.go` sort both sides before asserting, so they pass whether or not the implementation sorts. That is exactly how this went unnoticed, and it means the fix as extracted had nothing guarding it.

The added test asserts sortedness against an explicit expected order rather than against a sorted copy of the output:

- root object `required[]` is sorted
- a nested object's `required[]` is sorted, since every object level builds its own list
- twenty successive builds of the same input agree

All three fail if `sort.Strings` is removed. Verified by doing exactly that.

## Compatibility check

Reordering `required[]` could in principle trip kro's breaking-change detection and make every existing RGD report a spurious breaking change on upgrade. It does not: `compareRequiredFields` in `pkg/graph/crd/compat/schema.go` converts both sides to sets via `toStringSet` before comparing, so a pure reordering yields neither a breaking nor a non-breaking change. Worth stating explicitly since the failure mode would have been quiet and annoying.

## Verification

- `go test ./pkg/...` green, no failures
- `golangci-lint run ./pkg/simpleschema/...` with the repo's pinned v2.11.4: 0 issues
- the fix commit applied to main with no conflicts
