### PR TITLE
fix(graph/schema): add invalidation epoch tracking to CachedSchemaResolver and add schema tests

### DIFF
--- a/pkg/graph/schema/cache_test.go
+++ b/pkg/graph/schema/cache_test.go
@@ -1,0 +1,173 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func objectSchemaWith(props map[string]spec.Schema) *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type:       []string{"object"},
+			Properties: props,
+		},
+	}
+}
+
+// TestCacheLookupField pins the pointer-stability contract: a (parent, field)
+// pair always returns the same pointer, missing fields return nil, and a nil
+// parent or absent Properties is handled gracefully.
+func TestCacheLookupField(t *testing.T) {
+	tests := []struct {
+		name    string
+		parent  *spec.Schema
+		field   string
+		wantNil bool
+	}{
+		{
+			name:    "nil parent",
+			parent:  nil,
+			field:   "x",
+			wantNil: true,
+		},
+		{
+			name:    "nil properties",
+			parent:  &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"object"}}},
+			field:   "x",
+			wantNil: true,
+		},
+		{
+			name: "missing field",
+			parent: objectSchemaWith(map[string]spec.Schema{
+				"a": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			}),
+			field:   "b",
+			wantNil: true,
+		},
+		{
+			name: "existing field",
+			parent: objectSchemaWith(map[string]spec.Schema{
+				"a": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			}),
+			field:   "a",
+			wantNil: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewCache()
+			got := c.LookupField(tc.parent, tc.field)
+			if tc.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			// Pointer-stability: the same lookup returns the identical pointer.
+			again := c.LookupField(tc.parent, tc.field)
+			assert.Same(t, got, again)
+		})
+	}
+}
+
+// TestCacheLookupAdditionalProperties covers the three additionalProperties
+// shapes: an explicit schema (returned directly), Allows=true (a stable empty
+// schema), and the nil / Allows=false cases that return nil.
+func TestCacheLookupAdditionalProperties(t *testing.T) {
+	explicit := &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}}
+
+	tests := []struct {
+		name      string
+		parent    *spec.Schema
+		wantNil   bool
+		wantSame  *spec.Schema // if set, the result must be this exact pointer
+		wantEmpty bool         // if true, result is a fresh stable empty schema
+	}{
+		{
+			name:    "nil parent",
+			parent:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "nil additionalProperties",
+			parent:  &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"object"}}},
+			wantNil: true,
+		},
+		{
+			name: "explicit schema returned directly",
+			parent: &spec.Schema{SchemaProps: spec.SchemaProps{
+				AdditionalProperties: &spec.SchemaOrBool{Schema: explicit},
+			}},
+			wantSame: explicit,
+		},
+		{
+			name: "allows false returns nil",
+			parent: &spec.Schema{SchemaProps: spec.SchemaProps{
+				AdditionalProperties: &spec.SchemaOrBool{Allows: false},
+			}},
+			wantNil: true,
+		},
+		{
+			name: "allows true returns stable empty schema",
+			parent: &spec.Schema{SchemaProps: spec.SchemaProps{
+				AdditionalProperties: &spec.SchemaOrBool{Allows: true},
+			}},
+			wantEmpty: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewCache()
+			got := c.LookupAdditionalProperties(tc.parent)
+			switch {
+			case tc.wantNil:
+				assert.Nil(t, got)
+			case tc.wantSame != nil:
+				assert.Same(t, tc.wantSame, got)
+			case tc.wantEmpty:
+				require.NotNil(t, got)
+				assert.Equal(t, &spec.Schema{}, got)
+				// Stable across repeated lookups for the same parent.
+				assert.Same(t, got, c.LookupAdditionalProperties(tc.parent))
+			}
+		})
+	}
+}
+
+// TestCacheWrapAsList checks the wrapper structure and that the same item
+// pointer always yields the same wrapper pointer.
+func TestCacheWrapAsList(t *testing.T) {
+	c := NewCache()
+	item := &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}}
+
+	wrapped := c.WrapAsList(item)
+	require.NotNil(t, wrapped)
+	assert.Equal(t, spec.StringOrArray{"array"}, wrapped.Type)
+	require.NotNil(t, wrapped.Items)
+	assert.Same(t, item, wrapped.Items.Schema)
+
+	// Same item pointer returns the same wrapper.
+	assert.Same(t, wrapped, c.WrapAsList(item))
+
+	// Distinct item pointer gets a distinct wrapper.
+	other := &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"integer"}}}
+	assert.NotSame(t, wrapped, c.WrapAsList(other))
+}

