### PR TITLE
test: add coverage for unasserted RGD reconcile, ownership and upgrade contracts

### DIFF
--- a/pkg/metrics/register_families_test.go
+++ b/pkg/metrics/register_families_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// registeredFamilies is the set of metric family names Register installs.
+//
+// Metric names are part of kro's operator-facing surface: dashboards, alerts
+// and recording rules reference them by name. Dropping or renaming one is a
+// breaking change for whoever operates the controller, and it is invisible
+// both at compile time and at scrape time — a removed series simply stops
+// appearing, so panels go blank and alerts silently stop evaluating rather
+// than failing loudly.
+//
+// This list exists so that any such change has to be deliberate. If you add a
+// metric, add it here. If you remove or rename one, update this list in the
+// same commit and call the change out in the release notes so operators can
+// migrate their queries.
+var registeredFamilies = []string{
+	// CEL
+	"cel_expr_eval_duration_seconds",
+	"cel_expr_eval_total",
+
+	// Runtime
+	"runtime_collection_size",
+	"runtime_creation_duration_seconds",
+	"runtime_creation_total",
+	"runtime_node_eval_duration_seconds",
+	"runtime_node_eval_errors_total",
+	"runtime_node_eval_total",
+	"runtime_node_ignored_check_total",
+	"runtime_node_ignored_total",
+	"runtime_node_not_ready_total",
+	"runtime_node_ready_check_total",
+
+	// Dynamic controller
+	"dynamic_controller_gvr_count",
+	"dynamic_controller_handler_attach_total",
+	"dynamic_controller_handler_count_total",
+	"dynamic_controller_handler_detach_total",
+	"dynamic_controller_handler_errors_total",
+	"dynamic_controller_informer_events_total",
+	"dynamic_controller_informer_sync_duration_seconds",
+	"dynamic_controller_instance_watch_count",
+	"dynamic_controller_queue_length",
+	"dynamic_controller_reconcile_duration_seconds",
+	"dynamic_controller_reconcile_panics_total",
+	"dynamic_controller_reconcile_total",
+	"dynamic_controller_requeue_total",
+	"dynamic_controller_route_match_total",
+	"dynamic_controller_route_total",
+	"dynamic_controller_watch_count",
+	"dynamic_controller_watch_request_count",
+
+	// Instance controller
+	"instance_condition_current_status_seconds",
+	"instance_graph_resolution_failures_total",
+	"instance_graph_resolution_pending_total",
+	"instance_graph_resolution_success_total",
+	"instance_reconcile_duration_seconds",
+	"instance_reconcile_errors_total",
+	"instance_reconcile_total",
+	"instance_state_transitions_total",
+
+	// RGD controller
+	"rgd_deletion_duration_seconds",
+	"rgd_deletions_total",
+	"rgd_graph_build_duration_seconds",
+	"rgd_graph_build_errors_total",
+	"rgd_graph_build_total",
+	"rgd_graph_revision_gc_deleted_total",
+	"rgd_graph_revision_gc_errors_total",
+	"rgd_graph_revision_issue_total",
+	"rgd_graph_revision_registry_miss_total",
+	"rgd_graph_revision_resolution_total",
+	"rgd_graph_revision_wait_total",
+	"rgd_state_transitions_total",
+
+	// GraphRevision controller
+	"graph_revision_activation_deferred_total",
+	"graph_revision_compile_duration_seconds",
+	"graph_revision_compile_total",
+	"graph_revision_finalizer_evictions_total",
+	"graph_revision_status_update_errors_total",
+
+	// Schema resolver
+	"schema_resolver_api_call_duration_seconds",
+	"schema_resolver_cache_evictions_total",
+	"schema_resolver_cache_hits_total",
+	"schema_resolver_cache_misses_total",
+	"schema_resolver_cache_size",
+	"schema_resolver_errors_total",
+	"schema_resolver_singleflight_deduplicated_total",
+
+	// Revision registry
+	"graph_revision_registry_entries",
+	"graph_revision_registry_evictions_total",
+	"graph_revision_registry_transitions_total",
+
+	// Client-go
+	"rest_client_rate_limiter_duration_seconds",
+	"rest_client_request_duration_seconds",
+	"rest_client_request_retries_total",
+	"rest_client_request_size_bytes",
+	"rest_client_response_size_bytes",
+}
+
+// TestRegisterInstallsDocumentedFamilies asserts that Register installs every
+// metric family in registeredFamilies, and no others. Both directions matter:
+// a missing name means a series operators may depend on has disappeared, and
+// an unexpected name means a new metric was added without being recorded here.
+func TestRegisterInstallsDocumentedFamilies(t *testing.T) {
+	rec := &descRecorder{names: map[string]struct{}{}}
+	Register(rec)
+
+	want := map[string]struct{}{}
+	for _, name := range registeredFamilies {
+		want[name] = struct{}{}
+	}
+
+	var missing, unexpected []string
+	for name := range want {
+		if _, ok := rec.names[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	for name := range rec.names {
+		if _, ok := want[name]; !ok {
+			unexpected = append(unexpected, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+
+	if len(missing) > 0 {
+		t.Errorf("metric families are no longer registered: %v\n"+
+			"Removing a metric is a breaking change for dashboards and alerts. If this is "+
+			"intentional, drop the name from registeredFamilies in this file and note the "+
+			"removal in the release notes.", missing)
+	}
+	if len(unexpected) > 0 {
+		t.Errorf("metric families are registered but not documented here: %v\n"+
+			"Add them to registeredFamilies so the operator-facing metric surface stays "+
+			"reviewable.", unexpected)
+	}
+}
+
+// descRecorder is a prometheus.Registerer that records the fully-qualified
+// names a collector describes instead of collecting samples. Gathering from a
+// real registry would only surface families that already have observations,
+// which would make label-bearing counters invisible until first use.
+type descRecorder struct {
+	names map[string]struct{}
+}
+
+func (r *descRecorder) Register(c prometheus.Collector) error {
+	ch := make(chan *prometheus.Desc, 64)
+	go func() {
+		c.Describe(ch)
+		close(ch)
+	}()
+	for desc := range ch {
+		if name := fqNameOf(desc); name != "" {
+			r.names[name] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func (r *descRecorder) MustRegister(cs ...prometheus.Collector) {
+	for _, c := range cs {
+		if err := r.Register(c); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (r *descRecorder) Unregister(prometheus.Collector) bool { return false }
+
+// fqNameOf extracts a Desc's fully-qualified metric name. Desc keeps fqName
+// unexported and only exposes it through String(), which renders as
+// `Desc{fqName: "name", help: ...}`.
+func fqNameOf(d *prometheus.Desc) string {
+	const marker = `fqName: "`
+	s := d.String()
+	start := strings.Index(s, marker)
+	if start < 0 {
+		return ""
+	}
+	s = s[start+len(marker):]
+	end := strings.Index(s, `"`)
+	if end < 0 {
+		return ""
+	}
+	return s[:end]
+}

--- a/test/integration/suites/core/collection_behavior_test.go
+++ b/test/integration/suites/core/collection_behavior_test.go
@@ -1,0 +1,213 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// configuredMaxCollectionSize mirrors the RGDConfig the integration environment
+// installs (see test/integration/environment/setup.go). The collection cap is
+// an operator-facing setting, so the value the controller enforces has to be
+// the value it was given rather than a built-in default.
+const configuredMaxCollectionSize = 1000
+
+// Collection behavior that the existing forEach coverage does not reach.
+//
+//   - The configured collection cap is what gets enforced. Operators raise or
+//     lower it deliberately; silently enforcing a different number makes a
+//     tuned deployment behave unlike its configuration, and the effective limit
+//     can end up lower than what was asked for.
+//   - Drift correction has to cover every namespace a collection spans. A
+//     collection can template items into different namespaces, and an item is
+//     no less managed for living in the second one. If only part of a
+//     collection is watched, the rest drifts unnoticed while the instance keeps
+//     reporting that everything is ready.
+var _ = Describe("CollectionBehavior", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("enforces the configured collection size limit", func(ctx SpecContext) {
+		// 34 x 34 = 1156 items, above the configured cap. Nothing should be
+		// created, and the instance should say which limit it hit.
+		rgd := generator.NewResourceGraphDefinition("test-collection-cap",
+			generator.WithSchema(
+				"TestCollectionCap", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResourceCollection("configmaps", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-${string(i)}-${string(j)}",
+				},
+			},
+				[]krov1alpha1.ForEachDimension{
+					{"i": "${lists.range(34)}"},
+					{"j": "${lists.range(34)}"},
+				},
+				nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "collection-cap"
+		instance := newInstance("TestCollectionCap", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, instance)).To(Succeed())
+
+			conds := instanceConditions(instance)
+			g.Expect(conds).To(ContainSubstring(fmt.Sprintf("%d", configuredMaxCollectionSize)),
+				"the instance should report the configured collection limit of %d; conditions: %s",
+				configuredMaxCollectionSize, conds)
+		}, 60*time.Second, 2*time.Second).WithContext(ctx).Should(Succeed())
+
+		state, _, err := unstructured.NestedString(instance.Object, "status", "state")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(state).ToNot(Equal("ACTIVE"),
+			"an instance whose collection exceeds the cap must not report ACTIVE")
+	})
+
+	It("corrects drift on collection items in every namespace the collection spans", func(ctx SpecContext) {
+		altNamespace := fmt.Sprintf("alt-%s", namespace)
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: altNamespace},
+		})).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: altNamespace},
+			})
+		})
+
+		// Item 0 lands in the instance's namespace, item 1 in the other one.
+		rgd := generator.NewResourceGraphDefinition("test-collection-multi-ns-drift",
+			generator.WithSchema(
+				"TestCollectionMultiNsDrift", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+					"ns1":  "string",
+					"ns2":  "string",
+				},
+				nil,
+			),
+			generator.WithResourceCollection("configmaps", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "${schema.spec.name}-item-${string(i)}",
+					"namespace": "${i == 0 ? schema.spec.ns1 : schema.spec.ns2}",
+				},
+				"data": map[string]interface{}{
+					"managed": "expected",
+				},
+			},
+				[]krov1alpha1.ForEachDimension{
+					{"i": "${lists.range(2)}"},
+				},
+				nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "multi-ns-drift"
+		instance := newInstance("TestCollectionMultiNsDrift", name, namespace, map[string]interface{}{
+			"name": name,
+			"ns1":  namespace,
+			"ns2":  altNamespace,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+		items := map[string]string{
+			namespace:    name + "-item-0",
+			altNamespace: name + "-item-1",
+		}
+		for ns, cmName := range items {
+			Eventually(func(g Gomega, ctx SpecContext) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{
+					Name:      cmName,
+					Namespace: ns,
+				}, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKeyWithValue("managed", "expected"))
+			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		}
+
+		// Tamper with an item in each namespace in turn and expect both to be
+		// restored. The namespace an item happens to live in must not decide
+		// whether kro notices.
+		for ns, cmName := range items {
+			By(fmt.Sprintf("restoring drift on %s/%s", ns, cmName))
+
+			cm := &corev1.ConfigMap{}
+			Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      cmName,
+				Namespace: ns,
+			}, cm)).To(Succeed())
+			cm.Data["managed"] = "tampered"
+			Expect(env.Client.Update(ctx, cm)).To(Succeed())
+
+			Eventually(func(g Gomega, ctx SpecContext) {
+				current := &corev1.ConfigMap{}
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{
+					Name:      cmName,
+					Namespace: ns,
+				}, current)).To(Succeed())
+				g.Expect(current.Data).To(HaveKeyWithValue("managed", "expected"),
+					"drift on collection item %s/%s was not corrected", ns, cmName)
+			}, 60*time.Second, 2*time.Second).WithContext(ctx).Should(Succeed())
+		}
+	})
+})

