### PR TITLE
refactor(watch): extract shared informer-fleet Manager into pkg/watch

### DIFF
--- a/pkg/controller/instance/test_helpers_test.go
+++ b/pkg/controller/instance/test_helpers_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	krt "github.com/kubernetes-sigs/kro/pkg/runtime"
+	"github.com/kubernetes-sigs/kro/pkg/watch"
 )
 
 var (
@@ -200,7 +201,7 @@ func newControllerTestCoordinator(t *testing.T) *dynamiccontroller.WatchCoordina
 	metadataClient := metadatafake.NewSimpleMetadataClient(scheme)
 
 	var coord *dynamiccontroller.WatchCoordinator
-	watches := dynamiccontroller.NewWatchManager(metadataClient, time.Hour, func(event dynamiccontroller.Event) {
+	watches := watch.NewManager(metadataClient, time.Hour, func(event watch.Event) {
 		if coord != nil {
 			coord.RouteEvent(event)
 		}

--- a/pkg/dynamiccontroller/coordinator.go
+++ b/pkg/dynamiccontroller/coordinator.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
+	kwatch "github.com/kubernetes-sigs/kro/pkg/watch"
 )
 
 // InstanceWatcher is the interface the instance reconciler uses to request
@@ -107,7 +108,7 @@ type collectionEntry struct {
 type WatchCoordinator struct {
 	mu sync.RWMutex
 
-	watches *WatchManager
+	watches *kwatch.Manager
 	enqueue EnqueueFunc
 	log     logr.Logger
 
@@ -123,7 +124,7 @@ type WatchCoordinator struct {
 }
 
 // NewWatchCoordinator creates a new WatchCoordinator.
-func NewWatchCoordinator(watches *WatchManager, enqueue EnqueueFunc, log logr.Logger) *WatchCoordinator {
+func NewWatchCoordinator(watches *kwatch.Manager, enqueue EnqueueFunc, log logr.Logger) *WatchCoordinator {
 	return &WatchCoordinator{
 		watches:         watches,
 		enqueue:         enqueue,
@@ -330,7 +331,7 @@ func (c *WatchCoordinator) RemoveParentGVR(parentGVR schema.GroupVersionResource
 
 // RouteEvent routes a watch event to all matching instances.
 // Called by the watch handler for every event.
-func (c *WatchCoordinator) RouteEvent(event Event) {
+func (c *WatchCoordinator) RouteEvent(event kwatch.Event) {
 	metrics.DynRouteTotal.WithLabelValues(event.GVR.String()).Inc()
 
 	c.mu.RLock()

--- a/pkg/dynamiccontroller/coordinator_test.go
+++ b/pkg/dynamiccontroller/coordinator_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/client-go/metadata/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kwatch "github.com/kubernetes-sigs/kro/pkg/watch"
 )
 
 var (
@@ -85,7 +87,7 @@ func newTestCoordinator(t *testing.T) (*WatchCoordinator, *enqueueRecorder) {
 	// Create WatchManager with a placeholder onEvent; we'll wire the
 	// coordinator's RouteEvent after construction.
 	var coord *WatchCoordinator
-	wm := NewWatchManager(client, 1*time.Hour, func(event Event) {
+	wm := kwatch.NewManager(client, 1*time.Hour, func(event kwatch.Event) {
 		if coord != nil {
 			coord.RouteEvent(event)
 		}
@@ -122,8 +124,8 @@ func TestWatchAndDone_ScalarWatch(t *testing.T) {
 	assert.Equal(t, 1, coord.InstanceWatchCount())
 
 	// Simulate an event matching the scalar watch.
-	coord.RouteEvent(Event{
-		Type:      EventUpdate,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventUpdate,
 		GVR:       testDeployGVR,
 		Name:      "my-deploy",
 		Namespace: "default",
@@ -131,8 +133,8 @@ func TestWatchAndDone_ScalarWatch(t *testing.T) {
 	assert.Equal(t, 1, recorder.count())
 
 	// Non-matching event.
-	coord.RouteEvent(Event{
-		Type:      EventUpdate,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventUpdate,
 		GVR:       testDeployGVR,
 		Name:      "other-deploy",
 		Namespace: "default",
@@ -153,8 +155,8 @@ func TestWatchAndDone_CleanupStaleRequests(t *testing.T) {
 	w1.Done(true)
 
 	// Verify both match.
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
 	assert.Equal(t, 2, recorder.count())
 	recorder.reset()
 
@@ -164,11 +166,11 @@ func TestWatchAndDone_CleanupStaleRequests(t *testing.T) {
 	w2.Done(true)
 
 	// Deployment still matches, service no longer does.
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
 	assert.Equal(t, 1, recorder.count())
 	recorder.reset()
 
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
 	assert.Equal(t, 0, recorder.count())
 }
 
@@ -187,8 +189,8 @@ func TestCollectionWatch(t *testing.T) {
 	watcher.Done(true)
 
 	// Matching labels.
-	coord.RouteEvent(Event{
-		Type:      EventAdd,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventAdd,
 		GVR:       testCmGVR,
 		Name:      "config-1",
 		Namespace: "default",
@@ -197,8 +199,8 @@ func TestCollectionWatch(t *testing.T) {
 	assert.Equal(t, 1, recorder.count())
 
 	// Non-matching labels.
-	coord.RouteEvent(Event{
-		Type:      EventAdd,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventAdd,
 		GVR:       testCmGVR,
 		Name:      "config-2",
 		Namespace: "default",
@@ -207,8 +209,8 @@ func TestCollectionWatch(t *testing.T) {
 	assert.Equal(t, 1, recorder.count())
 
 	// Wrong namespace.
-	coord.RouteEvent(Event{
-		Type:      EventAdd,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventAdd,
 		GVR:       testCmGVR,
 		Name:      "config-3",
 		Namespace: "other-ns",
@@ -226,7 +228,7 @@ func TestRemoveInstance(t *testing.T) {
 	watcher.Done(true)
 
 	// Verify match.
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
 	assert.Equal(t, 1, recorder.count())
 	recorder.reset()
 
@@ -235,7 +237,7 @@ func TestRemoveInstance(t *testing.T) {
 	assert.Equal(t, 0, coord.InstanceWatchCount())
 
 	// No longer matches.
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
 	assert.Equal(t, 0, recorder.count())
 }
 
@@ -260,8 +262,8 @@ func TestRemoveParentGVR(t *testing.T) {
 	assert.Equal(t, 0, coord.InstanceWatchCount())
 
 	// No more matches.
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d2", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d2", Namespace: "default"})
 	assert.Equal(t, 0, recorder.count())
 }
 
@@ -280,7 +282,7 @@ func TestSharedWatchAcrossInstances(t *testing.T) {
 	w2.Done(true)
 
 	// One event should trigger BOTH instances.
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testCmGVR, Name: "shared-cm", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testCmGVR, Name: "shared-cm", Namespace: "default"})
 	assert.Equal(t, 2, recorder.count())
 }
 
@@ -523,8 +525,8 @@ func TestDuplicateCollectionRegistration_Idempotent(t *testing.T) {
 	assert.Equal(t, 1, collection, "duplicate collection registration should be deduped")
 
 	// One matching event should trigger exactly one enqueue, not two.
-	coord.RouteEvent(Event{
-		Type:      EventAdd,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventAdd,
 		GVR:       testCmGVR,
 		Name:      "config-1",
 		Namespace: "default",
@@ -556,8 +558,8 @@ func TestScalarAndCollectionDedup(t *testing.T) {
 	watcher.Done(true)
 
 	// An event matching both scalar and collection should enqueue only once.
-	coord.RouteEvent(Event{
-		Type:      EventUpdate,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventUpdate,
 		GVR:       testCmGVR,
 		Name:      "config-1",
 		Namespace: "default",
@@ -593,8 +595,8 @@ func TestCollectionWatch_SelectorChange(t *testing.T) {
 	w2.Done(true)
 
 	// Old selector should not match.
-	coord.RouteEvent(Event{
-		Type:      EventAdd,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventAdd,
 		GVR:       testCmGVR,
 		Name:      "config-1",
 		Namespace: "default",
@@ -603,8 +605,8 @@ func TestCollectionWatch_SelectorChange(t *testing.T) {
 	assert.Equal(t, 0, recorder.count(), "old selector should not match after change")
 
 	// New selector should match.
-	coord.RouteEvent(Event{
-		Type:      EventAdd,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventAdd,
 		GVR:       testCmGVR,
 		Name:      "config-2",
 		Namespace: "default",
@@ -633,8 +635,8 @@ func TestRouteEvent_OldLabelsMatch(t *testing.T) {
 
 	// Update event: new labels no longer match, but old labels did.
 	// Should still trigger re-reconciliation (label-loss detection).
-	coord.RouteEvent(Event{
-		Type:      EventUpdate,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventUpdate,
 		GVR:       testCmGVR,
 		Name:      "config-1",
 		Namespace: "default",
@@ -715,10 +717,10 @@ func TestAbortInstance_RollsBackFailedCycleTargetChange(t *testing.T) {
 	}))
 	w2.Done(false)
 
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
 	assert.Equal(t, 0, recorder.count(), "aborted target change should not stay active")
 
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
 	assert.Equal(t, 1, recorder.count(), "previous committed watch should remain active after abort")
 
 	assert.NotNil(t, coord.watches.GetInformer(testDeployGVR), "previous informer should stay running")
@@ -751,7 +753,7 @@ func TestAbortInstance_SameTargetKeepsPreviousWatch(t *testing.T) {
 	}))
 	w2.Done(false)
 
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
 	assert.Equal(t, 1, recorder.count(), "aborting an unchanged request must not drop the previous watch")
 
 	scalar, collection := coord.WatchRequestCount()
@@ -790,10 +792,10 @@ func TestAbortInstance_DoesNotPromoteFailedCurrentOnLaterSuccess(t *testing.T) {
 	}))
 	w3.Done(true)
 
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testServiceGVR, Name: "s1", Namespace: "default"})
 	assert.Equal(t, 0, recorder.count(), "aborted requests must not be committed by a later successful Done")
 
-	coord.RouteEvent(Event{Type: EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
+	coord.RouteEvent(kwatch.Event{Type: kwatch.EventUpdate, GVR: testDeployGVR, Name: "d1", Namespace: "default"})
 	assert.Equal(t, 1, recorder.count(), "successful cycle should keep only the committed watch")
 }
 
@@ -824,8 +826,8 @@ func TestAbortInstance_RollsBackCollectionSelectorChange(t *testing.T) {
 	}))
 	w2.Done(false)
 
-	coord.RouteEvent(Event{
-		Type:      EventUpdate,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventUpdate,
 		GVR:       testCmGVR,
 		Name:      "cm-v2",
 		Namespace: "default",
@@ -833,8 +835,8 @@ func TestAbortInstance_RollsBackCollectionSelectorChange(t *testing.T) {
 	})
 	assert.Equal(t, 0, recorder.count(), "aborted selector change should not stay active")
 
-	coord.RouteEvent(Event{
-		Type:      EventUpdate,
+	coord.RouteEvent(kwatch.Event{
+		Type:      kwatch.EventUpdate,
 		GVR:       testCmGVR,
 		Name:      "cm-v1",
 		Namespace: "default",
@@ -855,7 +857,7 @@ func TestAddWatch_EnsureWatchSyncError(t *testing.T) {
 	})
 
 	recorder := &enqueueRecorder{}
-	wm := NewWatchManager(client, 1*time.Hour, func(event Event) {}, log)
+	wm := kwatch.NewManager(client, 1*time.Hour, func(event kwatch.Event) {}, log)
 	wm.SyncTimeout = 100 * time.Millisecond
 
 	coord := NewWatchCoordinator(wm, recorder.enqueue, log)

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -82,6 +82,7 @@ import (
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
+	kwatch "github.com/kubernetes-sigs/kro/pkg/watch"
 )
 
 // Config holds the configuration for DynamicController
@@ -152,7 +153,7 @@ type DynamicController struct {
 	log    logr.Logger
 
 	// Shared watch lifecycle management.
-	watches *WatchManager
+	watches *kwatch.Manager
 
 	// Instance-level watch coordination.
 	coordinator *WatchCoordinator
@@ -186,7 +187,7 @@ func NewDynamicController(
 	}
 
 	// WatchManager routes all informer events through the coordinator.
-	dc.watches = NewWatchManager(kubeClient, config.ResyncPeriod, dc.routeChildEvent, logger)
+	dc.watches = newWatchManager(kubeClient, config.ResyncPeriod, dc.routeChildEvent, logger)
 
 	// Initialize coordinator eagerly so it's never nil.
 	dc.coordinator = NewWatchCoordinator(dc.watches, dc.enqueueInstance, logger)
@@ -221,8 +222,29 @@ func (dc *DynamicController) Coordinator() *WatchCoordinator {
 
 // routeChildEvent is the EventHandler callback given to WatchManager.
 // It delegates to the coordinator for child/external resource event routing.
-func (dc *DynamicController) routeChildEvent(event Event) {
+func (dc *DynamicController) routeChildEvent(event kwatch.Event) {
 	dc.coordinator.RouteEvent(event)
+}
+
+// newWatchManager creates a kwatch.Manager wired to the dynamic controller's
+// Prometheus metrics. The onEvent callback is invoked for every informer event
+// across all GVRs.
+func newWatchManager(client k8smetadata.Interface, resync time.Duration, onEvent kwatch.EventHandler, log logr.Logger) *kwatch.Manager {
+	wm := kwatch.NewManager(client, resync, onEvent, log)
+	wm.Metrics = dynMetricsRecorder{}
+	return wm
+}
+
+// dynMetricsRecorder forwards WatchManager observability signals to the
+// dynamic controller's Prometheus vectors in pkg/metrics.
+type dynMetricsRecorder struct{}
+
+func (dynMetricsRecorder) SetActiveWatches(active int) {
+	metrics.DynWatchCount.Set(float64(active))
+}
+
+func (dynMetricsRecorder) ObserveInformerSync(gvr schema.GroupVersionResource, seconds float64) {
+	metrics.DynInformerSyncDuration.WithLabelValues(gvr.String()).Observe(seconds)
 }
 
 func (dc *DynamicController) worker(ctx context.Context) {
@@ -327,7 +349,7 @@ func (dc *DynamicController) syncFunc(ctx context.Context, oi ObjectIdentifiers,
 }
 
 // enqueueParent enqueues an instance directly from a parent watch event.
-func (dc *DynamicController) enqueueParent(parentGVR schema.GroupVersionResource, event Event) {
+func (dc *DynamicController) enqueueParent(parentGVR schema.GroupVersionResource, event kwatch.Event) {
 	oi := ObjectIdentifiers{
 		NamespacedName: types.NamespacedName{
 			Namespace: event.Namespace,
@@ -418,13 +440,13 @@ func (dc *DynamicController) Register(
 func (dc *DynamicController) parentEventHandlerFor(parent schema.GroupVersionResource) cache.ResourceEventHandler {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
-			dc.enqueueFromInformer(parent, nil, obj, EventAdd)
+			dc.enqueueFromInformer(parent, nil, obj, kwatch.EventAdd)
 		},
 		UpdateFunc: func(oldObj, newObj any) {
-			dc.enqueueFromInformer(parent, oldObj, newObj, EventUpdate)
+			dc.enqueueFromInformer(parent, oldObj, newObj, kwatch.EventUpdate)
 		},
 		DeleteFunc: func(obj any) {
-			dc.enqueueFromInformer(parent, nil, obj, EventDelete)
+			dc.enqueueFromInformer(parent, nil, obj, kwatch.EventDelete)
 		},
 	}
 }
@@ -434,7 +456,7 @@ func (dc *DynamicController) parentEventHandlerFor(parent schema.GroupVersionRes
 func (dc *DynamicController) enqueueExistingInstances(parent schema.GroupVersionResource) {
 	if inf := dc.watches.GetInformer(parent); inf != nil && !inf.IsStopped() {
 		for _, obj := range inf.GetStore().List() {
-			dc.enqueueFromInformer(parent, nil, obj, EventUpdate)
+			dc.enqueueFromInformer(parent, nil, obj, kwatch.EventUpdate)
 		}
 	}
 }
@@ -442,7 +464,7 @@ func (dc *DynamicController) enqueueExistingInstances(parent schema.GroupVersion
 // enqueueFromInformer converts a raw informer callback into an enqueue call.
 // For Update events it compares generations and skips if unchanged (unless
 // the reconcile-disabled label was just removed).
-func (dc *DynamicController) enqueueFromInformer(parentGVR schema.GroupVersionResource, oldObject, newObject any, eventType EventType) {
+func (dc *DynamicController) enqueueFromInformer(parentGVR schema.GroupVersionResource, oldObject, newObject any, eventType kwatch.EventType) {
 	newMeta, err := meta.Accessor(newObject)
 	if err != nil {
 		dc.log.Error(err, "Failed to get meta for parent object")
@@ -450,18 +472,20 @@ func (dc *DynamicController) enqueueFromInformer(parentGVR schema.GroupVersionRe
 	}
 
 	// Generation-based skip only applies to updates where we have both old and new objects.
-	if eventType == EventUpdate && oldObject != nil {
+	if eventType == kwatch.EventUpdate && oldObject != nil {
 		oldMeta, err := meta.Accessor(oldObject)
 		if err != nil {
 			dc.log.Error(err, "Failed to get meta for old parent object")
 			return
 		}
 		if newMeta.GetGeneration() == oldMeta.GetGeneration() {
-			// Normally skip, but we should enqueue if the oldMeta had the reconcile disabled annotation, and the newMeta doesn't.
-			// This covers an edge case where the user only updates the reconcile annotation from disabled to enabled,
-			// which will trigger this func, but the generation won't change since it's a metadata-only update.
-			// We want to make sure this transition still triggers a reconciliation.
-			if !reconcileEnabledInUpdate(oldMeta, newMeta) {
+			// Normally skip metadata-only updates, but a change to the
+			// reconcile-suspended annotation does not bump generation yet must
+			// still trigger a reconcile: resuming (suspended->enabled) so the
+			// instance re-converges, and suspending (enabled->suspended) so the
+			// ReconciliationSuspended status is written promptly (the graph
+			// engine does not periodically requeue).
+			if !reconcileSuspensionChangedInUpdate(oldMeta, newMeta) {
 				dc.log.V(2).Info("Skipping update due to unchanged generation",
 					"name", newMeta.GetName(), "namespace", newMeta.GetNamespace(), "generation", newMeta.GetGeneration())
 				return
@@ -469,7 +493,7 @@ func (dc *DynamicController) enqueueFromInformer(parentGVR schema.GroupVersionRe
 		}
 	}
 
-	dc.enqueueParent(parentGVR, Event{
+	dc.enqueueParent(parentGVR, kwatch.Event{
 		Type:      eventType,
 		GVR:       parentGVR,
 		Name:      newMeta.GetName(),
@@ -477,10 +501,15 @@ func (dc *DynamicController) enqueueFromInformer(parentGVR schema.GroupVersionRe
 	})
 }
 
-func reconcileEnabledInUpdate(oldMeta, newMeta metav1.Object) bool {
+// reconcileSuspensionChangedInUpdate reports whether the reconcile-suspended
+// annotation flipped between the old and new object. It is symmetric: both
+// suspended->enabled and enabled->suspended transitions return true so each is
+// reconciled exactly once. A steadily-suspended (or steadily-enabled) instance
+// returns false, so it is not re-enqueued every metadata update.
+func reconcileSuspensionChangedInUpdate(oldMeta, newMeta metav1.Object) bool {
 	oldSuspended := v1alpha1.IsReconcileSuspended(oldMeta.GetAnnotations()[v1alpha1.InstanceReconcileAnnotation])
 	newSuspended := v1alpha1.IsReconcileSuspended(newMeta.GetAnnotations()[v1alpha1.InstanceReconcileAnnotation])
-	return oldSuspended && !newSuspended
+	return oldSuspended != newSuspended
 }
 
 // Deregister removes a parent GVR handler and cleans up coordinator state.

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
+	kwatch "github.com/kubernetes-sigs/kro/pkg/watch"
 )
 
 // NOTE(a-hilaly): I'm just playing around with the dynamic controller code here
@@ -179,8 +180,8 @@ func TestEnqueueObject(t *testing.T) {
 
 	parentGVR := schema.GroupVersionResource{Group: "group", Version: "version", Resource: "resource"}
 
-	dc.enqueueParent(parentGVR, Event{
-		Type:      EventAdd,
+	dc.enqueueParent(parentGVR, kwatch.Event{
+		Type:      kwatch.EventAdd,
 		GVR:       parentGVR,
 		Name:      "test-object",
 		Namespace: "default",
@@ -654,10 +655,10 @@ func TestEnqueueFromInformer_GenerationSkip(t *testing.T) {
 			expectQueue: 0,
 		},
 		{
-			name:        "same generation, reconcile disabled on new only — skips",
+			name:        "same generation, reconcile disabled on new only — enqueues",
 			oldObj:      makeObj("a", "default", 5, nil),
 			newObj:      makeObj("a", "default", 5, map[string]string{v1alpha1.InstanceReconcileAnnotation: "disabled"}),
-			expectQueue: 0,
+			expectQueue: 1,
 		},
 		{
 			name:        "same generation, reconcile re-enabled case-insensitive — enqueues",
@@ -675,7 +676,7 @@ func TestEnqueueFromInformer_GenerationSkip(t *testing.T) {
 			mapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
 
 			dc := NewDynamicController(noopLogger(), testConfig(), client, mapper)
-			dc.enqueueFromInformer(parentGVR, tt.oldObj, tt.newObj, EventUpdate)
+			dc.enqueueFromInformer(parentGVR, tt.oldObj, tt.newObj, kwatch.EventUpdate)
 			assert.Equal(t, tt.expectQueue, dc.queue.Len())
 		})
 	}
@@ -698,7 +699,7 @@ func TestEnqueueFromInformer_AddAndDelete(t *testing.T) {
 	obj.SetGeneration(1)
 
 	// AddFunc passes nil as oldObject — should enqueue
-	dc.enqueueFromInformer(parentGVR, nil, obj, EventAdd)
+	dc.enqueueFromInformer(parentGVR, nil, obj, kwatch.EventAdd)
 	assert.Equal(t, 1, dc.queue.Len(), "Add events should be enqueued")
 
 	// Drain
@@ -707,7 +708,7 @@ func TestEnqueueFromInformer_AddAndDelete(t *testing.T) {
 	dc.queue.Forget(item)
 
 	// DeleteFunc passes nil as oldObject — should enqueue
-	dc.enqueueFromInformer(parentGVR, nil, obj, EventDelete)
+	dc.enqueueFromInformer(parentGVR, nil, obj, kwatch.EventDelete)
 	assert.Equal(t, 1, dc.queue.Len(), "Delete events should be enqueued")
 }
 
@@ -721,11 +722,11 @@ func TestEnqueueFromInformer_NilNewObject(t *testing.T) {
 	parentGVR := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
 	dc := NewDynamicController(noopLogger(), testConfig(), client, mapper)
 
-	dc.enqueueFromInformer(parentGVR, nil, nil, EventDelete)
+	dc.enqueueFromInformer(parentGVR, nil, nil, kwatch.EventDelete)
 	assert.Equal(t, 0, dc.queue.Len(), "nil newObject should cause early return")
 }
 
-func TestReconcileEnabledInUpdate(t *testing.T) {
+func TestReconcileSuspensionChangedInUpdate(t *testing.T) {
 	makeObj := func(annotations map[string]string) *v1.PartialObjectMetadata {
 		obj := &v1.PartialObjectMetadata{}
 		obj.SetAnnotations(annotations)
@@ -761,7 +762,7 @@ func TestReconcileEnabledInUpdate(t *testing.T) {
 			name:   "enabled -> disabled",
 			old:    nil,
 			new:    map[string]string{v1alpha1.InstanceReconcileAnnotation: "disabled"},
-			expect: false,
+			expect: true,
 		},
 		{
 			name:   "case insensitive disabled",
@@ -792,7 +793,7 @@ func TestReconcileEnabledInUpdate(t *testing.T) {
 			name:   "enabled -> suspended",
 			old:    nil,
 			new:    map[string]string{v1alpha1.InstanceReconcileAnnotation: "suspended"},
-			expect: false,
+			expect: true,
 		},
 		{
 			name:   "case insensitive suspended",
@@ -823,7 +824,7 @@ func TestReconcileEnabledInUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := reconcileEnabledInUpdate(makeObj(tt.old), makeObj(tt.new))
+			result := reconcileSuspensionChangedInUpdate(makeObj(tt.old), makeObj(tt.new))
 			assert.Equal(t, tt.expect, result)
 		})
 	}
@@ -867,7 +868,7 @@ func TestGetInformer_ReturnsNil_ForMissingWatch(t *testing.T) {
 	// guard in Register protects against.
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1.AddMetaToScheme(scheme))
-	wm := NewWatchManager(fake.NewSimpleMetadataClient(scheme), 1*time.Hour, func(Event) {}, noopLogger())
+	wm := kwatch.NewManager(fake.NewSimpleMetadataClient(scheme), 1*time.Hour, func(kwatch.Event) {}, noopLogger())
 
 	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
 	assert.Nil(t, wm.GetInformer(gvr), "GetInformer should return nil for unwatched GVR")
@@ -875,8 +876,8 @@ func TestGetInformer_ReturnsNil_ForMissingWatch(t *testing.T) {
 	require.NoError(t, wm.EnsureWatch(gvr, "owner"))
 	assert.NotNil(t, wm.GetInformer(gvr))
 
-	wm.forceStopWatch(gvr)
-	assert.Nil(t, wm.GetInformer(gvr), "GetInformer should return nil after forceStopWatch")
+	wm.ReleaseWatch(gvr, "owner")
+	assert.Nil(t, wm.GetInformer(gvr), "GetInformer should return nil after the last owner releases the watch")
 }
 
 func TestDeregister_HandlerNoLongerReceivesEvents(t *testing.T) {

--- a/pkg/watch/event.go
+++ b/pkg/watch/event.go
@@ -12,7 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package dynamiccontroller
+// Package watch provides the shared informer-fleet machinery used by kro's
+// controllers. A [Manager] owns one metadata-only informer per GVR, starting
+// them lazily and reference-counting owners so an informer stops as soon as
+// its last owner releases it. Informer callbacks are normalized into [Event]
+// values and delivered to a single [EventHandler].
+//
+// The package is deliberately controller-agnostic: it does not know about
+// work queues, parent CRDs, or controller-runtime. Consumers (the RGD/instance
+// dynamic controller and the graph-engine watch router) layer their own event
+// routing and reconcile dispatch on top of a shared Manager.
+package watch
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -25,7 +35,7 @@ const (
 	EventDelete EventType = "delete"
 )
 
-// Event is a normalized watch event emitted by the WatchManager.
+// Event is a normalized watch event emitted by the [Manager].
 // Consumers decide what to act on -- no old/new comparison or generation
 // filtering is performed by the watch layer.
 type Event struct {
@@ -40,5 +50,7 @@ type Event struct {
 	OldLabels map[string]string
 }
 
-// EventHandler processes a single watch event.
+// EventHandler processes a single watch event. The [Manager] invokes the
+// handler synchronously from informer goroutines, so implementations must keep
+// work fast -- push to a queue or fan-out channel for heavy work.
 type EventHandler func(event Event)

--- a/pkg/watch/manager.go
+++ b/pkg/watch/manager.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package dynamiccontroller
+package watch
 
 import (
 	"context"
@@ -28,14 +28,26 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/tools/cache"
-
-	"github.com/kubernetes-sigs/kro/pkg/metrics"
 )
 
-// WatchManager manages informer lifecycle per GVR.
-// Informers start lazily on first use and stay alive until all owners release
-// them or Shutdown() is called.
-type WatchManager struct {
+// MetricsRecorder receives observability signals from a [Manager]. It is
+// optional: leave [Manager.Metrics] nil to disable instrumentation. The
+// recorder is called while the manager may hold internal locks, so
+// implementations must not call back into the manager and must return quickly.
+type MetricsRecorder interface {
+	// SetActiveWatches reports the current number of running informers.
+	SetActiveWatches(active int)
+	// ObserveInformerSync records how long EnsureWatch waited for an
+	// informer's initial cache sync, whether it succeeded or timed out.
+	ObserveInformerSync(gvr schema.GroupVersionResource, seconds float64)
+}
+
+// Manager owns the lifecycle of one shared informer per GVR. Informers start
+// lazily on first [Manager.EnsureWatch] and run until the last owner releases
+// them (or [Manager.Shutdown] is called). Owners are arbitrary string IDs; the
+// manager makes no distinction between them, which lets several independent
+// consumers share a single informer for the same GVR.
+type Manager struct {
 	mu      sync.Mutex
 	watches map[schema.GroupVersionResource]*gvrWatch
 	// owners tracks who retains each GVR. An informer is eligible for
@@ -53,8 +65,12 @@ type WatchManager struct {
 	// Zero means use the default (30s).
 	SyncTimeout time.Duration
 
-	// createInformer builds a SharedIndexInformer for a GVR. Defaults to
-	// metadatainformer.NewFilteredMetadataInformer. Override in tests only.
+	// Metrics receives observability signals. Nil disables instrumentation.
+	Metrics MetricsRecorder
+
+	// createInformer builds a SharedIndexInformer for a GVR. Defaults to a
+	// metadatainformer-backed factory. Override via SetInformerFactory in
+	// tests only.
 	createInformer func(schema.GroupVersionResource) cache.SharedIndexInformer
 }
 
@@ -68,10 +84,12 @@ type gvrWatch struct {
 	log        logr.Logger
 }
 
-// NewWatchManager creates a new WatchManager. The onEvent callback is invoked
-// for every informer event across all GVRs.
-func NewWatchManager(client metadata.Interface, resync time.Duration, onEvent EventHandler, log logr.Logger) *WatchManager {
-	wm := &WatchManager{
+// NewManager creates a Manager. The onEvent callback is invoked for every
+// informer event across all GVRs. The metadata client backs the informers, so
+// only object metadata is retrieved -- memory stays bounded as the set of
+// watched GVRs grows.
+func NewManager(client metadata.Interface, resync time.Duration, onEvent EventHandler, log logr.Logger) *Manager {
+	m := &Manager{
 		watches: make(map[schema.GroupVersionResource]*gvrWatch),
 		owners:  make(map[schema.GroupVersionResource]map[string]struct{}),
 		client:  client,
@@ -79,13 +97,27 @@ func NewWatchManager(client metadata.Interface, resync time.Duration, onEvent Ev
 		onEvent: onEvent,
 		log:     log.WithName("watch-manager"),
 	}
-	wm.createInformer = wm.defaultCreateInformer
-	return wm
+	m.createInformer = m.defaultCreateInformer
+	return m
 }
 
-// EnsureWatch ensures a watch on the given GVR registered under a given owner.
-// If the informer fails to start, the owner is removed.
-func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource, ownerID string) error {
+// SetInformerFactory overrides the informer constructor. Intended for tests
+// that need to inject a fake SharedIndexInformer.
+func (m *Manager) SetInformerFactory(f func(schema.GroupVersionResource) cache.SharedIndexInformer) {
+	m.createInformer = f
+}
+
+// EnsureWatch retains the informer for gvr under ownerID, starting one if
+// none is running yet. It then blocks until the informer reports HasSynced
+// (up to SyncTimeout) so callers can rely on a usable cache on return.
+// Idempotent for a given ownerID.
+//
+// On sync timeout only ownerID's retention is dropped -- the informer is never
+// force-stopped. If another owner attached while we were waiting, the informer
+// keeps running under that owner (and it gets its own chance to wait for
+// sync); if we were the sole owner, releasing empties the owner set and the
+// informer stops naturally.
+func (m *Manager) EnsureWatch(gvr schema.GroupVersionResource, ownerID string) error {
 	m.mu.Lock()
 	if m.owners[gvr] == nil {
 		m.owners[gvr] = make(map[string]struct{})
@@ -93,20 +125,18 @@ func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource, ownerID stri
 	m.owners[gvr][ownerID] = struct{}{}
 
 	// Check if watch already exists while still holding the lock.
-	if _, ok := m.watches[gvr]; ok {
-		m.mu.Unlock()
-		return nil
+	w, alreadyExists := m.watches[gvr]
+	if !alreadyExists {
+		// Create and start the informer while still holding the lock, so no
+		// ReleaseWatch can remove our owner before the watch exists.
+		w = m.newWatch(gvr)
+		m.watches[gvr] = w
+		ctx, cancel := context.WithCancel(context.Background())
+		w.cancel = cancel
+		go w.informer.RunWithContext(ctx)
+		m.recordActiveWatchesLocked()
+		m.log.V(1).Info("Informer started", "gvr", gvr)
 	}
-
-	// Create and start the informer while still holding the lock,
-	// so no ReleaseWatch can remove our owner before the watch exists.
-	w := m.newWatch(gvr)
-	m.watches[gvr] = w
-	ctx, cancel := context.WithCancel(context.Background())
-	w.cancel = cancel
-	go w.informer.RunWithContext(ctx)
-	metrics.DynWatchCount.Set(float64(len(m.watches)))
-	m.log.V(1).Info("Informer started", "gvr", gvr)
 
 	// Release the lock before blocking on cache sync.
 	m.mu.Unlock()
@@ -117,18 +147,19 @@ func (m *WatchManager) EnsureWatch(gvr schema.GroupVersionResource, ownerID stri
 	defer syncCancel()
 
 	if !cache.WaitForCacheSync(syncCtx.Done(), w.informer.HasSynced) {
-		metrics.DynInformerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
-		m.forceStopWatch(gvr)
+		m.observeInformerSync(gvr, time.Since(syncStart))
+		// Drop our retention only. See the method comment for why we never
+		// force-stop here.
 		m.ReleaseWatch(gvr, ownerID)
 		return fmt.Errorf("cache sync timeout for %s", gvr)
 	}
-	metrics.DynInformerSyncDuration.WithLabelValues(gvr.String()).Observe(time.Since(syncStart).Seconds())
+	m.observeInformerSync(gvr, time.Since(syncStart))
 	return nil
 }
 
 // ReleaseWatch removes an owner from the GVR. If no owners remain, the
 // informer is stopped automatically.
-func (m *WatchManager) ReleaseWatch(gvr schema.GroupVersionResource, ownerID string) {
+func (m *Manager) ReleaseWatch(gvr schema.GroupVersionResource, ownerID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -143,7 +174,7 @@ func (m *WatchManager) ReleaseWatch(gvr schema.GroupVersionResource, ownerID str
 
 // GetInformer returns the SharedIndexInformer for the given GVR, or nil
 // if no watch exists.
-func (m *WatchManager) GetInformer(gvr schema.GroupVersionResource) cache.SharedIndexInformer {
+func (m *Manager) GetInformer(gvr schema.GroupVersionResource) cache.SharedIndexInformer {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if w, ok := m.watches[gvr]; ok {
@@ -153,14 +184,14 @@ func (m *WatchManager) GetInformer(gvr schema.GroupVersionResource) cache.Shared
 }
 
 // ActiveWatchCount returns the number of active watches.
-func (m *WatchManager) ActiveWatchCount() int {
+func (m *Manager) ActiveWatchCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.watches)
 }
 
 // Shutdown stops all informers and clears state.
-func (m *WatchManager) Shutdown() {
+func (m *Manager) Shutdown() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -173,14 +204,26 @@ func (m *WatchManager) Shutdown() {
 
 const defaultSyncTimeout = 30 * time.Second
 
-func (m *WatchManager) syncTimeout() time.Duration {
+func (m *Manager) syncTimeout() time.Duration {
 	if m.SyncTimeout > 0 {
 		return m.SyncTimeout
 	}
 	return defaultSyncTimeout
 }
 
-func (m *WatchManager) defaultCreateInformer(gvr schema.GroupVersionResource) cache.SharedIndexInformer {
+func (m *Manager) recordActiveWatchesLocked() {
+	if m.Metrics != nil {
+		m.Metrics.SetActiveWatches(len(m.watches))
+	}
+}
+
+func (m *Manager) observeInformerSync(gvr schema.GroupVersionResource, d time.Duration) {
+	if m.Metrics != nil {
+		m.Metrics.ObserveInformerSync(gvr, d.Seconds())
+	}
+}
+
+func (m *Manager) defaultCreateInformer(gvr schema.GroupVersionResource) cache.SharedIndexInformer {
 	return metadatainformer.NewFilteredMetadataInformer(
 		m.client, gvr, metav1.NamespaceAll, m.resync,
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
@@ -188,7 +231,7 @@ func (m *WatchManager) defaultCreateInformer(gvr schema.GroupVersionResource) ca
 	).Informer()
 }
 
-func (m *WatchManager) newWatch(gvr schema.GroupVersionResource) *gvrWatch {
+func (m *Manager) newWatch(gvr schema.GroupVersionResource) *gvrWatch {
 	inf := m.createInformer(gvr)
 
 	_ = inf.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
@@ -212,13 +255,7 @@ func (m *WatchManager) newWatch(gvr schema.GroupVersionResource) *gvrWatch {
 	return w
 }
 
-func (m *WatchManager) forceStopWatch(gvr schema.GroupVersionResource) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.stopWatchLocked(gvr, true)
-}
-
-func (m *WatchManager) stopWatchLocked(gvr schema.GroupVersionResource, force bool) {
+func (m *Manager) stopWatchLocked(gvr schema.GroupVersionResource, force bool) {
 	w, ok := m.watches[gvr]
 	if !ok {
 		return
@@ -234,14 +271,14 @@ func (m *WatchManager) stopWatchLocked(gvr schema.GroupVersionResource, force bo
 	_ = w.informer.RemoveEventHandler(w.handlerReg)
 	w.cancel()
 	delete(m.watches, gvr)
-	metrics.DynWatchCount.Set(float64(len(m.watches)))
+	m.recordActiveWatchesLocked()
 	m.log.V(1).Info("Watch stopped", "gvr", gvr)
 }
 
 // eventHandlerFuncs returns cache.ResourceEventHandlerFuncs that convert
 // informer callbacks into normalized Event structs.
 func (w *gvrWatch) eventHandlerFuncs(onEvent EventHandler) cache.ResourceEventHandlerFuncs {
-	toEvent := func(obj interface{}, eventType EventType) *Event {
+	toEvent := func(obj any, eventType EventType) *Event {
 		mobj, err := meta.Accessor(obj)
 		if err != nil {
 			w.log.Error(err, "Failed to get meta for watched object")
@@ -257,12 +294,12 @@ func (w *gvrWatch) eventHandlerFuncs(onEvent EventHandler) cache.ResourceEventHa
 	}
 
 	return cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			if e := toEvent(obj, EventAdd); e != nil {
 				onEvent(*e)
 			}
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			e := toEvent(newObj, EventUpdate)
 			if e == nil {
 				return
@@ -273,7 +310,7 @@ func (w *gvrWatch) eventHandlerFuncs(onEvent EventHandler) cache.ResourceEventHa
 			}
 			onEvent(*e)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			// Unwrap tombstones: when the informer's watch expires and
 			// re-lists, deleted objects may arrive wrapped in
 			// DeletedFinalStateUnknown.

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package dynamiccontroller
+package watch
 
 import (
 	"fmt"
@@ -20,17 +20,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/metadata/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
-func newTestWatchManager(t *testing.T) *WatchManager {
+// noopLogger discards all output; the manager tests only assert on state.
+func noopLogger() logr.Logger { return logr.Discard() }
+
+// NewWatchManager keeps the identifier this suite used before the Manager moved
+// into pkg/watch. NewManager is the real constructor; this is a thin test-only
+// alias without the dynamiccontroller metrics wiring (these tests do not assert
+// on metrics).
+func NewWatchManager(client metadata.Interface, resync time.Duration, onEvent EventHandler, log logr.Logger) *Manager {
+	return NewManager(client, resync, onEvent, log)
+}
+
+func newTestWatchManager(t *testing.T) *Manager {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := v1.AddMetaToScheme(scheme); err != nil {


### PR DESCRIPTION
## Description
Extracts the controller-agnostic dynamic informer-fleet Manager and normalized watch event types into .

This decouples the informer lifecycle management from  so that multiple controllers can share the same refcounted informer machinery without code duplication or circular dependencies.

## Type of change
- [x] Refactoring / Architecture

## Testing
- test -s /tmp/kro-pr2/bin/controller-gen && /tmp/kro-pr2/bin/controller-gen --version | grep -q v0.21.0 || \
GOBIN=/tmp/kro-pr2/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.21.0
/tmp/kro-pr2/bin/controller-gen crd webhook paths="./..." output:crd:artifacts:config=helm/crds
Copying CRDs to website docs...
CRDs copied successfully
/tmp/kro-pr2/bin/controller-gen object paths="./..."
go generate
go fmt ./...
go vet ./...
go build -ldflags="-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=v0.9.3-52-gf12b8b3c -X sigs.k8s.io/release-utils/version.gitCommit=f12b8b3cb9e5eb7fbb4ade5fe5735a51afd820f9 -X sigs.k8s.io/release-utils/version.gitTreeState="clean" -X sigs.k8s.io/release-utils/version.buildDate=2026-08-19T10:20:23Z" -o bin/controller ./cmd/controller
- /tmp/kro-pr2/bin/golangci-lint run
0 issues.
- test -s /tmp/kro-pr2/bin/controller-gen && /tmp/kro-pr2/bin/controller-gen --version | grep -q v0.21.0 || \
GOBIN=/tmp/kro-pr2/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.21.0
/tmp/kro-pr2/bin/controller-gen crd webhook paths="./..." output:crd:artifacts:config=helm/crds
Copying CRDs to website docs...
CRDs copied successfully
/tmp/kro-pr2/bin/controller-gen object paths="./..."
go generate
go fmt ./...
go vet ./...
test -s /tmp/kro-pr2/bin/setup-envtest || GOBIN=/tmp/kro-pr2/bin  go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
go test -race ./pkg/... -coverprofile unit-cover.out 
ok  	github.com/kubernetes-sigs/kro/pkg/apis	(cached)	coverage: 82.1% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/cel	(cached)	coverage: 36.6% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/cel/ast	(cached)	coverage: 92.9% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/cel/conversion	(cached)	coverage: 65.9% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/cel/library	(cached)	coverage: 92.1% of statements
	github.com/kubernetes-sigs/kro/pkg/cel/sentinels		coverage: 0.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/cel/unstructured	(cached)	coverage: 77.9% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/client	(cached)	coverage: 31.8% of statements
	github.com/kubernetes-sigs/kro/pkg/client/fake		coverage: 0.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/controller/graphrevision	(cached)	coverage: 97.7% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/controller/instance	(cached)	coverage: 89.8% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset	(cached)	coverage: 90.5% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/controller/resourcegraphdefinition	(cached)	coverage: 98.5% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/dynamiccontroller	(cached)	coverage: 93.1% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/features	(cached)	coverage: 50.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph	(cached)	coverage: 95.9% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/crd	(cached)	coverage: 67.6% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/crd/compat	(cached)	coverage: 97.9% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/dag	(cached)	coverage: 84.8% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/fieldpath	(cached)	coverage: 97.1% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/hash	(cached)	coverage: 96.1% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/parser	(cached)	coverage: 89.5% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/revisions	(cached)	coverage: 99.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/schema	(cached)	coverage: 50.8% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/schema/resolver	(cached)	coverage: 60.6% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/graph/variable	(cached)	coverage: 80.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/metadata	(cached)	coverage: 93.2% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/metrics	(cached)	coverage: 86.1% of statements
	github.com/kubernetes-sigs/kro/pkg/requeue		coverage: 0.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/runtime	(cached)	coverage: 98.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/runtime/resolver	(cached)	coverage: 100.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/simpleschema	(cached)	coverage: 99.4% of statements
	github.com/kubernetes-sigs/kro/pkg/simpleschema/types		coverage: 0.0% of statements
	github.com/kubernetes-sigs/kro/pkg/testutil/generator		coverage: 0.0% of statements
	github.com/kubernetes-sigs/kro/pkg/testutil/k8s		coverage: 0.0% of statements
ok  	github.com/kubernetes-sigs/kro/pkg/watch	(cached)	coverage: 96.9% of statements
- Integration test suite passed.