### PR TITLE
lint: bump golangci-lint to v2.12.2 and update lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - copyloopvar
     - dupl
     - errcheck
-    - goconst
     - gocyclo
     - govet
     - ineffassign
@@ -29,13 +28,48 @@ linters:
           - dupl
           - lll
         path: pkg/*
+      # Test files legitimately repeat fixture strings, use long table rows,
+      # and take fixed helper arguments — these linters are noise there.
+      # Same reasoning for the fixture generators under test/integration and
+      # the test-support scaffolding under pkg/testutil — they're test-suite
+      # scaffolding, just not named _test.go.
+      - linters:
+          - lll
+          - dupl
+          - unparam
+          - gocyclo
+        path: (_test\.go|^test/integration/.*\.go|^pkg/testutil/.*\.go)$
     paths:
       - third_party$
       - builtin$
       - examples$
   settings:
     goconst:
-      ignore-string-values: ["true","false"]
+      # Ignore protocol/schema vocabulary that recurs by nature — Kubernetes
+      # object field keys and JSON-Schema type names. Deduping these into named
+      # constants adds no clarity.
+      ignore-string-values:
+        - "true"
+        - "false"
+        - "apiVersion"
+        - "kind"
+        - "metadata"
+        - "name"
+        - "namespace"
+        - "spec"
+        - "status"
+        - "conditions"
+        - "labels"
+        - "annotations"
+        - "object"
+        - "string"
+        - "integer"
+        - "number"
+        - "boolean"
+        - "array"
+        - "map"
+        - "bool"
+        - "int"
     staticcheck:
       checks:
         - -QF1008

--- a/Makefile
+++ b/Makefile
@@ -167,18 +167,9 @@ test-coverage: ## Run all tests and report coverage
 	@echo "Combined:    $$(go tool cover -func=combined-cover.out | grep total | awk '{print $$NF}')"
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-# NB: golangci-lint 2.12.x publishes an SBOM alongside the tarball
-# (foo-linux-amd64.tar.gz.sbom.json). The bundled install.sh does a substring
-# grep against the checksums file and matches both entries, causing a spurious
-# checksum-mismatch error. Stay on 2.11.4 until the install script is fixed
-# upstream. See https://github.com/golangci/golangci-lint/blob/HEAD/install.sh
-# hash_sha256_verify().
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 golangci-lint:
-	@[ -f $(GOLANGCI_LINT) ] || { \
-	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION) ;\
-	}
+	@[ -f $(GOLANGCI_LINT) ] || GOBIN=$(shell dirname $(GOLANGCI_LINT)) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint


### PR DESCRIPTION
## Description

This PR splits out the linting and tooling improvements from #1355 into its own standalone PR:

1. **Bump golangci-lint to v2.12.2 via `go install`**:
   - `golangci-lint` v2.11.4 cannot lint a Go 1.26 module due to the built-with-older-Go guard, blocking `make lint`.
   - Bump to v2.12.2 and install via `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)` instead of the raw curl script, which avoids the SBOM substring-grep checksum mismatch bug in upstream's `install.sh`.
2. **Linter configuration updates**:
   - Disable `goconst` due to high false-positive noise on common identifiers and domain keywords in v2.12.2.
   - Exclude fixture-noise linters (`lll`, `dupl`, `unparam`, `gocyclo`) on test files, test fixture generators (`test/integration/`), and test utilities (`pkg/testutil/`).
   - Add standard Kubernetes object fields and JSON schema types to `ignore-string-values`.

## How Has This Been Tested?

- Verified `make lint` runs with 0 issues.
- Verified `go test ./pkg/...` passes.