--- a/test/integration/suites/core/instance_expression_isolation_test.go
+++ b/test/integration/suites/core/instance_expression_isolation_test.go
@@ -1,0 +1,284 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// Values inside an instance are data, not templates.
+//
+// An instance is written by the consumer of a kro-generated API, who knows the
+// schema but not the ResourceGraphDefinition behind it. Whatever they put in a
+// spec field or an annotation has to be carried through verbatim:
+//
+//   - Users legitimately store text that contains "${...}" — shell snippets,
+//     container commands, Grafana dashboards, config for a downstream
+//     templating engine. That text must survive a round trip unchanged.
+//   - Instance values must not be resolvable against the graph's resources.
+//     Resource ids are an internal detail of the definition, and resources can
+//     hold cluster state the instance's author has no access to, so a value
+//     that happens to name one must stay a plain string.
+//
+// Both properties are easy to lose the moment instance data is fed through the
+// same path as author-written templates, and neither fails loudly when it
+// breaks: the value is either rejected with an error about an identifier the
+// user never wrote, or silently replaced by something else entirely.
+var _ = Describe("InstanceExpressionIsolation", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("carries a literal ${...} in an instance spec field through to a managed resource", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-instance-literal-expr",
+			generator.WithSchema(
+				"TestInstanceLiteralExpr", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+					"note": "string",
+				},
+				nil,
+			),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-cm",
+				},
+				"data": map[string]interface{}{
+					"note": "${schema.spec.note}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		// A shell snippet is the most common way this shows up in practice.
+		const literal = "echo ${HOME} && echo ${NOT_A_RESOURCE.field}"
+
+		name := "literal-expr"
+		instance := newInstance("TestInstanceLiteralExpr", name, namespace, map[string]interface{}{
+			"name": name,
+			"note": literal,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+		cm := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name + "-cm",
+				Namespace: namespace,
+			}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("note", literal))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("reconciles an instance whose annotations contain a literal ${...}", func(ctx SpecContext) {
+		// Annotations are not covered by the generated CRD's schema, so they
+		// are the least constrained place a "${...}" can appear. An instance
+		// carrying one must still reconcile normally.
+		rgd := generator.NewResourceGraphDefinition("test-instance-annotation-expr",
+			generator.WithSchema(
+				"TestInstanceAnnotationExpr", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-cm",
+				},
+				"data": map[string]interface{}{
+					"name": "${schema.spec.name}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "annotation-expr"
+		instance := newInstance("TestInstanceAnnotationExpr", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(unstructured.SetNestedStringMap(instance.Object, map[string]string{
+			"example.com/command": "run ${SOME_VAR}",
+		}, "metadata", "annotations")).To(Succeed())
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+		cm := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name + "-cm",
+				Namespace: namespace,
+			}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("name", name))
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("does not resolve an instance value that names one of the definition's resources", func(ctx SpecContext) {
+		// "${secretCarrier.data.token}" is a valid expression when an author
+		// writes it in a template. Supplied as instance data it must stay a
+		// string: the instance's author is not the definition's author and
+		// should not be able to read a resource's contents by naming it.
+		rgd := generator.NewResourceGraphDefinition("test-instance-scope-isolation",
+			generator.WithSchema(
+				"TestInstanceScopeIsolation", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+					"note": "string",
+				},
+				nil,
+			),
+			generator.WithResource("secretCarrier", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-carrier",
+				},
+				"data": map[string]interface{}{
+					"token": "carrier-token-value",
+				},
+			}, nil, nil),
+			generator.WithResource("echo", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-echo",
+				},
+				"data": map[string]interface{}{
+					"note": "${schema.spec.note}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		const literal = "${secretCarrier.data.token}"
+
+		name := "scope-isolation"
+		instance := newInstance("TestInstanceScopeIsolation", name, namespace, map[string]interface{}{
+			"name": name,
+			"note": literal,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+		cm := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name + "-echo",
+				Namespace: namespace,
+			}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("note", literal))
+			g.Expect(cm.Data["note"]).NotTo(Equal("carrier-token-value"),
+				"the referenced resource's value must not be substituted into instance data")
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})
+
+// newInstance builds an unstructured instance of a kro-generated kind.
+func newInstance(kind, name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+// waitForInstanceState blocks until the instance reports the wanted
+// .status.state, surfacing its conditions on failure.
+func waitForInstanceState(
+	ctx SpecContext,
+	instance *unstructured.Unstructured,
+	name, namespace, want string,
+) {
+	Eventually(func(g Gomega, ctx SpecContext) {
+		g.Expect(env.Client.Get(ctx, types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}, instance)).To(Succeed())
+		state, _, err := unstructured.NestedString(instance.Object, "status", "state")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal(want), "instance conditions: %s", instanceConditions(instance))
+	}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+}
+
+// instanceConditions renders an instance's conditions as type=status(reason):
+// message, for use in failure output.
+func instanceConditions(instance *unstructured.Unstructured) string {
+	conds, _, err := unstructured.NestedSlice(instance.Object, "status", "conditions")
+	if err != nil || len(conds) == 0 {
+		return "<none>"
+	}
+	out := ""
+	for _, c := range conds {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		typ, _, _ := unstructured.NestedString(cond, "type")
+		status, _, _ := unstructured.NestedString(cond, "status")
+		reason, _, _ := unstructured.NestedString(cond, "reason")
+		msg, _, _ := unstructured.NestedString(cond, "message")
+		out += fmt.Sprintf("[%s=%s(%s): %s] ", typ, status, reason, msg)
+	}
+	return out
+}

--- a/test/integration/suites/core/reconcile_error_metrics_test.go
+++ b/test/integration/suites/core/reconcile_error_metrics_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/metrics"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// instance_reconcile_errors_total counts reconcile-level failures.
+//
+// The counter is what operators alert on to find instances the controller
+// cannot make progress on, so its scale has to stay stable: a resource-level
+// apply failure that the controller expects to retry is reported through the
+// instance's conditions, not by incrementing this counter. Otherwise a single
+// instance waiting on something external — a namespace that doesn't exist
+// yet, an admission webhook that is temporarily rejecting writes — produces
+// unbounded error counts, and any absolute threshold built on this series
+// starts firing on healthy-but-waiting workloads.
+var _ = Describe("ReconcileErrorMetrics", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("does not count a retryable resource apply failure as a reconcile error", func(ctx SpecContext) {
+		// The child targets a namespace that does not exist, so every apply
+		// fails with a retryable error for as long as the spec runs.
+		rgd := generator.NewResourceGraphDefinition("test-reconcile-error-metric",
+			generator.WithSchema(
+				"TestReconcileErrorMetric", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "${schema.spec.name}-cm",
+					"namespace": "does-not-exist-" + rand.String(5),
+				},
+				"data": map[string]interface{}{
+					"managed": "yes",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		gvr := schema.GroupVersionResource{
+			Group:    krov1alpha1.KRODomainName,
+			Version:  "v1alpha1",
+			Resource: "testreconcileerrormetrics",
+		}.String()
+		before := testutil.ToFloat64(metrics.InstanceReconcileErrorsTotal.WithLabelValues(gvr))
+
+		name := "reconcile-error-metric"
+		instance := newInstance("TestReconcileErrorMetric", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		// The failure has to be visible to the user, otherwise this spec would
+		// pass simply because nothing happened.
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, instance)).To(Succeed())
+			g.Expect(instanceConditions(instance)).To(ContainSubstring("does-not-exist"),
+				"the instance should report the failing apply; conditions: %s",
+				instanceConditions(instance))
+		}, 60*time.Second, 2*time.Second).WithContext(ctx).Should(Succeed())
+
+		// Give the controller several reconcile attempts, then check the counter
+		// did not track them.
+		Consistently(func(g Gomega, ctx SpecContext) {
+			current := testutil.ToFloat64(metrics.InstanceReconcileErrorsTotal.WithLabelValues(gvr))
+			g.Expect(current).To(Equal(before),
+				"a retryable apply failure incremented instance_reconcile_errors_total "+
+					"(%v -> %v); alerts with absolute thresholds on this series would fire "+
+					"for an instance that is merely waiting", before, current)
+		}, 20*time.Second, 2*time.Second).WithContext(ctx).Should(Succeed())
+	})
+})

--- a/test/integration/suites/core/resource_ownership_test.go
+++ b/test/integration/suites/core/resource_ownership_test.go
@@ -1,0 +1,213 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// How kro takes ownership of the resources it manages.
+//
+// Two properties, both about not losing track of what we own:
+//
+//   - The server-side-apply field manager is a compatibility surface. Which
+//     manager owns a field decides whether dropping that field from a template
+//     actually removes it from the live object: server-side apply only deletes
+//     fields the *same* manager previously owned. If the name changes between
+//     releases, every object created by an older version keeps its fields
+//     owned by a manager that will never apply again, and template removals
+//     silently stop taking effect on exactly those objects.
+//
+//   - Two instances that render the same object must not silently overwrite
+//     each other. Fixed resource names are easy to write by accident (a name
+//     that doesn't derive from the instance), and force-applying in a loop
+//     leaves both instances reporting healthy while the object flips between
+//     them on every reconcile.
+var _ = Describe("ResourceOwnership", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("applies managed resources under a stable field manager", func(ctx SpecContext) {
+		// The expected name is spelled out rather than read from
+		// applyset.FieldManager on purpose: referencing the constant would make
+		// this assertion follow a rename instead of catching it. If the manager
+		// name has to change, update it here and treat pre-existing objects as
+		// a migration concern — see the note above.
+		const expectedFieldManager = "kro.run/applyset"
+		Expect(applyset.FieldManager).To(Equal(expectedFieldManager),
+			"the field manager kro applies with has changed; objects created by "+
+				"earlier versions keep their fields owned by %q, which no longer "+
+				"applies, so template field removals will not take effect on them",
+			expectedFieldManager)
+
+		rgd := generator.NewResourceGraphDefinition("test-field-manager",
+			generator.WithSchema(
+				"TestFieldManager", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-cm",
+				},
+				"data": map[string]interface{}{
+					"managed": "yes",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "field-manager"
+		instance := newInstance("TestFieldManager", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+		cm := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name + "-cm",
+				Namespace: namespace,
+			}, cm)).To(Succeed())
+
+			managers := make([]string, 0, len(cm.GetManagedFields()))
+			ownsData := false
+			for _, entry := range cm.GetManagedFields() {
+				managers = append(managers, fmt.Sprintf("%s/%s", entry.Manager, entry.Operation))
+				if entry.Manager == expectedFieldManager &&
+					entry.Operation == metav1.ManagedFieldsOperationApply {
+					ownsData = true
+				}
+			}
+			g.Expect(ownsData).To(BeTrue(),
+				"no Apply entry for field manager %q on the managed resource; managedFields: %v",
+				expectedFieldManager, managers)
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("does not let two instances silently overwrite the same resource", func(ctx SpecContext) {
+		// The resource name is fixed, so both instances render the same object.
+		rgd := generator.NewResourceGraphDefinition("test-shared-target",
+			generator.WithSchema(
+				"TestSharedTarget", "v1alpha1",
+				map[string]interface{}{
+					"owner": "string",
+				},
+				nil,
+			),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "shared-target",
+				},
+				"data": map[string]interface{}{
+					"owner": "${schema.spec.owner}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		first := newInstance("TestSharedTarget", "owner-a", namespace, map[string]interface{}{
+			"owner": "a",
+		})
+		Expect(env.Client.Create(ctx, first)).To(Succeed())
+		waitForInstanceState(ctx, first, "owner-a", namespace, "ACTIVE")
+
+		cm := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      "shared-target",
+				Namespace: namespace,
+			}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("owner", "a"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+
+		firstApplySetID := cm.Labels[applyset.ApplysetPartOfLabel]
+		Expect(firstApplySetID).ToNot(BeEmpty(),
+			"managed resource should carry an ApplySet membership label")
+
+		// A second instance now claims the same object.
+		second := newInstance("TestSharedTarget", "owner-b", namespace, map[string]interface{}{
+			"owner": "b",
+		})
+		Expect(env.Client.Create(ctx, second)).To(Succeed())
+
+		// The established owner keeps the object, and its ApplySet membership
+		// label is not rewritten. Sampling over a window matters here: a single
+		// read can land between two competing writes and look stable.
+		Consistently(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      "shared-target",
+				Namespace: namespace,
+			}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("owner", "a"),
+				"the resource changed hands between instances")
+			g.Expect(cm.Labels).To(HaveKeyWithValue(applyset.ApplysetPartOfLabel, firstApplySetID),
+				"ApplySet membership was reassigned to a competing instance")
+		}, 20*time.Second, 2*time.Second).WithContext(ctx).Should(Succeed())
+
+		// And the contention is reported rather than hidden: the instance that
+		// could not take the resource must not claim to be reconciled.
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      "owner-b",
+				Namespace: namespace,
+			}, second)).To(Succeed())
+			state, _, err := unstructured.NestedString(second.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(state).ToNot(Equal("ACTIVE"),
+				"an instance that could not take ownership of its resource reports ACTIVE; "+
+					"conditions: %s", instanceConditions(second))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})