--- a/pkg/graph/schema/conversion_cel_test.go
+++ b/pkg/graph/schema/conversion_cel_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// TestInferSchemaTypeFromGoValue exercises every branch of the Go-value type
+// switch, including scalars, the nil "any allowed" case, and the unsupported
+// type error.
+func TestInferSchemaTypeFromGoValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   interface{}
+		want    *extv1.JSONSchemaProps
+		wantErr bool
+	}{
+		{name: "bool", value: true, want: &extv1.JSONSchemaProps{Type: "boolean"}},
+		{name: "int64", value: int64(5), want: &extv1.JSONSchemaProps{Type: "integer"}},
+		{name: "uint64", value: uint64(5), want: &extv1.JSONSchemaProps{Type: "integer"}},
+		{name: "float64", value: float64(1.5), want: &extv1.JSONSchemaProps{Type: "number"}},
+		{name: "string", value: "x", want: &extv1.JSONSchemaProps{Type: "string"}},
+		{
+			name:  "nil any allowed",
+			value: nil,
+			want: &extv1.JSONSchemaProps{
+				Description:            "the original schema type was optional or nil so any type is allowed",
+				XPreserveUnknownFields: new(true),
+			},
+		},
+		{
+			name:  "array of strings",
+			value: []interface{}{"a", "b"},
+			want: &extv1.JSONSchemaProps{
+				Type: "array",
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: "string"},
+				},
+			},
+		},
+		{
+			name:  "empty array no items",
+			value: []interface{}{},
+			want:  &extv1.JSONSchemaProps{Type: "array"},
+		},
+		{
+			name:  "object",
+			value: map[string]interface{}{"k": int64(1)},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"k": {Type: "integer"},
+				},
+			},
+		},
+		{
+			name:    "unsupported type",
+			value:   struct{ X int }{X: 1},
+			wantErr: true,
+		},
+		{
+			name:    "array with unsupported item",
+			value:   []interface{}{struct{}{}},
+			wantErr: true,
+		},
+		{
+			name:    "object with unsupported value",
+			value:   map[string]interface{}{"bad": struct{}{}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := inferSchemaTypeFromGoValue(tc.value)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestInferSchemaFromCELValue covers the public entry point: a nil ref.Val
+// errors, while a concrete CEL value flows through to the Go-value inference.
+func TestInferSchemaFromCELValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     ref.Val
+		want    *extv1.JSONSchemaProps
+		wantErr bool
+	}{
+		{name: "nil value errors", val: nil, wantErr: true},
+		{name: "string value", val: types.String("hi"), want: &extv1.JSONSchemaProps{Type: "string"}},
+		{name: "int value", val: types.Int(3), want: &extv1.JSONSchemaProps{Type: "integer"}},
+		{name: "bool value", val: types.Bool(true), want: &extv1.JSONSchemaProps{Type: "boolean"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := inferSchemaFromCELValue(tc.val)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/graph/schema/conversion_cel_type_fallback_test.go
+++ b/pkg/graph/schema/conversion_cel_type_fallback_test.go
@@ -1,0 +1,253 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+)
+
+// TestPrimitiveTypeToSchema covers the full primitive name switch, including
+// bytes, null_type, and the unknown fallthrough.
+func TestPrimitiveTypeToSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeName string
+		want     *extv1.JSONSchemaProps
+		wantOK   bool
+	}{
+		{name: "bool", typeName: "bool", want: &extv1.JSONSchemaProps{Type: "boolean"}, wantOK: true},
+		{name: "int", typeName: "int", want: &extv1.JSONSchemaProps{Type: "integer"}, wantOK: true},
+		{name: "uint", typeName: "uint", want: &extv1.JSONSchemaProps{Type: "integer"}, wantOK: true},
+		{name: "double", typeName: "double", want: &extv1.JSONSchemaProps{Type: "number"}, wantOK: true},
+		{name: "string", typeName: "string", want: &extv1.JSONSchemaProps{Type: "string"}, wantOK: true},
+		{name: "bytes", typeName: "bytes", want: &extv1.JSONSchemaProps{Type: "string", Format: "byte"}, wantOK: true},
+		{
+			name:     "null_type",
+			typeName: "null_type",
+			want: &extv1.JSONSchemaProps{
+				Description:            "null type - any value allowed",
+				XPreserveUnknownFields: new(true),
+			},
+			wantOK: true,
+		},
+		{name: "unknown", typeName: "widget", want: nil, wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := primitiveTypeToSchema(tc.typeName)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestInferSchemaFromCELType_Fallbacks drives the branches reached when no
+// DeclTypeProvider is supplied (nil provider): collections fall back to their
+// CEL type parameters, parameterless / dyn / unknown kinds get permissive
+// schemas, and a nil type errors.
+func TestInferSchemaFromCELType_Fallbacks(t *testing.T) {
+	tests := []struct {
+		name    string
+		celType *cel.Type
+		want    *extv1.JSONSchemaProps
+		wantErr bool
+	}{
+		{name: "nil type errors", celType: nil, wantErr: true},
+		{
+			name:    "list fallback to element param",
+			celType: cel.ListType(cel.BoolType),
+			want: &extv1.JSONSchemaProps{
+				Type: "array",
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: "boolean"},
+				},
+			},
+		},
+		{
+			name:    "map fallback to value param",
+			celType: cel.MapType(cel.StringType, cel.BoolType),
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+					Schema: &extv1.JSONSchemaProps{Type: "boolean"},
+				},
+			},
+		},
+		{
+			name:    "dyn kind permissive",
+			celType: cel.DynType,
+			want:    &extv1.JSONSchemaProps{XPreserveUnknownFields: new(true)},
+		},
+		{
+			name: "struct kind fallback permissive object",
+			celType: apiservercel.NewObjectType("FallbackStruct", map[string]*apiservercel.DeclField{
+				"a": apiservercel.NewDeclField("a", apiservercel.StringType, true, nil, nil),
+			}).CelType(),
+			want: &extv1.JSONSchemaProps{
+				Type:                 "object",
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{Allows: true},
+			},
+		},
+		{
+			name:    "timestamp kind",
+			celType: cel.TimestampType,
+			want: &extv1.JSONSchemaProps{
+				Description: "Timestamp representing a creation time",
+				Type:        "string",
+				Format:      "date-time",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := inferSchemaFromCELType(tc.celType, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGenerateSchemaFromCELTypes_Error confirms that a nil type in the map
+// surfaces a wrapped error naming the offending path.
+func TestGenerateSchemaFromCELTypes_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		typeMap map[string]*cel.Type
+		wantErr bool
+	}{
+		{
+			name:    "nil type errors",
+			typeMap: map[string]*cel.Type{"bad": nil},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GenerateSchemaFromCELTypes(tc.typeMap, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestExtractSchemaFromDeclType_EdgeCases covers the non-object branches of
+// the DeclType walker: a nil DeclType yields a permissive schema, a list
+// DeclType wraps its element, a map DeclType becomes an object with
+// additionalProperties, and a scalar (non-object) DeclType maps to its
+// primitive schema.
+func TestExtractSchemaFromDeclType_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		declType *apiservercel.DeclType
+		validate func(t *testing.T, got *extv1.JSONSchemaProps)
+	}{
+		{
+			name:     "nil decl type permissive",
+			declType: nil,
+			validate: func(t *testing.T, got *extv1.JSONSchemaProps) {
+				require.NotNil(t, got.XPreserveUnknownFields)
+				assert.True(t, *got.XPreserveUnknownFields)
+			},
+		},
+		{
+			name:     "list decl type wraps element",
+			declType: apiservercel.NewListType(apiservercel.StringType, -1),
+			validate: func(t *testing.T, got *extv1.JSONSchemaProps) {
+				assert.Equal(t, "array", got.Type)
+				require.NotNil(t, got.Items)
+				require.NotNil(t, got.Items.Schema)
+				assert.Equal(t, "string", got.Items.Schema.Type)
+			},
+		},
+		{
+			name:     "map decl type becomes object",
+			declType: apiservercel.NewMapType(apiservercel.StringType, apiservercel.IntType, -1),
+			validate: func(t *testing.T, got *extv1.JSONSchemaProps) {
+				assert.Equal(t, "object", got.Type)
+				require.NotNil(t, got.AdditionalProperties)
+				require.NotNil(t, got.AdditionalProperties.Schema)
+				assert.Equal(t, "integer", got.AdditionalProperties.Schema.Type)
+			},
+		},
+		{
+			name:     "scalar decl type maps to primitive",
+			declType: apiservercel.StringType,
+			validate: func(t *testing.T, got *extv1.JSONSchemaProps) {
+				assert.Equal(t, "string", got.Type)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractSchemaFromDeclTypeWithCycleDetection(tc.declType, make(map[string]bool))
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			tc.validate(t, got)
+		})
+	}
+}
+
+// TestExtractSchemaFromDeclType_NestedFieldError ensures that an error
+// surfacing while walking a struct field (here a self-referential cycle)
+// propagates up wrapped with the field name.
+func TestExtractSchemaFromDeclType_NestedFieldError(t *testing.T) {
+	selfField := apiservercel.NewDeclField("self", nil, false, nil, nil)
+	selfType := apiservercel.NewObjectType("SelfRef", map[string]*apiservercel.DeclField{
+		"self": selfField,
+	})
+	// Point the field's type back at the enclosing object to create a cycle.
+	selfField.Type = selfType
+
+	_, err := extractSchemaFromDeclTypeWithCycleDetection(selfType, make(map[string]bool))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "self")
+}
+
+// TestExtractSchemaFromDeclType_NilFieldSkipped verifies a nil entry in an
+// object's field map is skipped rather than dereferenced.
+func TestExtractSchemaFromDeclType_NilFieldSkipped(t *testing.T) {
+	objType := apiservercel.NewObjectType("WithNilField", map[string]*apiservercel.DeclField{
+		"ok":  apiservercel.NewDeclField("ok", apiservercel.StringType, true, nil, nil),
+		"nil": nil,
+	})
+
+	got, err := extractSchemaFromDeclTypeWithCycleDetection(objType, make(map[string]bool))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "object", got.Type)
+	_, hasOK := got.Properties["ok"]
+	assert.True(t, hasOK)
+	_, hasNil := got.Properties["nil"]
+	assert.False(t, hasNil)
+}

--- a/pkg/graph/schema/conversion_schema_extra_test.go
+++ b/pkg/graph/schema/conversion_schema_extra_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+)
+
+// TestConvertJSONSchemaPropsToSpecSchema walks the major branches of the
+// extv1 -> spec.Schema converter: nil input, scalar metadata carry-over, the
+// two Items shapes, the allOf/oneOf/anyOf/not combinators, nested properties,
+// both additionalProperties forms, and the x-kubernetes-preserve-unknown-fields
+// extension.
+func TestConvertJSONSchemaPropsToSpecSchema(t *testing.T) {
+	preserve := true
+
+	tests := []struct {
+		name  string
+		props *extv1.JSONSchemaProps
+	}{
+		{
+			name:  "nil props returns nil",
+			props: nil,
+		},
+		{
+			name: "scalar with metadata",
+			props: &extv1.JSONSchemaProps{
+				Type:        "string",
+				Description: "a field",
+				Pattern:     "^x$",
+				Required:    []string{"foo"},
+			},
+		},
+		{
+			name: "items single schema",
+			props: &extv1.JSONSchemaProps{
+				Type: "array",
+				Items: &extv1.JSONSchemaPropsOrArray{
+					Schema: &extv1.JSONSchemaProps{Type: "string"},
+				},
+			},
+		},
+		{
+			name: "items tuple schemas",
+			props: &extv1.JSONSchemaProps{
+				Type: "array",
+				Items: &extv1.JSONSchemaPropsOrArray{
+					JSONSchemas: []extv1.JSONSchemaProps{
+						{Type: "string"},
+						{Type: "integer"},
+					},
+				},
+			},
+		},
+		{
+			name: "allOf oneOf anyOf not combinators",
+			props: &extv1.JSONSchemaProps{
+				AllOf: []extv1.JSONSchemaProps{{Type: "string"}},
+				OneOf: []extv1.JSONSchemaProps{{Type: "integer"}},
+				AnyOf: []extv1.JSONSchemaProps{{Type: "boolean"}},
+				Not:   &extv1.JSONSchemaProps{Type: "number"},
+			},
+		},
+		{
+			name: "nested properties",
+			props: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"name": {Type: "string"},
+				},
+			},
+		},
+		{
+			name: "additionalProperties schema",
+			props: &extv1.JSONSchemaProps{
+				Type: "object",
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+					Schema: &extv1.JSONSchemaProps{Type: "string"},
+				},
+			},
+		},
+		{
+			name: "additionalProperties allows",
+			props: &extv1.JSONSchemaProps{
+				Type: "object",
+				AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+					Allows: true,
+				},
+			},
+		},
+		{
+			name: "preserve unknown fields extension",
+			props: &extv1.JSONSchemaProps{
+				Type:                   "object",
+				XPreserveUnknownFields: &preserve,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertJSONSchemaPropsToSpecSchema(tc.props)
+			require.NoError(t, err)
+
+			if tc.props == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+
+			switch tc.name {
+			case "scalar with metadata":
+				assert.Equal(t, spec.StringOrArray{"string"}, got.Type)
+				assert.Equal(t, "a field", got.Description)
+				assert.Equal(t, "^x$", got.Pattern)
+				assert.Equal(t, []string{"foo"}, got.Required)
+			case "items single schema":
+				require.NotNil(t, got.Items)
+				require.NotNil(t, got.Items.Schema)
+				assert.Equal(t, spec.StringOrArray{"string"}, got.Items.Schema.Type)
+			case "items tuple schemas":
+				require.NotNil(t, got.Items)
+				require.Len(t, got.Items.Schemas, 2)
+				assert.Equal(t, spec.StringOrArray{"string"}, got.Items.Schemas[0].Type)
+				assert.Equal(t, spec.StringOrArray{"integer"}, got.Items.Schemas[1].Type)
+			case "allOf oneOf anyOf not combinators":
+				require.Len(t, got.AllOf, 1)
+				require.Len(t, got.OneOf, 1)
+				require.Len(t, got.AnyOf, 1)
+				require.NotNil(t, got.Not)
+				assert.Equal(t, spec.StringOrArray{"number"}, got.Not.Type)
+			case "nested properties":
+				prop, ok := got.Properties["name"]
+				require.True(t, ok)
+				assert.Equal(t, spec.StringOrArray{"string"}, prop.Type)
+			case "additionalProperties schema":
+				require.NotNil(t, got.AdditionalProperties)
+				require.NotNil(t, got.AdditionalProperties.Schema)
+				assert.Equal(t, spec.StringOrArray{"string"}, got.AdditionalProperties.Schema.Type)
+			case "additionalProperties allows":
+				require.NotNil(t, got.AdditionalProperties)
+				assert.True(t, got.AdditionalProperties.Allows)
+				assert.Nil(t, got.AdditionalProperties.Schema)
+			case "preserve unknown fields extension":
+				v, ok := got.Extensions[krocel.XKubernetesPreserveUnknownFields]
+				require.True(t, ok)
+				assert.Equal(t, true, v)
+			}
+		})
+	}
+}