--- a/test/integration/suites/core/resource_pruning_test.go
+++ b/test/integration/suites/core/resource_pruning_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// Pruning a resource that left the definition must not depend on unrelated
+// resources being ready.
+//
+// Removing a resource from a ResourceGraphDefinition is how an author retires
+// something, and it has to take effect on existing instances. Readiness of the
+// *other* resources in the graph is a separate concern: a graph that contains
+// one permanently-unready resource is normal in a degraded environment, and it
+// must not pin retired resources in the cluster indefinitely.
+//
+// The failure mode is a silent leak. Nothing reports that a prune was skipped,
+// so the orphaned object simply stays, and the instance keeps reporting
+// whatever its readiness state was.
+var _ = Describe("ResourcePruning", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("prunes a removed resource while another resource is not ready", func(ctx SpecContext) {
+		// "gate" never satisfies its readyWhen, so the instance stays
+		// IN_PROGRESS for the whole spec. "retired" is removed from the
+		// definition partway through and must still be cleaned up.
+		newRGD := func(withRetired bool) *krov1alpha1.ResourceGraphDefinition {
+			opts := []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"TestPruneWhileUnready", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("gate", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "${schema.spec.name}-gate",
+					},
+					"data": map[string]interface{}{
+						"ready": "false",
+					},
+				}, []string{`${gate.data.ready == "true"}`}, nil),
+			}
+			if withRetired {
+				opts = append(opts, generator.WithResource("retired", map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "${schema.spec.name}-retired",
+					},
+					"data": map[string]interface{}{
+						"keep": "for-now",
+					},
+				}, nil, nil))
+			}
+			return generator.NewResourceGraphDefinition("test-prune-while-unready", opts...)
+		}
+
+		rgd := newRGD(true)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "prune-unready"
+		instance := newInstance("TestPruneWhileUnready", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		// Both resources exist, and the instance is held IN_PROGRESS by "gate".
+		for _, suffix := range []string{"-gate", "-retired"} {
+			Eventually(func(g Gomega, ctx SpecContext) {
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{
+					Name:      name + suffix,
+					Namespace: namespace,
+				}, &corev1.ConfigMap{})).To(Succeed())
+			}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		}
+		waitForInstanceState(ctx, instance, name, namespace, "IN_PROGRESS")
+
+		// Retire the resource.
+		Eventually(func(g Gomega, ctx SpecContext) {
+			current := &krov1alpha1.ResourceGraphDefinition{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, current)).To(Succeed())
+			current.Spec.Resources = newRGD(false).Spec.Resources
+			g.Expect(env.Client.Update(ctx, current)).To(Succeed())
+		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+		waitForRGDActive(ctx, rgd.Name)
+
+		// The retired resource is cleaned up even though "gate" is still not
+		// ready, and the still-declared resource is left alone.
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      name + "-retired",
+				Namespace: namespace,
+			}, &corev1.ConfigMap{})
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+				"resource removed from the definition was not pruned (err=%v); instance conditions: %s",
+				err, instanceConditions(instance))
+		}, 60*time.Second, 2*time.Second).WithContext(ctx).Should(Succeed())
+
+		Expect(env.Client.Get(ctx, types.NamespacedName{
+			Name:      name + "-gate",
+			Namespace: namespace,
+		}, &corev1.ConfigMap{})).To(Succeed(), "still-declared resource must not be pruned")
+	})
+})

--- a/test/integration/suites/core/resource_shape_compatibility_test.go
+++ b/test/integration/suites/core/resource_shape_compatibility_test.go
@@ -1,0 +1,422 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// Resource shapes a definition is allowed to reference or produce.
+//
+//   - API versions are opaque strings. Kubernetes only requires a CRD version
+//     to be a valid DNS label, and widely used operators pick names outside the
+//     vN[alpha|beta]N convention — Azure Service Operator versions every type
+//     as vNapiYYYYMMDD, and Google's Config Connector ships versions like
+//     v1p1beta1. kro must template and reference those types like any other.
+//   - A definition may create a CustomResourceDefinition. Shipping an operator
+//     or a set of CRDs as a kro API is an established pattern, and a CRD's
+//     openAPIV3Schema is a deeply nested, self-referential document, which
+//     makes it the most demanding template payload kro handles.
+//   - When a resource's namespace cannot be resolved, the error has to name the
+//     field the author must fix. A cluster-scoped instance gives its namespaced
+//     children no namespace to inherit, so an expression that yields an empty
+//     string is an authoring mistake, and the diagnostic is the only way to
+//     find it.
+var _ = Describe("ResourceShapeCompatibility", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	DescribeTable("templates a resource whose apiVersion is outside the vN convention",
+		func(ctx SpecContext, version, schemaKind string) {
+			group := fmt.Sprintf("shape%s.example.com", rand.String(5))
+			installTestCRD(ctx, group, version, "Widget", "widgets", apiextensionsv1.NamespaceScoped)
+
+			rgd := generator.NewResourceGraphDefinition("test-shape-"+rand.String(5),
+				generator.WithSchema(
+					schemaKind, "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithResource("widget", map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", group, version),
+					"kind":       "Widget",
+					"metadata": map[string]interface{}{
+						"name": "${schema.spec.name}-widget",
+					},
+					"spec": map[string]interface{}{
+						"size": "large",
+					},
+				}, nil, nil),
+			)
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+			})
+			waitForRGDActive(ctx, rgd.Name)
+
+			name := "shape-version"
+			instance := newInstance(schemaKind, name, namespace, map[string]interface{}{
+				"name": name,
+			})
+			Expect(env.Client.Create(ctx, instance)).To(Succeed())
+			waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+			widget := &unstructured.Unstructured{}
+			widget.SetGroupVersionKind(schemaGVK(group, version, "Widget"))
+			Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name + "-widget",
+				Namespace: namespace,
+			}, widget)).To(Succeed())
+		},
+		// Azure Service Operator's convention.
+		Entry("date-stamped version", "v1api20200601", "TestShapeDateVersion"),
+		// Google Config Connector's convention.
+		Entry("patch-qualified version", "v1p1beta1", "TestShapePatchVersion"),
+	)
+
+	It("resolves an external reference whose apiVersion is outside the vN convention", func(ctx SpecContext) {
+		group := fmt.Sprintf("shaperef%s.example.com", rand.String(5))
+		const version = "v1api20200601"
+		installTestCRD(ctx, group, version, "Widget", "widgets", apiextensionsv1.NamespaceScoped)
+
+		existing := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", group, version),
+			"kind":       "Widget",
+			"metadata": map[string]interface{}{
+				"name":      "existing-widget",
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"size": "small",
+			},
+		}}
+		Expect(env.Client.Create(ctx, existing)).To(Succeed())
+
+		rgd := generator.NewResourceGraphDefinition("test-shape-ref-"+rand.String(5),
+			generator.WithSchema(
+				"TestShapeRefVersion", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			generator.WithExternalRef("widget", &krov1alpha1.ExternalRef{
+				APIVersion: fmt.Sprintf("%s/%s", group, version),
+				Kind:       "Widget",
+				Metadata: krov1alpha1.ExternalRefMetadata{
+					Name:      "existing-widget",
+					Namespace: namespace,
+				},
+			}, nil, nil),
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-cm",
+				},
+				"data": map[string]interface{}{
+					"size": "${widget.spec.size}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "shape-ref"
+		instance := newInstance("TestShapeRefVersion", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+		cm := &corev1.ConfigMap{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name + "-cm",
+				Namespace: namespace,
+			}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("size", "small"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("creates a CustomResourceDefinition declared by a definition", func(ctx SpecContext) {
+		group := fmt.Sprintf("crdtpl%s.example.com", rand.String(5))
+		crdName := "gadgets." + group
+
+		rgd := generator.NewResourceGraphDefinition("test-crd-template-"+rand.String(5),
+			generator.WithSchema(
+				"TestCRDTemplate", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				nil,
+			),
+			// A representative CRD payload: a versioned, structural schema with
+			// descriptions and nested properties, as generated by controller-gen.
+			generator.WithResource("gadgetCRD", map[string]interface{}{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata": map[string]interface{}{
+					"name": crdName,
+				},
+				"spec": map[string]interface{}{
+					"group": group,
+					"scope": "Namespaced",
+					"names": map[string]interface{}{
+						"kind":     "Gadget",
+						"listKind": "GadgetList",
+						"plural":   "gadgets",
+						"singular": "gadget",
+					},
+					"versions": []interface{}{
+						map[string]interface{}{
+							"name":    "v1alpha1",
+							"served":  true,
+							"storage": true,
+							"schema": map[string]interface{}{
+								"openAPIV3Schema": map[string]interface{}{
+									"description": "Gadget is a test resource.",
+									"type":        "object",
+									"properties": map[string]interface{}{
+										"apiVersion": map[string]interface{}{
+											"description": "APIVersion defines the versioned schema of this representation.",
+											"type":        "string",
+										},
+										"kind": map[string]interface{}{
+											"description": "Kind is a string value representing the REST resource.",
+											"type":        "string",
+										},
+										"metadata": map[string]interface{}{
+											"type": "object",
+										},
+										"spec": map[string]interface{}{
+											"description": "GadgetSpec defines the desired state.",
+											"type":        "object",
+											"properties": map[string]interface{}{
+												"size": map[string]interface{}{
+													"description": "Size of the gadget.",
+													"type":        "string",
+												},
+											},
+										},
+										"status": map[string]interface{}{
+											"description": "GadgetStatus defines the observed state.",
+											"type":        "object",
+											"properties": map[string]interface{}{
+												"ready": map[string]interface{}{
+													"type": "boolean",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "crd-template"
+		instance := newInstance("TestCRDTemplate", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: crdName},
+			})
+		})
+
+		waitForInstanceState(ctx, instance, name, namespace, "ACTIVE")
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: crdName}, crd)).To(Succeed())
+			g.Expect(crd.Spec.Names.Kind).To(Equal("Gadget"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("names the unresolved field when a cluster-scoped instance's child namespace is empty", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-unresolved-namespace",
+			generator.WithSchema(
+				"TestUnresolvedNamespace", "v1alpha1",
+				map[string]interface{}{
+					"name":            "string",
+					"targetNamespace": "string",
+				},
+				nil,
+				generator.WithScope(krov1alpha1.ResourceScopeCluster),
+			),
+			// A cluster-scoped instance gives namespaced children nothing to
+			// inherit, so this expression yielding "" is an authoring mistake.
+			generator.WithResource("cm", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "${schema.spec.name}-cm",
+					"namespace": "${schema.spec.targetNamespace}",
+				},
+				"data": map[string]interface{}{
+					"managed": "yes",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "unresolved-ns-" + rand.String(4)
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TestUnresolvedNamespace",
+				"metadata": map[string]interface{}{
+					"name": name,
+				},
+				"spec": map[string]interface{}{
+					"name":            name,
+					"targetNamespace": "",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			_ = env.Client.Delete(ctx, instance)
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name}, instance)).To(Succeed())
+			conds := instanceConditions(instance)
+			g.Expect(conds).To(ContainSubstring("metadata.namespace"),
+				"the failure should name the field the author has to fix; conditions: %s", conds)
+		}, 60*time.Second, 2*time.Second).WithContext(ctx).Should(Succeed())
+	})
+})
+
+// installTestCRD creates a minimal CRD for use as a template or reference
+// target and waits for it to be Established, removing it when the spec ends.
+func installTestCRD(
+	ctx SpecContext,
+	group, version, kind, plural string,
+	scope apiextensionsv1.ResourceScope,
+) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: plural + "." + group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Scope: scope,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     kind,
+				ListKind: kind + "List",
+				Plural:   plural,
+				Singular: strings.ToLower(kind),
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    version,
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec": {
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"size": {Type: "string"},
+								},
+							},
+							"status": {
+								Type:                   "object",
+								XPreserveUnknownFields: ptrTrue(),
+							},
+						},
+					},
+				},
+				Subresources: &apiextensionsv1.CustomResourceSubresources{
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+				},
+			}},
+		},
+	}
+	Expect(env.Client.Create(ctx, crd)).To(Succeed())
+	DeferCleanup(func(ctx SpecContext) {
+		_ = env.Client.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: crd.Name},
+		})
+	})
+
+	Eventually(func(g Gomega, ctx SpecContext) {
+		current := &apiextensionsv1.CustomResourceDefinition{}
+		g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: crd.Name}, current)).To(Succeed())
+		established := false
+		for _, cond := range current.Status.Conditions {
+			if cond.Type == apiextensionsv1.Established &&
+				cond.Status == apiextensionsv1.ConditionTrue {
+				established = true
+			}
+		}
+		g.Expect(established).To(BeTrue(), "CRD %s is not Established", crd.Name)
+	}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+}
+
+func ptrTrue() *bool {
+	v := true
+	return &v
+}
+
+// schemaGVK builds a GroupVersionKind for the test CRDs above.
+func schemaGVK(group, version, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
+}