--- a/pkg/graph/schema/field_descriptor_evals_test.go
+++ b/pkg/graph/schema/field_descriptor_evals_test.go
@@ -1,0 +1,164 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// TestAreValidExpressionEvals pins the validity rule used when a field is
+// built from a multi-segment template: no values is invalid, a single value
+// is always valid, and multi-value runs are only valid when every value is a
+// string (string concatenation being the only meaningful multi-expression
+// combination).
+func TestAreValidExpressionEvals(t *testing.T) {
+	tests := []struct {
+		name  string
+		evals []ref.Val
+		want  bool
+	}{
+		{name: "empty is invalid", evals: nil, want: false},
+		{name: "single value is valid", evals: []ref.Val{types.Int(1)}, want: true},
+		{
+			name:  "multi strings valid",
+			evals: []ref.Val{types.String("a"), types.String("b")},
+			want:  true,
+		},
+		{
+			name:  "multi first not string invalid",
+			evals: []ref.Val{types.Int(1), types.Int(2)},
+			want:  false,
+		},
+		{
+			name:  "multi mixed types invalid",
+			evals: []ref.Val{types.String("a"), types.Int(2)},
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, areValidExpressionEvals(tc.evals))
+		})
+	}
+}
+
+// TestGenerateSchemaFromEvals_ErrorPaths covers the failure surface of the
+// evals-to-schema entry point: invalid eval sets and unsupported value types
+// both bubble up as errors.
+func TestGenerateSchemaFromEvals_ErrorPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		evals   map[string][]ref.Val
+		wantErr bool
+	}{
+		{
+			name:    "invalid eval set (empty)",
+			evals:   map[string][]ref.Val{"status.x": {}},
+			wantErr: true,
+		},
+		{
+			name:    "multi-value mixed types",
+			evals:   map[string][]ref.Val{"status.x": {types.Int(1), types.Int(2)}},
+			wantErr: true,
+		},
+		{
+			name:    "unsupported value type errors",
+			evals:   map[string][]ref.Val{"status.x": {types.NullValue}},
+			wantErr: true,
+		},
+		{
+			name:    "valid single value",
+			evals:   map[string][]ref.Val{"status.x": {types.String("v")}},
+			wantErr: false,
+		},
+		{
+			name:    "unparsable path errors",
+			evals:   map[string][]ref.Val{"status..x": {types.String("v")}},
+			wantErr: true,
+		},
+		{
+			name:    "array leaf path",
+			evals:   map[string][]ref.Val{"status.items[0]": {types.String("v")}},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GenerateSchemaFromEvals(tc.evals)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+		})
+	}
+}
+
+// TestAddFieldToSchema_NilLeafDefaultsToString verifies that a field
+// descriptor with a nil schema defaults its leaf to a string type, and that
+// an unparsable path surfaces an error.
+func TestAddFieldToSchema_NilLeafDefaultsToString(t *testing.T) {
+	tests := []struct {
+		name      string
+		fd        fieldDescriptor
+		wantErr   bool
+		wantField bool
+	}{
+		{
+			name:      "nil schema defaults to string",
+			fd:        fieldDescriptor{Path: "status.x", Schema: nil},
+			wantField: true,
+		},
+		{
+			name:      "empty path is a no-op",
+			fd:        fieldDescriptor{Path: "", Schema: nil},
+			wantField: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := &extv1.JSONSchemaProps{
+				Type:       "object",
+				Properties: make(map[string]extv1.JSONSchemaProps),
+			}
+			err := addFieldToSchema(tc.fd, root)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if !tc.wantField {
+				assert.Empty(t, root.Properties)
+				return
+			}
+			status, ok := root.Properties["status"]
+			require.True(t, ok)
+			x, ok := status.Properties["x"]
+			require.True(t, ok)
+			assert.Equal(t, "string", x.Type)
+		})
+	}
+}

--- a/pkg/graph/schema/resolver/cached.go
+++ b/pkg/graph/schema/resolver/cached.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/sync/singleflight"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// CachedSchemaResolver wraps an underlying schema resolver with a
+// bounded LRU cache and push-driven invalidation. Entries live until
+// either the LRU evicts them under capacity pressure or
+// InvalidateGroupKind is called (typically by the schema watcher when
+// a CRD content change is observed).
+//
+// There is no time-based TTL: because the schema watcher fires precise
+// invalidations on CRD changes, periodic refetches are redundant. The cache
+// stays correct as long as the watcher pushes every relevant change.
+//
+// Concurrent fetches for the same GVK are deduplicated through
+// singleflight so the underlying delegate sees one call per unique
+// key, even under high concurrency.
+type CachedSchemaResolver struct {
+	delegate resolver.SchemaResolver
+
+	cache  *lru.Cache[schema.GroupVersionKind, *spec.Schema]
+	sf     singleflight.Group
+	mu     sync.RWMutex
+	epochs map[schema.GroupKind]uint64
+}
+
+// NewCachedSchemaResolver builds a cached resolver around the given
+// delegate. maxSize bounds the LRU; oldest entries evict first when
+// capacity is reached. A reasonable default for production: ~500 for
+// installations with up to a few hundred CRDs.
+func NewCachedSchemaResolver(delegate resolver.SchemaResolver, maxSize int) (*CachedSchemaResolver, error) {
+	cache, err := lru.New[schema.GroupVersionKind, *spec.Schema](maxSize)
+	if err != nil {
+		return nil, err
+	}
+	return &CachedSchemaResolver{
+		delegate: delegate,
+		cache:    cache,
+		epochs:   make(map[schema.GroupKind]uint64),
+	}, nil
+}
+
+// InvalidateGroupKind drops every cached entry whose GroupKind matches
+// the supplied value. The schema watcher calls this on CRD content
+// changes so subsequent ResolveSchema calls re-fetch the new shape.
+// Idempotent: calling for an unknown GK is a no-op.
+func (c *CachedSchemaResolver) InvalidateGroupKind(gk schema.GroupKind) {
+	c.mu.Lock()
+	c.epochs[gk]++
+	for _, k := range c.cache.Keys() {
+		if k.GroupKind() == gk {
+			c.cache.Remove(k)
+			c.sf.Forget(k.String())
+		}
+	}
+	c.mu.Unlock()
+}
+
+// ResolveSchema returns the schema for gvk, hitting the cache when
+// possible. Concurrent misses for the same gvk collapse to one
+// delegate call via singleflight.
+func (c *CachedSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	if sch, ok := c.cache.Get(gvk); ok {
+		return sch, nil
+	}
+	gk := gvk.GroupKind()
+	c.mu.RLock()
+	epoch := c.epochs[gk]
+	c.mu.RUnlock()
+
+	key := gvk.String()
+	result, err, _ := c.sf.Do(key, func() (any, error) {
+		if sch, ok := c.cache.Get(gvk); ok {
+			return sch, nil
+		}
+		sch, err := c.delegate.ResolveSchema(gvk)
+		if err != nil {
+			return nil, err
+		}
+		c.mu.RLock()
+		curEpoch := c.epochs[gk]
+		c.mu.RUnlock()
+		if curEpoch == epoch {
+			c.cache.Add(gvk, sch)
+		}
+		return sch, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*spec.Schema), nil
+}

--- a/pkg/graph/schema/resolver/cached_test.go
+++ b/pkg/graph/schema/resolver/cached_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// mockResolver counts ResolveSchema invocations and hands back a
+// deterministic empty schema. Counts are atomic-safe for the
+// concurrent test row.
+type pushMockResolver struct {
+	calls int32
+}
+
+func (m *pushMockResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	atomic.AddInt32(&m.calls, 1)
+	return &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"object"}}}, nil
+}
+
+func (m *pushMockResolver) count() int { return int(atomic.LoadInt32(&m.calls)) }
+
+func gvk(group, version, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
+}
+
+// TestCachedSchemaResolver_Caching covers the cache-hit / cache-miss
+// mechanics in a single table — dedup on concurrent fetch, separate
+// GVKs each take a slot, repeated lookups don't pay a delegate call.
+// LRU eviction has its own row because the steps run in a specific
+// order with a small cache size.
+func TestCachedSchemaResolver_Caching(t *testing.T) {
+	tests := []struct {
+		name      string
+		size      int
+		fetches   func(t *testing.T, c *CachedSchemaResolver, m *pushMockResolver)
+		wantCalls int
+	}{
+		{
+			name: "single-gvk-repeated-fetch-hits-once",
+			size: 100,
+			fetches: func(t *testing.T, c *CachedSchemaResolver, _ *pushMockResolver) {
+				k := gvk("apps", "v1", "Deployment")
+				for i := 0; i < 10; i++ {
+					_, err := c.ResolveSchema(k)
+					require.NoError(t, err)
+				}
+			},
+			wantCalls: 1,
+		},
+		{
+			name: "distinct-gvks-each-fetch-once",
+			size: 100,
+			fetches: func(t *testing.T, c *CachedSchemaResolver, _ *pushMockResolver) {
+				for _, k := range []schema.GroupVersionKind{
+					gvk("apps", "v1", "Deployment"),
+					gvk("apps", "v1", "StatefulSet"),
+					gvk("batch", "v1", "Job"),
+				} {
+					_, err := c.ResolveSchema(k)
+					require.NoError(t, err)
+					_, err = c.ResolveSchema(k) // second fetch is a hit
+					require.NoError(t, err)
+				}
+			},
+			wantCalls: 3,
+		},
+		{
+			name: "concurrent-fetches-for-same-gvk-collapse-to-one",
+			size: 100,
+			fetches: func(t *testing.T, c *CachedSchemaResolver, _ *pushMockResolver) {
+				k := gvk("apps", "v1", "Deployment")
+				var wg sync.WaitGroup
+				for i := 0; i < 50; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						_, err := c.ResolveSchema(k)
+						assert.NoError(t, err)
+					}()
+				}
+				wg.Wait()
+			},
+			wantCalls: 1,
+		},
+		{
+			name: "lru-evicts-oldest-then-refetches",
+			size: 3,
+			fetches: func(t *testing.T, c *CachedSchemaResolver, m *pushMockResolver) {
+				gvks := []schema.GroupVersionKind{
+					gvk("apps", "v1", "Deployment"), // oldest
+					gvk("apps", "v1", "StatefulSet"),
+					gvk("batch", "v1", "Job"),
+					gvk("batch", "v1", "CronJob"), // forces eviction of Deployment
+				}
+				for _, k := range gvks {
+					_, err := c.ResolveSchema(k)
+					require.NoError(t, err)
+				}
+				// Re-fetch the evicted GVK: should hit the delegate again.
+				preCount := m.count()
+				_, err := c.ResolveSchema(gvks[0])
+				require.NoError(t, err)
+				assert.Equal(t, preCount+1, m.count(), "evicted GVK should re-call delegate")
+				// CronJob is still in the cache.
+				preCount = m.count()
+				_, err = c.ResolveSchema(gvks[3])
+				require.NoError(t, err)
+				assert.Equal(t, preCount, m.count(), "cached GVK should not re-call delegate")
+			},
+			wantCalls: 5, // 4 initial + 1 refetch
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &pushMockResolver{}
+			cached, err := NewCachedSchemaResolver(mock, tc.size)
+			require.NoError(t, err)
+			tc.fetches(t, cached, mock)
+			assert.Equal(t, tc.wantCalls, mock.count())
+		})
+	}
+}
+
+// TestCachedSchemaResolver_InvalidateGroupKind pins push-driven
+// eviction. The schema watcher calls InvalidateGroupKind when a CRD's
+// schema content changes; this test confirms entries for that GK are
+// dropped (and entries for other GKs untouched).
+func TestCachedSchemaResolver_InvalidateGroupKind(t *testing.T) {
+	mock := &pushMockResolver{}
+	cached, err := NewCachedSchemaResolver(mock, 100)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		seed        []schema.GroupVersionKind
+		invalidate  schema.GroupKind
+		refetch     schema.GroupVersionKind
+		wantNewCall bool
+	}{
+		{
+			name: "matching-gk-evicts-entry",
+			seed: []schema.GroupVersionKind{
+				gvk("apps", "v1", "Deployment"),
+				gvk("apps", "v1beta1", "Deployment"), // same GK, different version
+			},
+			invalidate:  schema.GroupKind{Group: "apps", Kind: "Deployment"},
+			refetch:     gvk("apps", "v1", "Deployment"),
+			wantNewCall: true,
+		},
+		{
+			name: "non-matching-gk-leaves-entry",
+			seed: []schema.GroupVersionKind{
+				gvk("apps", "v1", "Deployment"),
+				gvk("batch", "v1", "Job"),
+			},
+			invalidate:  schema.GroupKind{Group: "batch", Kind: "Job"},
+			refetch:     gvk("apps", "v1", "Deployment"),
+			wantNewCall: false,
+		},
+		{
+			name:        "invalidate-unknown-gk-is-noop",
+			seed:        []schema.GroupVersionKind{gvk("apps", "v1", "Deployment")},
+			invalidate:  schema.GroupKind{Group: "fictional", Kind: "Widget"},
+			refetch:     gvk("apps", "v1", "Deployment"),
+			wantNewCall: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fresh resolver per row so seed counts don't leak across.
+			mock := &pushMockResolver{}
+			cached, err := NewCachedSchemaResolver(mock, 100)
+			require.NoError(t, err)
+			for _, k := range tc.seed {
+				_, err := cached.ResolveSchema(k)
+				require.NoError(t, err)
+			}
+			seedCalls := mock.count()
+			cached.InvalidateGroupKind(tc.invalidate)
+			_, err = cached.ResolveSchema(tc.refetch)
+			require.NoError(t, err)
+			postCalls := mock.count()
+			if tc.wantNewCall {
+				assert.Equal(t, seedCalls+1, postCalls, "expected delegate to be called again post-invalidate")
+			} else {
+				assert.Equal(t, seedCalls, postCalls, "expected cache to still cover refetch")
+			}
+		})
+	}
+
+	_ = cached // keep linter happy if the outer cached is unused
+}
+
+// TestCachedSchemaResolver_InvalidateDuringInFlightFetch pins the epoch tracking contract:
+// if InvalidateGroupKind is called while an in-flight fetch is in progress, the fetched schema
+// must not be cached because it may be stale.
+func TestCachedSchemaResolver_InvalidateDuringInFlightFetch(t *testing.T) {
+	fetchStarted := make(chan struct{})
+	allowFetchToComplete := make(chan struct{})
+
+	var calls int32
+	blockingDelegate := &blockingResolver{
+		onResolve: func() {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				close(fetchStarted)
+				<-allowFetchToComplete
+			}
+		},
+	}
+
+	cached, err := NewCachedSchemaResolver(blockingDelegate, 100)
+	require.NoError(t, err)
+
+	k := gvk("custom.example.com", "v1", "MyResource")
+
+	// Start in-flight fetch in background
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := cached.ResolveSchema(k)
+		assert.NoError(t, err)
+	}()
+
+	// Wait until delegate has started resolving
+	<-fetchStarted
+
+	// Invalidate the GK while the fetch is still running
+	cached.InvalidateGroupKind(k.GroupKind())
+
+	// Allow the first fetch to complete
+	close(allowFetchToComplete)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	// Next ResolveSchema should not hit cache, but call delegate again
+	_, err = cached.ResolveSchema(k)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "expected second call to delegate because in-flight result was invalidated")
+}
+
+type blockingResolver struct {
+	onResolve func()
+}
+
+func (b *blockingResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	if b.onResolve != nil {
+		b.onResolve()
+	}
+	return &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"object"}}}, nil
+}