--- a/test/integration/suites/core/status_array_projection_test.go
+++ b/test/integration/suites/core/status_array_projection_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// Status fields declared as arrays must be projected as arrays.
+//
+// A status block is a nested document, and an author can put expressions
+// anywhere in it — including inside a list, which is how you expose a set of
+// endpoints, addresses or names. The projected instance status has to keep
+// that shape: an expression at endpoints[0] belongs in an array under
+// "endpoints", not under a key literally named "endpoints[0]".
+//
+// This one is worth pinning because the failure mode is silent. A field
+// written to the wrong path is dropped by the generated CRD's structural
+// schema, so the instance still reports healthy and the status field simply
+// never appears — no error, no condition, nothing in the logs.
+var _ = Describe("StatusArrayProjection", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("projects a top-level array of expressions as an array", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-status-array",
+			generator.WithSchema(
+				"TestStatusArray", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				map[string]interface{}{
+					"endpoints": []interface{}{
+						"${primary.metadata.name}",
+						"${secondary.metadata.name}",
+					},
+				},
+			),
+			generator.WithResource("primary", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-primary",
+				},
+			}, nil, nil),
+			generator.WithResource("secondary", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-secondary",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "status-array"
+		instance := newInstance("TestStatusArray", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, instance)).To(Succeed())
+
+			endpoints, found, err := unstructured.NestedStringSlice(instance.Object, "status", "endpoints")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue(),
+				"status.endpoints must be projected as an array; conditions: %s",
+				instanceConditions(instance))
+			g.Expect(endpoints).To(ConsistOf(name+"-primary", name+"-secondary"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("projects an array nested under an object as an array", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-status-nested-array",
+			generator.WithSchema(
+				"TestStatusNestedArray", "v1alpha1",
+				map[string]interface{}{
+					"name": "string",
+				},
+				map[string]interface{}{
+					"network": map[string]interface{}{
+						"names": []interface{}{
+							"${primary.metadata.name}",
+						},
+					},
+				},
+			),
+			generator.WithResource("primary", map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "${schema.spec.name}-primary",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		name := "status-nested-array"
+		instance := newInstance("TestStatusNestedArray", name, namespace, map[string]interface{}{
+			"name": name,
+		})
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, instance)).To(Succeed())
+
+			names, found, err := unstructured.NestedStringSlice(instance.Object, "status", "network", "names")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue(),
+				"status.network.names must be projected as an array; conditions: %s",
+				instanceConditions(instance))
+			g.Expect(names).To(ConsistOf(name + "-primary"))
+		}, 30*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+})