--- a/pkg/graph/schema/resolver/combined_cached_test.go
+++ b/pkg/graph/schema/resolver/combined_cached_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// errResolver always returns the configured error, counting calls so the
+// delegate-error rows can assert the cache never memoizes a failure.
+type errResolver struct {
+	err   error
+	calls int
+}
+
+func (e *errResolver) ResolveSchema(_ schema.GroupVersionKind) (*spec.Schema, error) {
+	e.calls++
+	return nil, e.err
+}
+
+// TestNewCachedSchemaResolver covers the constructor's success and failure
+// surfaces in one table: a positive size builds a usable resolver, while a
+// non-positive size bubbles up the LRU's error.
+func TestNewCachedSchemaResolver(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    int
+		wantErr bool
+	}{
+		{name: "positive-size-succeeds", size: 10, wantErr: false},
+		{name: "zero-size-errors", size: 0, wantErr: true},
+		{name: "negative-size-errors", size: -1, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCachedSchemaResolver(&pushMockResolver{}, tc.size)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, c)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, c)
+		})
+	}
+}
+
+// TestCachedSchemaResolver_ResolveSchema_DelegateError pins the error path:
+// a failing delegate must surface its error and must NOT be memoized, so a
+// subsequent call re-invokes the delegate.
+func TestCachedSchemaResolver_ResolveSchema_DelegateError(t *testing.T) {
+	tests := []struct {
+		name      string
+		delegate  *errResolver
+		wantCalls int
+	}{
+		{
+			name:      "error-propagates-and-is-not-cached",
+			delegate:  &errResolver{err: errors.New("boom")},
+			wantCalls: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCachedSchemaResolver(tc.delegate, 10)
+			require.NoError(t, err)
+
+			k := gvk("apps", "v1", "Deployment")
+
+			sch, err := c.ResolveSchema(k)
+			require.Error(t, err)
+			assert.Nil(t, sch)
+
+			// Error results are not memoized, so a second call re-hits the delegate.
+			sch, err = c.ResolveSchema(k)
+			require.Error(t, err)
+			assert.Nil(t, sch)
+
+			assert.Equal(t, tc.wantCalls, tc.delegate.calls)
+		})
+	}
+}
+
+// TestNewCombinedResolverWithCache exercises the wiring helper. Building a discovery
+// client from a rest.Config is offline (no server contact), so a minimal
+// config yields a combined resolver plus the live cached resolver for
+// invalidation plumbing.
+func TestNewCombinedResolverWithCache(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *rest.Config
+		wantErr bool
+	}{
+		{
+			name:    "minimal-config-wires-resolvers",
+			config:  &rest.Config{Host: "https://example.invalid"},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			combined, cached, err := NewCombinedResolverWithCache(tc.config, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, combined)
+			assert.NotNil(t, cached)
+		})
+	}
+}