--- a/test/upgrade/fixtures/template-shrink/instance.yaml
+++ b/test/upgrade/fixtures/template-shrink/instance.yaml
@@ -1,0 +1,7 @@
+apiVersion: kro.run/v1alpha1
+kind: UpgradeTemplateShrink
+metadata:
+  name: test-template-shrink
+  namespace: upgrade-test
+spec:
+  name: test-template-shrink

--- a/test/upgrade/fixtures/template-shrink/rgd.yaml
+++ b/test/upgrade/fixtures/template-shrink/rgd.yaml
@@ -1,0 +1,24 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: upgrade-template-shrink
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: UpgradeTemplateShrink
+    spec:
+      name: string
+  resources:
+  # Both data keys are written by the version that applies this fixture.
+  # The post-upgrade spec removes "removable" from the template and expects it
+  # to disappear from this already-existing object, while "keep" is untouched.
+  - id: configmap
+    template:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ${schema.spec.name}-configmap
+        namespace: ${schema.metadata.namespace}
+      data:
+        keep: retained
+        removable: remove-me

--- a/test/upgrade/mutation_test.go
+++ b/test/upgrade/mutation_test.go
@@ -236,8 +236,8 @@ var _ = ginkgo.Describe("Post-Upgrade RGD Mutation", ginkgo.Ordered, func() {
 			ginkgo.GinkgoLogr.Info("No pre-upgrade snapshot available, checking relative counts only")
 
 			for rgdName, count := range grCountPerRGD {
-				if rgdName == mutationRGDName {
-					continue // we already verified this one got +1
+				if rgdName == mutationRGDName || rgdName == shrinkRGDName {
+					continue // deliberately mutated by a post-upgrade suite
 				}
 				// For pre-GR upgrades, each RGD should have exactly 1 GR.
 				// For GR-aware upgrades, we don't know the exact count without
@@ -255,8 +255,9 @@ var _ = ginkgo.Describe("Post-Upgrade RGD Mutation", ginkgo.Ordered, func() {
 		// Skip RGDs intentionally mutated by other post-upgrade test suites:
 		//   - mutationRGDName: mutated by this suite (expected +1 GR)
 		//   - retentionRGDName: mutated by the rapid-mutations suite (GC'd to maxGraphRevisions)
+		//   - shrinkRGDName: mutated by the template-shrink suite (expected +1 GR)
 		for rgdName, currentCount := range grCountPerRGD {
-			if rgdName == mutationRGDName || rgdName == retentionRGDName {
+			if rgdName == mutationRGDName || rgdName == retentionRGDName || rgdName == shrinkRGDName {
 				continue
 			}
 			preCount := snapshot.GRCountPerRGD[rgdName]

--- a/test/upgrade/template_shrink_test.go
+++ b/test/upgrade/template_shrink_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade_test
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+)
+
+const (
+	shrinkTimeout  = 2 * time.Minute
+	shrinkInterval = 2 * time.Second
+
+	shrinkRGDName        = "upgrade-template-shrink"
+	shrinkResourceID     = "configmap"
+	shrinkConfigMapName  = "test-template-shrink-configmap"
+	shrinkInstanceNS     = "upgrade-test"
+	shrinkRemovableKey   = "removable"
+	shrinkRetainedKey    = "keep"
+	shrinkRetainedValue  = "retained"
+	shrinkRemovableValue = "remove-me"
+)
+
+// Removing a field from a template has to take effect on resources that were
+// created by the version we upgraded from.
+//
+// kro applies managed resources with server-side apply, which only clears
+// fields the same field manager set previously. Everything about that is
+// version-sensitive: if a release changes the field manager it applies under,
+// objects created by an earlier release keep their fields owned by a manager
+// that never applies again, and dropping a field from a template silently stops
+// removing it from exactly those objects — the pre-existing ones. New objects
+// behave correctly, which makes the divergence easy to miss.
+//
+// Adding a field is already covered by the RGD mutation checks. This is the
+// other direction, which is the one that depends on field ownership carrying
+// across the upgrade.
+var _ = ginkgo.Describe("Post-Upgrade Template Shrink", ginkgo.Ordered, func() {
+	ginkgo.BeforeAll(func() {
+		if !isPostUpgrade() {
+			ginkgo.Skip("Template shrink checks only run in post-upgrade mode")
+		}
+	})
+
+	ginkgo.It("should start from a resource carrying both template fields", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			cm := &corev1.ConfigMap{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      shrinkConfigMapName,
+				Namespace: shrinkInstanceNS,
+			}, cm)).To(gomega.Succeed())
+			g.Expect(cm.Data).To(gomega.HaveKeyWithValue(shrinkRetainedKey, shrinkRetainedValue))
+			g.Expect(cm.Data).To(gomega.HaveKeyWithValue(shrinkRemovableKey, shrinkRemovableValue),
+				"the pre-upgrade fixture should have created both data keys")
+		}, shrinkTimeout, shrinkInterval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should remove the field from the RGD template", func() {
+		rgd := &krov1alpha1.ResourceGraphDefinition{}
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: shrinkRGDName}, rgd)).To(gomega.Succeed())
+
+		var patched bool
+		for i, res := range rgd.Spec.Resources {
+			if res == nil || res.ID != shrinkResourceID {
+				continue
+			}
+
+			var template map[string]interface{}
+			gomega.Expect(json.Unmarshal(res.Template.Raw, &template)).To(gomega.Succeed())
+
+			data, ok := template["data"].(map[string]interface{})
+			gomega.Expect(ok).To(gomega.BeTrue(), "template should carry a data block")
+			delete(data, shrinkRemovableKey)
+
+			raw, err := json.Marshal(template)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			rgd.Spec.Resources[i].Template.Raw = raw
+			patched = true
+			break
+		}
+		gomega.Expect(patched).To(gomega.BeTrue(),
+			"should have found resource %q to patch", shrinkResourceID)
+
+		gomega.Expect(k8sClient.Update(ctx, rgd)).To(gomega.Succeed())
+		ginkgo.GinkgoLogr.Info("removed template field", "rgd", shrinkRGDName, "key", shrinkRemovableKey)
+	})
+
+	ginkgo.It("should see the RGD return to Active after the change", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			rgd := &krov1alpha1.ResourceGraphDefinition{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: shrinkRGDName}, rgd)).To(gomega.Succeed())
+			g.Expect(rgd.Status.State).To(gomega.Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			for _, cond := range rgd.Status.Conditions {
+				if string(cond.Type) == legacyConditionResourceGraphAccepted {
+					continue
+				}
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue),
+					"Condition %s should be True", cond.Type)
+			}
+		}, shrinkTimeout, shrinkInterval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should drop the removed field from the pre-upgrade resource", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			cm := &corev1.ConfigMap{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      shrinkConfigMapName,
+				Namespace: shrinkInstanceNS,
+			}, cm)).To(gomega.Succeed())
+
+			g.Expect(cm.Data).NotTo(gomega.HaveKey(shrinkRemovableKey),
+				"field removed from the template is still present on a resource created "+
+					"before the upgrade; managed fields: %s", managedFieldSummary(cm))
+
+			// Guard against the opposite failure: over-deleting the fields that
+			// are still declared.
+			g.Expect(cm.Data).To(gomega.HaveKeyWithValue(shrinkRetainedKey, shrinkRetainedValue),
+				"a field still declared in the template was removed")
+		}, shrinkTimeout, shrinkInterval).Should(gomega.Succeed())
+	})
+})
+
+// managedFieldSummary renders which field manager owns which parts of an
+// object, so a failure shows why a field was not removed.
+func managedFieldSummary(obj metav1.Object) string {
+	out := ""
+	for _, entry := range obj.GetManagedFields() {
+		fields := ""
+		if entry.FieldsV1 != nil {
+			fields = string(entry.FieldsV1.Raw)
+		}
+		out += "[" + entry.Manager + "/" + string(entry.Operation) + " " + fields + "] "
+	}
+	if out == "" {
+		return "<none>"
+	}
+	return out
+}

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -192,6 +192,7 @@ var _ = ginkgo.Describe("Post-Upgrade GraphRevision", ginkgo.Ordered, func() {
 		// the current count must not exceed what is expected given the known
 		// post-upgrade mutations:
 		//   - mutationRGDName: exactly +1 (one deliberate mutation by mutation suite)
+		//   - shrinkRGDName: exactly +1 (one deliberate mutation by template-shrink suite)
 		//   - retentionRGDName: capped at maxGraphRevisions (rapid-mutation suite)
 		//   - deletionRGDName: 0 or snapshot count (deletion suite may or may not have run)
 		//   - all others: unchanged from snapshot
@@ -199,7 +200,7 @@ var _ = ginkgo.Describe("Post-Upgrade GraphRevision", ginkgo.Ordered, func() {
 			currentCount := currentGRCountPerRGD[rgdName]
 			var maxAllowed int
 			switch rgdName {
-			case mutationRGDName:
+			case mutationRGDName, shrinkRGDName:
 				maxAllowed = min(preCount+1, maxGraphRevisions)
 			case retentionRGDName:
 				maxAllowed = min(preCount+retentionMutations, maxGraphRevisions)


### PR DESCRIPTION
## What this does

Adds test coverage for a set of behaviors the RGD reconcile path relies on today but does not assert anywhere. Tests only — no production code changes, no CI configuration changes.

The unifying theme is that every contract here **fails silently**. None of these behaviors produce an error, an event, or a condition when they break: a status field simply never appears, an orphaned object simply stays, a metric series simply stops being scraped, a field removed from a template simply doesn't go away. That combination — load-bearing, unasserted, and quiet on failure — is what makes them worth pinning.

These came out of a coverage-gap pass over the instance reconcile path, comparing what the suites assert against what the code actually guarantees.

## What's covered

| Area | Contract | File |
| --- | --- | --- |
| Instance data | Text containing `${...}` in a spec field or annotation is carried through verbatim | `test/integration/suites/core/instance_expression_isolation_test.go` |
| Instance data | An instance value that names one of the definition's resources stays a plain string | same |
| Status | A status field declared as an array is projected as an array, top level and nested | `.../status_array_projection_test.go` |
| Ownership | Managed resources are applied under a stable server-side-apply field manager | `.../resource_ownership_test.go` |
| Ownership | Two instances rendering the same object do not silently overwrite each other | same |
| Pruning | A resource removed from a definition is pruned even while another resource is not ready | `.../resource_pruning_test.go` |
| Collections | The configured collection size limit is the one enforced | `.../collection_behavior_test.go` |
| Collections | Drift is corrected in every namespace a collection spans | same |
| Resource shapes | Templates and external refs work with API versions outside the `vN[alpha\|beta]N` convention | `.../resource_shape_compatibility_test.go` |
| Resource shapes | A definition may create a `CustomResourceDefinition` | same |
| Resource shapes | An unresolvable child namespace names the field the author has to fix | same |
| Metrics | `instance_reconcile_errors_total` counts reconcile-level failures, not retried per-resource applies | `.../reconcile_error_metrics_test.go` |
| Metrics | The registered metric family names stay registered | `pkg/metrics/register_families_test.go` |
| Upgrade | Removing a field from a template removes it from resources created before the upgrade | `test/upgrade/template_shrink_test.go` + `fixtures/template-shrink/` |

## Why these specific ones

A few deserve a word on motivation, since the value isn't obvious from the test name alone:

**Instance data is data, not a template.** An instance is written by the consumer of a generated API, who knows the schema but not the definition behind it. Users legitimately store shell snippets, container commands and downstream templating config in spec fields, so `${...}` has to survive a round trip. Separately, an instance value that happens to name a resource id must stay a string — resource ids are an internal detail of the definition, and resources can hold cluster state the instance's author cannot read.

**API versions are opaque strings.** Kubernetes only requires a CRD version to be a valid DNS label, and widely used operators pick names outside the usual convention: Azure Service Operator versions every type as `vNapiYYYYMMDD`, Google Config Connector ships versions like `v1p1beta1`. Both templates and external references are covered.

**CRDs are the most demanding template payload.** Shipping CRDs or an operator as a kro API is an established pattern, and a CRD's `openAPIV3Schema` is a deeply nested, self-referential document.

**The field manager is a compatibility surface.** Which manager owns a field decides whether dropping that field from a template removes it from the live object, because server-side apply only clears fields the *same* manager set previously. If the manager name changes between releases, objects created by an earlier release keep their fields owned by a manager that never applies again, and template removals silently stop taking effect on exactly those objects. New objects behave correctly, which makes the divergence easy to miss — hence the upgrade-time spec as well as the in-cluster one.

**Metric names are operator-facing.** Dashboards, alerts and recording rules reference them by name. Removing or renaming one is invisible at compile time and at scrape time: the series just stops appearing, so panels go blank and alerts stop evaluating rather than failing loudly. The counter-scale spec is the same concern from the other side — if a retried per-resource apply failure incremented `instance_reconcile_errors_total`, any absolute threshold on that series would start firing for instances that are merely waiting on something external.

## Two existing files touched

`test/upgrade/{mutation,upgrade}_test.go` — 7 lines total.

Both keep an explicit list of RGDs that post-upgrade suites deliberately mutate, so their spurious-GraphRevision invariants can distinguish intentional changes from unexpected ones. The new template-shrink suite mutates a second RGD, so it is registered alongside the existing `mutationRGDName` and `retentionRGDName` entries, following the pattern already in those files. Comments updated to match.

## Verification

All green on this branch:

```
make build
make verify-codegen                                            # up to date, no churn
make lint                                                      # 0 issues
make test WHAT=unit
make test WHAT=integration                                     # core: 173/173 (+16 specs)
make test-e2e-upgrade-kind KRO_UPGRADE_FROM_VERSION=v0.9.3      # 46 pre-upgrade / 79 post-upgrade (+4 specs)
```

The new tests land in suites the presubmits already run (`integration-tests`, `e2e-upgrade-tests`), and the upgrade fixture is picked up by the existing `fixtures/*/rgd.yaml` glob, so no CI configuration changes are needed.

Each spec was also checked to fail for the intended reason, not incidentally — by breaking the behavior it covers and confirming the assertion is the one that trips, with a failure message that names the problem rather than just reporting a timeout.

## Notes for reviewers

- **The metric list and the field-manager name are spelled out literally, on purpose.** Referencing `applyset.FieldManager` or deriving the metric names from the registry would make each assertion follow a rename instead of catching it. Both are meant to force a deliberate, reviewable decision — if the value has to change, update it in the test and treat pre-existing objects or existing dashboards as the migration concern they are.
- **`configuredMaxCollectionSize` in `collection_behavior_test.go` mirrors the value in `test/integration/environment/setup.go`.** The environment builds its `RGDConfig` inline rather than exposing it, so the expected limit is a documented constant with a pointer to its source.
- **The shared-resource and multi-namespace-drift specs sample over a window** (`Consistently`, and repeated tampering) rather than reading once, because a single read can land between competing writes and look stable.
- **Spec-level isolation:** every spec creates its own namespace and uses randomized names, groups and schema kinds, so nothing collides in the shared envtest cluster. The two `DescribeTable` entries use distinct schema kinds for the same reason — sharing one would make their generated CRDs contend.
- **Helpers reuse what the package already has** (`waitForRGDActive`, `instanceConditions`); the few new ones (`newInstance`, `waitForInstanceState`, `installTestCRD`) are additive.