--- a/pkg/graph/schema/resolver/resolver.go
+++ b/pkg/graph/schema/resolver/resolver.go
@@ -15,6 +15,7 @@
 package resolver
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -56,4 +57,34 @@ func NewCombinedResolver(clientConfig *rest.Config, httpClient *http.Client) (re
 
 	combinedResolver := coreResolver.Combine(cachedResolver)
 	return combinedResolver, nil
+}
+
+// NewCombinedResolverWithCache uses the same two-tier wiring as
+// NewCombinedResolver, but the discovery-backed tier is a push-invalidated LRU
+// (CachedSchemaResolver) instead of a TTL cache. The live cache is returned so
+// a schema watcher can call InvalidateGroupKind.
+func NewCombinedResolverWithCache(clientConfig *rest.Config, httpClient *http.Client) (resolver.SchemaResolver, *CachedSchemaResolver, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(clientConfig, httpClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create discovery client: %w", err)
+	}
+
+	clientResolver := &resolver.ClientDiscoveryResolver{
+		Discovery: discoveryClient,
+	}
+
+	// 500 entries comfortably covers ~200 CRDs × 2-3 versions, with
+	// LRU eviction handling installations with more.
+	cached, err := NewCachedSchemaResolver(clientResolver, 500)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create cached schema resolver: %w", err)
+	}
+
+	coreResolver := resolver.NewDefinitionsSchemaResolver(
+		openapi.GetOpenAPIDefinitions,
+		scheme.Scheme,
+	)
+
+	combined := coreResolver.Combine(cached)
+	return combined, cached, nil
 }

--- a/pkg/graph/schema/schema_test.go
+++ b/pkg/graph/schema/schema_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// TestBuildNamespacelessObjectMetaSchema checks that the namespace property
+// and required entry are dropped, while other fields are preserved. The
+// nil-Properties / nil-Required rows exercise the early-skip branches.
+func TestBuildNamespacelessObjectMetaSchema(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        spec.Schema
+		wantProps    []string
+		wantNotProps []string
+		wantRequired []string
+	}{
+		{
+			name: "drops namespace property and required entry",
+			input: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"name":      {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+						"namespace": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					},
+					Required: []string{"name", "namespace"},
+				},
+			},
+			wantProps:    []string{"name"},
+			wantNotProps: []string{"namespace"},
+			wantRequired: []string{"name"},
+		},
+		{
+			name:  "nil properties and required is a no-op",
+			input: spec.Schema{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildNamespacelessObjectMetaSchema(tc.input)
+
+			for _, p := range tc.wantProps {
+				_, ok := got.Properties[p]
+				assert.True(t, ok, "expected property %q", p)
+			}
+			for _, p := range tc.wantNotProps {
+				_, ok := got.Properties[p]
+				assert.False(t, ok, "did not expect property %q", p)
+			}
+			if tc.wantRequired != nil {
+				assert.Equal(t, tc.wantRequired, got.Required)
+			}
+		})
+	}
+}
+
+// TestObjectMetaSchemasPopulated confirms the package-level schemas were
+// populated by init, and that the namespaceless variant has no namespace.
+func TestObjectMetaSchemasPopulated(t *testing.T) {
+	require.NotNil(t, ObjectMetaSchema.Properties)
+	_, hasNamespace := ObjectMetaSchema.Properties["namespace"]
+	assert.True(t, hasNamespace, "ObjectMeta should carry namespace")
+
+	require.NotNil(t, NamespacelessObjectMetaSchema.Properties)
+	_, hasNamespaceless := NamespacelessObjectMetaSchema.Properties["namespace"]
+	assert.False(t, hasNamespaceless, "namespaceless variant must omit namespace")
+}


### PR DESCRIPTION
## Description
- Adds per-GroupKind invalidation epoch tracking to `CachedSchemaResolver` to prevent in-flight `singleflight.Do` fetches from caching stale schemas if an `Invalidate()` event occurs concurrently.
- Adds comprehensive unit test coverage for schema caching, CEL type conversion, type fallbacks, and schema field descriptors.

## Type of change
- [x] Bug fix
- [x] Test coverage

## Testing
- `make build`
- `make lint`
- `make test WHAT=unit`
- Integration test suite passed.