### PR TITLE
feat(cel): add AST inspector, program cost limits, and CEL test coverage

### DIFF
--- a/pkg/cel/ast/inspector.go
+++ b/pkg/cel/ast/inspector.go
@@ -73,6 +73,13 @@ type ExpressionInspection struct {
 	// ResourceDependencies lists all known resources and their access paths
 	// used in the expression
 	ResourceDependencies []ResourceDependency
+	// OptionalResourceDependencies lists known resources that appear only as
+	// the direct receiver of CEL optional chaining (id.?field / id[?"k"]) —
+	// the id is arg[0] of a `_?._` or `_[?_]` call. This is a strict subset of
+	// the occurrences also recorded in ResourceDependencies; callers compare
+	// occurrence counts to decide whether every reference to an id is optional
+	// (a soft dependency) or at least one is a hard reference.
+	OptionalResourceDependencies []ResourceDependency
 	// FunctionCalls lists all known function calls and their arguments found
 	// in the expression
 	FunctionCalls []FunctionCall
@@ -95,6 +102,7 @@ func (e *ExpressionInspection) UsesOmit() bool {
 
 func (e *ExpressionInspection) merge(other ExpressionInspection) {
 	e.ResourceDependencies = append(e.ResourceDependencies, other.ResourceDependencies...)
+	e.OptionalResourceDependencies = append(e.OptionalResourceDependencies, other.OptionalResourceDependencies...)
 	e.FunctionCalls = append(e.FunctionCalls, other.FunctionCalls...)
 	e.UnknownResources = append(e.UnknownResources, other.UnknownResources...)
 	e.UnknownFunctions = append(e.UnknownFunctions, other.UnknownFunctions...)
@@ -262,6 +270,24 @@ func (a *Inspector) inspectCall(ast *celast.AST, call celast.CallExpr, path stri
 
 	for _, arg := range call.Args() {
 		out.merge(a.inspectExpr(ast, arg, ""))
+	}
+
+	// Optional chaining: `id.?field` (_?._) and `id[?"k"]` (_[?_]) parse with
+	// the made-optional receiver as arg[0]. When that receiver is a bare,
+	// known-resource identifier, the whole reference is non-gating: if the
+	// resource has not published yet the expression yields optional.none() and
+	// the field is dropped. Record it so the caller can tell a
+	// receiver-of-optional reference apart from a hard access on the same id.
+	if fn == "_?._" || fn == "_[?_]" {
+		args := call.Args()
+		if len(args) >= 1 && args[0].Kind() == celast.IdentKind {
+			name := args[0].AsIdent()
+			if _, isLoop := a.loopVars[name]; !isLoop {
+				if _, ok := a.resources[name]; ok {
+					out.OptionalResourceDependencies = append(out.OptionalResourceDependencies, ResourceDependency{ID: name, Path: name})
+				}
+			}
+		}
 	}
 
 	// Namespaced (member) function: target.method

--- a/pkg/cel/ast/inspector_test.go
+++ b/pkg/cel/ast/inspector_test.go
@@ -1149,3 +1149,106 @@ func testInspector(resources []string, functions []string) (*Inspector, error) {
 		loopVars:  make(map[string]struct{}),
 	}, nil
 }
+
+// TestInspector_OptionalDependencies verifies that a resource id is recorded
+// in OptionalResourceDependencies only when it is the direct receiver of CEL
+// optional chaining (id.?field / id[?"k"]), while every occurrence — optional
+// or hard — still appears in ResourceDependencies unchanged.
+func TestInspector_OptionalDependencies(t *testing.T) {
+	tests := []struct {
+		name          string
+		resources     []string
+		expression    string
+		wantResources []string // ids expected in ResourceDependencies
+		wantOptional  []string // ids expected in OptionalResourceDependencies
+	}{
+		{
+			name:          "optional select receiver",
+			resources:     []string{"x"},
+			expression:    `x.?y`,
+			wantResources: []string{"x"},
+			wantOptional:  []string{"x"},
+		},
+		{
+			name:          "optional index receiver",
+			resources:     []string{"x"},
+			expression:    `x[?"k"]`,
+			wantResources: []string{"x"},
+			wantOptional:  []string{"x"},
+		},
+		{
+			name:          "optional select with orValue",
+			resources:     []string{"x"},
+			expression:    `x.?y.orValue("z")`,
+			wantResources: []string{"x"},
+			wantOptional:  []string{"x"},
+		},
+		{
+			name:          "hard select stays hard",
+			resources:     []string{"x"},
+			expression:    `x.y`,
+			wantResources: []string{"x"},
+			wantOptional:  nil,
+		},
+		{
+			name:          "hard select then optional field: receiver is hard",
+			resources:     []string{"x"},
+			expression:    `x.spec.?field`,
+			wantResources: []string{"x"},
+			wantOptional:  nil,
+		},
+		{
+			name:          "one optional one hard across ids",
+			resources:     []string{"x", "z"},
+			expression:    `x.?y.orValue(z.w)`,
+			wantResources: []string{"x", "z"},
+			wantOptional:  []string{"x"},
+		},
+		{
+			name:          "same id optional and hard",
+			resources:     []string{"x"},
+			expression:    `x.?y.orValue(x.z)`,
+			wantResources: []string{"x", "x"},
+			wantOptional:  []string{"x"},
+		},
+	}
+
+	ids := func(deps []ResourceDependency) []string {
+		out := make([]string, 0, len(deps))
+		for _, d := range deps {
+			out = append(out, d.ID)
+		}
+		slices.Sort(out)
+		return out
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector, err := testInspector(tt.resources, nil)
+			if err != nil {
+				t.Fatalf("Failed to create inspector: %v", err)
+			}
+			got, err := inspector.Inspect(tt.expression)
+			if err != nil {
+				t.Fatalf("Inspect() error = %v", err)
+			}
+			wantRes := append([]string(nil), tt.wantResources...)
+			slices.Sort(wantRes)
+			if gotRes := ids(got.ResourceDependencies); !reflect.DeepEqual(gotRes, wantRes) {
+				t.Errorf("ResourceDependencies ids = %v, want %v", gotRes, wantRes)
+			}
+			wantOpt := append([]string(nil), tt.wantOptional...)
+			slices.Sort(wantOpt)
+			gotOpt := ids(got.OptionalResourceDependencies)
+			if len(gotOpt) == 0 {
+				gotOpt = nil
+			}
+			if len(wantOpt) == 0 {
+				wantOpt = nil
+			}
+			if !reflect.DeepEqual(gotOpt, wantOpt) {
+				t.Errorf("OptionalResourceDependencies ids = %v, want %v", gotOpt, wantOpt)
+			}
+		})
+	}
+}

--- a/pkg/cel/conversion/conversions_coverage_test.go
+++ b/pkg/cel/conversion/conversions_coverage_test.go
@@ -1,0 +1,198 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conversion
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
+)
+
+// evalExpr compiles and evaluates a CEL expression returning the ref.Val.
+func evalExpr(t *testing.T, expr string) ref.Val {
+	t.Helper()
+	env, err := cel.NewEnv()
+	require.NoError(t, err)
+	ast, issues := env.Compile(expr)
+	require.NoError(t, issues.Err())
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+	val, _, err := prog.Eval(map[string]interface{}{})
+	require.NoError(t, err)
+	return val
+}
+
+func TestGoNativeType_Scalars(t *testing.T) {
+	cases := []struct {
+		name string
+		val  ref.Val
+		want interface{}
+	}{
+		{name: "nil ref.Val", val: nil, want: nil},
+		{name: "bool", val: evalExpr(t, `true`), want: true},
+		{name: "int", val: evalExpr(t, `int(42)`), want: int64(42)},
+		{name: "uint", val: evalExpr(t, `uint(7)`), want: uint64(7)},
+		{name: "double", val: evalExpr(t, `3.5`), want: float64(3.5)},
+		{name: "string", val: evalExpr(t, `"hi"`), want: "hi"},
+		{name: "null", val: types.NullValue, want: nil},
+		{name: "optional empty", val: types.OptionalNone, want: nil},
+		{name: "optional with value", val: types.OptionalOf(types.String("x")), want: "x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GoNativeType(tc.val)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// omitTestVal is a minimal ref.Val whose Value() returns the omit sentinel
+// and whose Type() is unrecognized by GoNativeType, exercising the default
+// branch that special-cases the omit sentinel.
+type omitTestVal struct{}
+
+func (omitTestVal) ConvertToNative(reflect.Type) (any, error) { return sentinels.Omit{}, nil }
+func (omitTestVal) ConvertToType(ref.Type) ref.Val            { return types.NewErr("nope") }
+func (omitTestVal) Equal(ref.Val) ref.Val                     { return types.NewErr("nope") }
+func (omitTestVal) Type() ref.Type                            { return types.NewObjectType("kro.omit") }
+func (omitTestVal) Value() any                                { return sentinels.Omit{} }
+
+func TestGoNativeType_OmitSentinel(t *testing.T) {
+	got, err := GoNativeType(omitTestVal{})
+	require.NoError(t, err)
+	assert.Equal(t, sentinels.Omit{}, got)
+}
+
+func TestGoNativeType_UnsupportedType(t *testing.T) {
+	// A type that GoNativeType doesn't recognize and isn't the omit
+	// sentinel falls through to the error branch.
+	got, err := GoNativeType(types.NewErr("boom"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+	_ = got
+}
+
+func TestGoNativeType_MapKeyAndValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{name: "string keyed map", expr: `{"a": 1, "b": 2}`},
+		{name: "nested list value", expr: `{"items": [1, 2, 3]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val := evalExpr(t, tc.expr)
+			got, err := GoNativeType(val)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			_, ok := got.(map[string]interface{})
+			assert.True(t, ok, "expected map[string]interface{}, got %T", got)
+		})
+	}
+}
+
+func TestConvertMap_NonStringKey(t *testing.T) {
+	// A map keyed by a non-string type triggers the "map key must be string"
+	// error path in convertMap.
+	reg := types.NewEmptyRegistry()
+	val := reg.NativeToValue(map[int64]int64{1: 2})
+	require.Equal(t, types.MapType, val.Type())
+
+	_, err := GoNativeType(val)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "map key must be string")
+}
+
+func TestConvertList_RawSlice(t *testing.T) {
+	// A raw Go slice wrapped via the registry is a Lister and should round-trip
+	// through convertList.
+	reg := types.NewEmptyRegistry()
+	val := reg.NativeToValue([]interface{}{int64(1), "two", true})
+	require.Equal(t, types.ListType, val.Type())
+
+	got, err := GoNativeType(val)
+	require.NoError(t, err)
+	list, ok := got.([]interface{})
+	require.True(t, ok, "expected []interface{}, got %T", got)
+	assert.Equal(t, []interface{}{int64(1), "two", true}, list)
+}
+
+func TestIsBoolType(t *testing.T) {
+	cases := []struct {
+		name string
+		val  ref.Val
+		want bool
+	}{
+		{name: "bool true", val: types.Bool(true), want: true},
+		{name: "int is not bool", val: types.Int(1), want: false},
+		{name: "string is not bool", val: types.String("x"), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsBoolType(tc.val))
+		})
+	}
+}
+
+func TestWouldMatchIfUnwrapped(t *testing.T) {
+	cases := []struct {
+		name     string
+		output   *cel.Type
+		expected *cel.Type
+		want     bool
+	}{
+		{name: "nil output", output: nil, expected: cel.BoolType, want: false},
+		{name: "nil expected", output: cel.BoolType, expected: nil, want: false},
+		{name: "already assignable", output: cel.BoolType, expected: cel.BoolType, want: false},
+		{name: "optional of expected matches output", output: cel.OptionalType(cel.BoolType), expected: cel.BoolType, want: true},
+		{name: "unrelated types", output: cel.StringType, expected: cel.BoolType, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, WouldMatchIfUnwrapped(tc.output, tc.expected))
+		})
+	}
+}
+
+func TestIsBoolOrOptionalBool(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  *cel.Type
+		want bool
+	}{
+		{name: "bool", typ: cel.BoolType, want: true},
+		{name: "optional bool", typ: cel.OptionalType(cel.BoolType), want: true},
+		{name: "string", typ: cel.StringType, want: false},
+		{name: "optional string", typ: cel.OptionalType(cel.StringType), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsBoolOrOptionalBool(tc.typ))
+		})
+	}
+}

--- a/pkg/cel/coverage_test.go
+++ b/pkg/cel/coverage_test.go
@@ -1,0 +1,733 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// --- expression.go ---
+
+func TestExpression_Constructors(t *testing.T) {
+	t.Run("NewUncompiled", func(t *testing.T) {
+		e := NewUncompiled("schema.spec.name")
+		assert.Equal(t, "schema.spec.name", e.Original)
+		assert.Nil(t, e.Program)
+		assert.Nil(t, e.References)
+	})
+	t.Run("NewUncompiledSlice", func(t *testing.T) {
+		s := NewUncompiledSlice("a", "b", "c")
+		require.Len(t, s, 3)
+		assert.Equal(t, "a", s[0].Original)
+		assert.Equal(t, "c", s[2].Original)
+	})
+}
+
+func TestExpression_UserExpression(t *testing.T) {
+	cases := []struct {
+		name string
+		expr *Expression
+		want string
+	}{
+		{
+			name: "falls back to Original",
+			expr: &Expression{Original: `"x" + y`},
+			want: `"x" + y`,
+		},
+		{
+			name: "prefers OriginalTemplate",
+			expr: &Expression{Original: `"prefix-" + y`, OriginalTemplate: "prefix-${y}"},
+			want: "prefix-${y}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.expr.UserExpression())
+		})
+	}
+}
+
+func TestExpression_Eval(t *testing.T) {
+	env, err := DefaultEnvironment(WithResourceIDs([]string{"x"}))
+	require.NoError(t, err)
+
+	compile := func(t *testing.T, src string) cel.Program {
+		t.Helper()
+		ast, issues := env.Compile(src)
+		require.NoError(t, issues.Err())
+		prg, err := env.Program(ast)
+		require.NoError(t, err)
+		return prg
+	}
+
+	t.Run("success", func(t *testing.T) {
+		e := &Expression{Original: "x + 1", Program: compile(t, "x + 1")}
+		got, err := e.Eval(map[string]any{"x": int64(41)})
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), got)
+	})
+
+	t.Run("eval error surfaces wrapped", func(t *testing.T) {
+		// Division by zero produces an eval-time error.
+		e := &Expression{Original: "x / 0", Program: compile(t, "x / 0")}
+		_, err := e.Eval(map[string]any{"x": int64(1)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "eval")
+	})
+}
+
+// --- environment.go typed constructors ---
+
+// simpleObjectSchema builds an object schema with a couple of typed fields,
+// enough to drive SchemaDeclTypeWithMetadata and the typed-environment path.
+func simpleObjectSchema() *spec.Schema {
+	return &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"name":     {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			"replicas": {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+		},
+		Required: []string{"name"},
+	}}
+}
+
+func TestTypedEnvironmentConstructors(t *testing.T) {
+	schemas := map[string]*spec.Schema{"schema": simpleObjectSchema()}
+
+	t.Run("TypedEnvironment", func(t *testing.T) {
+		env, err := TypedEnvironment(schemas)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		_, issues := env.Compile("schema.name")
+		assert.NoError(t, issues.Err())
+	})
+
+	t.Run("TypedEnvironmentWithProvider", func(t *testing.T) {
+		env, provider, err := TypedEnvironmentWithProvider(schemas)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		require.NotNil(t, provider)
+	})
+
+	t.Run("TypedEnvironmentWithIDsAndProvider", func(t *testing.T) {
+		env, provider, err := TypedEnvironmentWithIDsAndProvider(schemas, []string{"extra"})
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		require.NotNil(t, provider)
+		// The typed var and the dyn id should both type-check.
+		_, issues := env.Compile("schema.replicas")
+		assert.NoError(t, issues.Err())
+		_, issues = env.Compile("extra")
+		assert.NoError(t, issues.Err())
+	})
+}
+
+func TestWithTypedResources(t *testing.T) {
+	a := map[string]*spec.Schema{"a": simpleObjectSchema()}
+	b := map[string]*spec.Schema{"b": simpleObjectSchema()}
+
+	t.Run("nil map assigns", func(t *testing.T) {
+		opts := &envOptions{}
+		WithTypedResources(a)(opts)
+		assert.Contains(t, opts.typedResources, "a")
+	})
+	t.Run("existing map merges", func(t *testing.T) {
+		opts := &envOptions{}
+		WithTypedResources(a)(opts)
+		WithTypedResources(b)(opts)
+		assert.Contains(t, opts.typedResources, "a")
+		assert.Contains(t, opts.typedResources, "b")
+	})
+}
+
+func TestWithListVariables(t *testing.T) {
+	opts := &envOptions{}
+	WithListVariables([]string{"items", "ports"})(opts)
+	assert.Len(t, opts.customDeclarations, 2)
+
+	// The declared variables should support list macros in a real env.
+	env, err := DefaultEnvironment(WithListVariables([]string{"items"}))
+	require.NoError(t, err)
+	_, issues := env.Compile("items.all(i, i != null)")
+	assert.NoError(t, issues.Err())
+}
+
+func TestListElementType(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   *cel.Type
+		want    *cel.Type
+		wantErr bool
+	}{
+		{name: "list of string", input: cel.ListType(cel.StringType), want: cel.StringType},
+		{name: "list of int", input: cel.ListType(cel.IntType), want: cel.IntType},
+		{name: "non-list (map)", input: cel.MapType(cel.StringType, cel.IntType), wantErr: true},
+		{name: "non-list (scalar)", input: cel.StringType, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ListElementType(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, tc.want.IsExactType(got), "got %v", got)
+		})
+	}
+}
+
+// --- schemas.go: SchemaDeclTypeWithMetadata across schema shapes ---
+
+func declType(t *testing.T, s *spec.Schema, root bool) *apiservercel.DeclType {
+	t.Helper()
+	if s == nil {
+		// Pass a typed-nil common.Schema to exercise the early nil check.
+		return SchemaDeclTypeWithMetadata(nil, root)
+	}
+	return SchemaDeclTypeWithMetadata(&openapi.Schema{Schema: s}, root)
+}
+
+func TestSchemaDeclTypeWithMetadata(t *testing.T) {
+	maxLen := int64(64)
+	maxItems := int64(10)
+	maxProps := int64(5)
+	negative := int64(-3)
+
+	cases := []struct {
+		name   string
+		schema *spec.Schema
+		root   bool
+		assert func(t *testing.T, dt *apiservercel.DeclType)
+	}{
+		{
+			name:   "nil schema returns nil",
+			schema: nil,
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { assert.Nil(t, dt) },
+		},
+		{
+			name:   "boolean",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"boolean"}}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "number",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"number"}}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "integer",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "plain string",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "string with maxLength",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}, MaxLength: &maxLen}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.Equal(t, maxLen*4, dt.MaxElements)
+			},
+		},
+		{
+			name: "string enum",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type: []string{"string"},
+				Enum: []interface{}{"short", "a-much-longer-value"},
+			}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.Equal(t, int64(len("a-much-longer-value")), dt.MaxElements)
+			},
+		},
+		{
+			name:   "string byte format",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}, Format: "byte"}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "string byte format with maxLength",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}, Format: "byte", MaxLength: &maxLen}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.Equal(t, maxLen, dt.MaxElements)
+			},
+		},
+		{
+			name:   "string duration format",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}, Format: "duration"}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "string date format",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}, Format: "date"}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "string date-time format",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}, Format: "date-time"}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name: "array of strings",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type:  []string{"array"},
+				Items: &spec.SchemaOrArray{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}}},
+			}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.True(t, dt.IsList())
+			},
+		},
+		{
+			name: "array with explicit maxItems",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type:     []string{"array"},
+				MaxItems: &maxItems,
+				Items:    &spec.SchemaOrArray{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}}},
+			}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.Equal(t, maxItems, dt.MaxElements)
+			},
+		},
+		{
+			name: "array with negative maxItems clamps to zero",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type:     []string{"array"},
+				MaxItems: &negative,
+				Items:    &spec.SchemaOrArray{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}}},
+			}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.Equal(t, int64(0), dt.MaxElements)
+			},
+		},
+		{
+			name:   "array without items returns nil",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"array"}}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { assert.Nil(t, dt) },
+		},
+		{
+			name: "object with properties",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+				},
+				Required: []string{"name"},
+			}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.True(t, dt.IsObject())
+			},
+		},
+		{
+			name: "object additionalProperties map",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				AdditionalProperties: &spec.SchemaOrBool{
+					Allows: true,
+					Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+				},
+			}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.True(t, dt.IsMap())
+			},
+		},
+		{
+			name: "object additionalProperties map with maxProperties",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type:          []string{"object"},
+				MaxProperties: &maxProps,
+				AdditionalProperties: &spec.SchemaOrBool{
+					Allows: true,
+					Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+				},
+			}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.True(t, dt.IsMap())
+				assert.Equal(t, maxProps, dt.MaxElements)
+			},
+		},
+		{
+			name:   "int-or-string",
+			schema: intOrStringSchemaSpec(),
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { require.NotNil(t, dt) },
+		},
+		{
+			name:   "int-or-string with maxLength",
+			schema: withMaxLength(intOrStringSchemaSpec(), 16),
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.Equal(t, int64(16*4), dt.MaxElements)
+			},
+		},
+		{
+			name:   "untyped schema returns nil",
+			schema: &spec.Schema{SchemaProps: spec.SchemaProps{}},
+			assert: func(t *testing.T, dt *apiservercel.DeclType) { assert.Nil(t, dt) },
+		},
+		{
+			name:   "resource root adds type meta",
+			schema: simpleObjectSchema(),
+			root:   true,
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.True(t, dt.IsObject())
+			},
+		},
+		{
+			name:   "preserve unknown fields object",
+			schema: preserveUnknownObjectSpec(),
+			assert: func(t *testing.T, dt *apiservercel.DeclType) {
+				require.NotNil(t, dt)
+				assert.Equal(t, "true", dt.Metadata[XKubernetesPreserveUnknownFields])
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(t, declType(t, tc.schema, tc.root))
+		})
+	}
+}
+
+func intOrStringSchemaSpec() *spec.Schema {
+	trueVal := true
+	return &spec.Schema{VendorExtensible: spec.VendorExtensible{
+		Extensions: spec.Extensions{"x-kubernetes-int-or-string": trueVal},
+	}}
+}
+
+func withMaxLength(s *spec.Schema, n int64) *spec.Schema {
+	s.MaxLength = &n
+	return s
+}
+
+func preserveUnknownObjectSpec() *spec.Schema {
+	trueVal := true
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"known": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			},
+		},
+		VendorExtensible: spec.VendorExtensible{
+			Extensions: spec.Extensions{"x-kubernetes-preserve-unknown-fields": trueVal},
+		},
+	}
+}
+
+// --- types.go: DeclTypeProvider methods ---
+
+func buildProvider(t *testing.T) *DeclTypeProvider {
+	t.Helper()
+	dt := declType(t, simpleObjectSchema(), false)
+	require.NotNil(t, dt)
+	dt = dt.MaybeAssignTypeName(TypeNamePrefix + "schema")
+	provider := NewDeclTypeProvider(dt)
+	registry := types.NewEmptyRegistry()
+	wrapped, err := provider.WithTypeProvider(registry)
+	require.NoError(t, err)
+	return wrapped
+}
+
+func TestDeclTypeProvider_Methods(t *testing.T) {
+	provider := buildProvider(t)
+
+	t.Run("FindDeclType found", func(t *testing.T) {
+		dt, found := provider.FindDeclType(TypeNamePrefix + "schema")
+		assert.True(t, found)
+		assert.NotNil(t, dt)
+	})
+
+	t.Run("FindDeclType scalar", func(t *testing.T) {
+		dt, found := provider.FindDeclType("string")
+		assert.True(t, found)
+		assert.NotNil(t, dt)
+	})
+
+	t.Run("FindDeclType missing", func(t *testing.T) {
+		_, found := provider.FindDeclType("does.not.exist")
+		assert.False(t, found)
+	})
+
+	t.Run("FindStructType found", func(t *testing.T) {
+		typ, found := provider.FindStructType(TypeNamePrefix + "schema")
+		assert.True(t, found)
+		assert.NotNil(t, typ)
+	})
+
+	t.Run("FindStructFieldType found", func(t *testing.T) {
+		ft, found := provider.FindStructFieldType(TypeNamePrefix+"schema", "name")
+		assert.True(t, found)
+		assert.NotNil(t, ft)
+	})
+
+	t.Run("FindStructFieldType missing field", func(t *testing.T) {
+		_, found := provider.FindStructFieldType(TypeNamePrefix+"schema", "nope")
+		assert.False(t, found)
+	})
+
+	t.Run("FindStructFieldNames returns empty", func(t *testing.T) {
+		names, found := provider.FindStructFieldNames(TypeNamePrefix + "schema")
+		assert.Empty(t, names)
+		assert.False(t, found)
+	})
+
+	t.Run("TypeNames includes schema", func(t *testing.T) {
+		names := provider.TypeNames()
+		assert.Contains(t, names, TypeNamePrefix+"schema")
+	})
+
+	t.Run("NativeToValue", func(t *testing.T) {
+		v := provider.NativeToValue("hello")
+		assert.Equal(t, types.String("hello"), v)
+	})
+
+	t.Run("NewValue delegates", func(t *testing.T) {
+		// NewValue delegates to the wrapped type provider. The registry has no
+		// such type, so it returns an error val rather than panicking.
+		v := provider.NewValue("does.not.exist", map[string]ref.Val{})
+		assert.NotNil(t, v)
+	})
+}
+
+func TestDeclTypeProvider_NilReceiver(t *testing.T) {
+	var rt *DeclTypeProvider
+
+	t.Run("FindStructType", func(t *testing.T) {
+		_, found := rt.FindStructType("x")
+		assert.False(t, found)
+	})
+	t.Run("FindDeclType", func(t *testing.T) {
+		_, found := rt.FindDeclType("x")
+		assert.False(t, found)
+	})
+	t.Run("WithTypeProvider", func(t *testing.T) {
+		got, err := rt.WithTypeProvider(types.NewEmptyRegistry())
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+	t.Run("EnvOptions", func(t *testing.T) {
+		opts, err := rt.EnvOptions(types.NewEmptyRegistry())
+		require.NoError(t, err)
+		assert.Empty(t, opts)
+	})
+}
+
+func TestDeclTypeProvider_EnvOptions(t *testing.T) {
+	dt := declType(t, simpleObjectSchema(), false).MaybeAssignTypeName(TypeNamePrefix + "schema")
+	provider := NewDeclTypeProvider(dt)
+	opts, err := provider.EnvOptions(types.NewEmptyRegistry())
+	require.NoError(t, err)
+	assert.Len(t, opts, 2)
+}
+
+func TestDeclTypeProvider_FindStructFieldType_Keyword(t *testing.T) {
+	// A field named after a CEL reserved keyword ("namespace") is stored
+	// escaped as "__namespace__"; with recognizeKeywordAsFieldName the
+	// provider should resolve it via the un-escaped name.
+	s := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"namespace": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+		},
+	}}
+	dt := declType(t, s, false).MaybeAssignTypeName(TypeNamePrefix + "meta")
+	provider := NewDeclTypeProvider(dt)
+	provider.SetRecognizeKeywordAsFieldName(true)
+	wrapped, err := provider.WithTypeProvider(types.NewEmptyRegistry())
+	require.NoError(t, err)
+
+	ft, found := wrapped.FindStructFieldType(TypeNamePrefix+"meta", "namespace")
+	assert.True(t, found)
+	assert.NotNil(t, ft)
+}
+
+func TestDeclTypeProvider_FindStructFieldType_DynamicMap(t *testing.T) {
+	// An additionalProperties map nested under a root object gets a path-based
+	// type name via FieldTypeMap. A lookup of any field name on the map type
+	// resolves to the element type (dynamic-map branch).
+	s := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"labels": {SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				AdditionalProperties: &spec.SchemaOrBool{
+					Allows: true,
+					Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+				},
+			}},
+		},
+	}}
+	dt := declType(t, s, false).MaybeAssignTypeName(TypeNamePrefix + "root")
+	provider := NewDeclTypeProvider(dt)
+	wrapped, err := provider.WithTypeProvider(types.NewEmptyRegistry())
+	require.NoError(t, err)
+
+	// The map type is registered under the "<root>.labels" path.
+	ft, found := wrapped.FindStructFieldType(TypeNamePrefix+"root.labels", "any-key")
+	assert.True(t, found)
+	assert.NotNil(t, ft)
+}
+
+func TestFindScalar(t *testing.T) {
+	cases := []struct {
+		name    string
+		typ     string
+		wantNil bool
+	}{
+		{name: "bool", typ: apiservercel.BoolType.TypeName()},
+		{name: "bytes", typ: apiservercel.BytesType.TypeName()},
+		{name: "double", typ: apiservercel.DoubleType.TypeName()},
+		{name: "duration", typ: apiservercel.DurationType.TypeName()},
+		{name: "int", typ: apiservercel.IntType.TypeName()},
+		{name: "null", typ: apiservercel.NullType.TypeName()},
+		{name: "string", typ: apiservercel.StringType.TypeName()},
+		{name: "timestamp", typ: apiservercel.TimestampType.TypeName()},
+		{name: "uint", typ: apiservercel.UintType.TypeName()},
+		{name: "list", typ: apiservercel.ListType.TypeName()},
+		{name: "map", typ: apiservercel.MapType.TypeName()},
+		{name: "unknown returns nil", typ: "not-a-scalar", wantNil: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findScalar(tc.typ)
+			if tc.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func TestNewDeclTypeProvider_NilRootTypes(t *testing.T) {
+	// rootTypes == nil yields an empty provider; nil entries are skipped.
+	assert.NotNil(t, NewDeclTypeProvider())
+	provider := NewDeclTypeProvider(nil, nil)
+	assert.Empty(t, provider.TypeNames())
+}
+
+// --- compatibility.go: remaining branches ---
+
+func TestResolveDeclTypeFromPath_Edges(t *testing.T) {
+	provider := buildProvider(t)
+	cases := []struct {
+		name    string
+		path    string
+		wantNil bool
+	}{
+		{name: "nil provider path", path: "", wantNil: true},
+		{name: "unknown root", path: "nonexistent.spec", wantNil: true},
+		{name: "resolve root", path: TypeNamePrefix + "schema"},
+		{name: "resolve field", path: TypeNamePrefix + "schema.name"},
+		{name: "missing field", path: TypeNamePrefix + "schema.missing", wantNil: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveDeclTypeFromPath(tc.path, provider)
+			if tc.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func TestResolveDeclTypeFromPath_NilProvider(t *testing.T) {
+	assert.Nil(t, resolveDeclTypeFromPath("x.y", nil))
+}
+
+func TestResolveDeclTypeFromPath_ListTraversal(t *testing.T) {
+	// Root object with a list-of-object field exercises the @idx element-type
+	// traversal and the array-index "[..]" stripping in resolveDeclTypeFromPath.
+	s := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"items": {SchemaProps: spec.SchemaProps{
+				Type: []string{"array"},
+				Items: &spec.SchemaOrArray{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+					Properties: map[string]spec.Schema{
+						"id": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+					},
+				}}},
+			}},
+		},
+	}}
+	dt := declType(t, s, false).MaybeAssignTypeName(TypeNamePrefix + "root")
+	provider := NewDeclTypeProvider(dt)
+	wrapped, err := provider.WithTypeProvider(types.NewEmptyRegistry())
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		path    string
+		wantNil bool
+	}{
+		{name: "elem via @idx", path: TypeNamePrefix + "root.items.@idx"},
+		{name: "field via @idx", path: TypeNamePrefix + "root.items.@idx.id"},
+		{name: "array index stripped", path: TypeNamePrefix + "root.items[0]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveDeclTypeFromPath(tc.path, wrapped)
+			if tc.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func TestAreStructTypesCompatible_NoProvider(t *testing.T) {
+	// With a nil provider, struct compatibility falls back to permissive true.
+	a := apiservercel.NewObjectType(TypeNamePrefix+"a", map[string]*apiservercel.DeclField{
+		"x": apiservercel.NewDeclField("x", apiservercel.StringType, false, nil, nil),
+	})
+	ok, err := areStructTypesCompatible(a.CelType(), a.CelType(), nil)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestAreListTypesCompatible_ElementIncompatible(t *testing.T) {
+	// Element kinds differ (string vs int) -> incompatible with wrapped error.
+	ok, err := areListTypesCompatible(cel.ListType(cel.StringType), cel.ListType(cel.IntType), nil)
+	assert.False(t, ok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list element type incompatible")
+}

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -52,6 +52,24 @@ type envOptions struct {
 	typedResources map[string]*spec.Schema
 	// customDeclarations will be added to the CEL environment.
 	customDeclarations []cel.EnvOption
+	// runtimeLibrary gates library.Runtime() and the ConditionTypeProvider
+	// wrap. Nil means default-on.
+	runtimeLibrary *bool
+}
+
+// runtimeEnabled reports whether the Runtime library (and its
+// ConditionTypeProvider wrap) should be installed. Default is on.
+func (o *envOptions) runtimeEnabled() bool {
+	return o.runtimeLibrary == nil || *o.runtimeLibrary
+}
+
+// WithRuntimeLibrary gates the `runtime` CEL library and the
+// ConditionTypeProvider wrap that resolves kro.run.Condition. Default is
+// on; environments with no author-condition surface pass false to omit it.
+func WithRuntimeLibrary(enabled bool) EnvOption {
+	return func(opts *envOptions) {
+		opts.runtimeLibrary = &enabled
+	}
 }
 
 // WithResourceIDs adds resource ids that will be declared as CEL variables.
@@ -92,66 +110,97 @@ func WithListVariables(names []string) EnvOption {
 }
 
 var (
-	baseDeclarationsOnce   sync.Once
-	cachedBaseDeclarations []cel.EnvOption
+	baseDeclarationsOnce   [2]sync.Once
+	cachedBaseDeclarations [2][]cel.EnvOption
 )
+
+func baseDeclarationsIndex(includeRuntime bool) int {
+	if includeRuntime {
+		return 1
+	}
+	return 0
+}
+
+// coreDeclarations is the Runtime-independent set of CEL environment options.
+func coreDeclarations() []cel.EnvOption {
+	return []cel.EnvOption{
+		ext.TwoVarComprehensions(),
+		ext.Lists(),
+		ext.Strings(),
+		ext.Bindings(),
+		cel.OptionalTypes(),
+		ext.Encoders(),
+		// Kubernetes CEL libraries: url(), regex, quantity, ip(), cidr(), semver(), etc.
+		// See https://kubernetes.io/docs/reference/using-api/cel/ and
+		// https://github.com/kubernetes-sigs/kro/issues/880.
+		k8scellib.Lists(),
+		k8scellib.URLs(),
+		k8scellib.Regex(),
+		k8scellib.Quantity(),
+		k8scellib.IP(),
+		k8scellib.CIDR(),
+		k8scellib.SemverLib(),
+		library.Random(),
+		library.Maps(),
+		library.JSON(),
+		library.Hash(),
+		library.Lists(),
+		// Omit() is registered globally so CEL can parse and type-check it
+		// everywhere. The graph builder rejects it in restricted contexts
+		// (includeWhen, readyWhen, forEach) via inspectExpressionRestricted
+		// and validateAndCompileForEach.
+		library.Omit(),
+	}
+}
 
 // BaseDeclarations returns the base CEL environment options shared by all kro
 // CEL environments. Includes list/string extensions, optional types, encoders,
 // and Kubernetes CEL libraries (URLs, Regex, Random).
 // The result is cached via sync.Once since these options are stateless.
-func BaseDeclarations() []cel.EnvOption {
-	baseDeclarationsOnce.Do(func() {
-		cachedBaseDeclarations = []cel.EnvOption{
-			ext.TwoVarComprehensions(),
-			ext.Lists(),
-			ext.Strings(),
-			ext.Bindings(),
-			cel.OptionalTypes(),
-			ext.Encoders(),
-			// Kubernetes CEL libraries: url(), regex, quantity, ip(), cidr(), semver(), etc.
-			// See https://kubernetes.io/docs/reference/using-api/cel/ and
-			// https://github.com/kubernetes-sigs/kro/issues/880.
-			k8scellib.Lists(),
-			k8scellib.URLs(),
-			k8scellib.Regex(),
-			k8scellib.Quantity(),
-			k8scellib.IP(),
-			k8scellib.CIDR(),
-			k8scellib.SemverLib(),
-			library.Random(),
-			library.Maps(),
-			library.JSON(),
-			library.Hash(),
-			library.Lists(),
-			// Omit() is registered globally so CEL can parse and type-check it
-			// everywhere. The graph builder rejects it in restricted contexts
-			// (includeWhen, readyWhen, forEach) via inspectExpressionRestricted
-			// and validateAndCompileForEach.
-			library.Omit(),
+//
+// The default includes library.Runtime(); pass WithRuntimeLibrary(false) to
+// omit it when there is no author-condition surface.
+func BaseDeclarations(options ...EnvOption) []cel.EnvOption {
+	opts := &envOptions{}
+	for _, opt := range options {
+		opt(opts)
+	}
+	includeRuntime := opts.runtimeEnabled()
+	idx := baseDeclarationsIndex(includeRuntime)
+	baseDeclarationsOnce[idx].Do(func() {
+		decls := coreDeclarations()
+		if includeRuntime {
 			// Runtime() registers the `runtime` CEL variable used to author
 			// custom status conditions. The graph builder rejects it outside
 			// the schema's status.conditions block.
-			library.Runtime(),
+			decls = append(decls, library.Runtime())
 		}
+		cachedBaseDeclarations[idx] = decls
 	})
-	return cachedBaseDeclarations
+	return cachedBaseDeclarations[idx]
 }
 
 var (
-	baseEnvOnce   sync.Once
-	cachedBaseEnv *cel.Env
-	baseEnvErr    error
+	baseEnvOnce   [2]sync.Once
+	cachedBaseEnv [2]*cel.Env
+	baseEnvErr    [2]error
 )
 
 // baseEnv returns a cached base CEL environment containing only the base
 // declarations. Use env.Extend() on the result to add custom declarations,
 // which is cheaper than building a full environment from scratch.
-func baseEnv() (*cel.Env, error) {
-	baseEnvOnce.Do(func() {
-		cachedBaseEnv, baseEnvErr = cel.NewEnv(BaseDeclarations()...)
+func baseEnv(includeRuntime bool) (*cel.Env, error) {
+	idx := baseDeclarationsIndex(includeRuntime)
+	baseEnvOnce[idx].Do(func() {
+		var decls []cel.EnvOption
+		if includeRuntime {
+			decls = BaseDeclarations()
+		} else {
+			decls = BaseDeclarations(WithRuntimeLibrary(false))
+		}
+		cachedBaseEnv[idx], baseEnvErr[idx] = cel.NewEnv(decls...)
 	})
-	return cachedBaseEnv, baseEnvErr
+	return cachedBaseEnv[idx], baseEnvErr[idx]
 }
 
 // DefaultEnvironment returns the default CEL environment.
@@ -164,14 +213,15 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 // and returns both the environment and the DeclTypeProvider (if typed resources
 // were configured).
 func defaultEnvironment(options ...EnvOption) (*cel.Env, *DeclTypeProvider, error) {
-	base, err := baseEnv()
-	if err != nil {
-		return nil, nil, fmt.Errorf("base environment: %w", err)
-	}
-
 	opts := &envOptions{}
 	for _, opt := range options {
 		opt(opts)
+	}
+
+	includeRuntime := opts.runtimeEnabled()
+	base, err := baseEnv(includeRuntime)
+	if err != nil {
+		return nil, nil, fmt.Errorf("base environment: %w", err)
 	}
 
 	// Only non-base declarations go here; base declarations are in the cached base env.
@@ -233,14 +283,27 @@ func defaultEnvironment(options ...EnvOption) (*cel.Env, *DeclTypeProvider, erro
 	// its fields. This must run after the typed-resource provider above is
 	// installed, since cel.CustomTypeProvider replaces (not layers) the
 	// provider; ConditionTypeProvider delegates everything else back to it.
-	env, err = env.Extend(cel.CustomTypeProvider(library.ConditionTypeProvider(env.CELTypeProvider())))
+	// Skipped when the runtime library is omitted.
+	if includeRuntime {
+		env, err = env.Extend(cel.CustomTypeProvider(library.ConditionTypeProvider(env.CELTypeProvider())))
+	}
 	return env, provider, err
 }
 
 // TypedEnvironmentWithProvider creates a typed CEL environment.
 // It returns both the environment and the DeclTypeProvider.
-func TypedEnvironmentWithProvider(schemas map[string]*spec.Schema) (*cel.Env, *DeclTypeProvider, error) {
-	return defaultEnvironment(WithTypedResources(schemas))
+func TypedEnvironmentWithProvider(schemas map[string]*spec.Schema, options ...EnvOption) (*cel.Env, *DeclTypeProvider, error) {
+	opts := append([]EnvOption{WithTypedResources(schemas)}, options...)
+	return defaultEnvironment(opts...)
+}
+
+// TypedEnvironmentWithIDsAndProvider builds the typed CEL environment with
+// the supplied typed resources, additionally declaring the given identifiers
+// as untyped (dyn) variables. Useful when some identifiers carry no schema
+// but must still resolve at type-check time.
+func TypedEnvironmentWithIDsAndProvider(schemas map[string]*spec.Schema, dynIDs []string, options ...EnvOption) (*cel.Env, *DeclTypeProvider, error) {
+	opts := append([]EnvOption{WithTypedResources(schemas), WithResourceIDs(dynIDs)}, options...)
+	return defaultEnvironment(opts...)
 }
 
 // TypedEnvironment creates a CEL environment with type checking enabled.

--- a/pkg/cel/environment_test.go
+++ b/pkg/cel/environment_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 func TestWithResourceIDs(t *testing.T) {
@@ -300,6 +301,44 @@ func TestBaseDeclarations_ReturnsSameSlice(t *testing.T) {
 	if len(a) > 0 && len(b) > 0 {
 		assert.Same(t, &a[0], &b[0], "expected same backing array from cached BaseDeclarations")
 	}
+}
+
+func TestWithRuntimeLibrary_DefaultOn(t *testing.T) {
+	env, err := DefaultEnvironment()
+	require.NoError(t, err)
+	_, issues := env.Compile(`runtime.newCondition({type: 'X', status: 'True', reason: '', message: ''})`)
+	assert.NoError(t, issues.Err(), "default environment must keep the Runtime library")
+}
+
+func TestWithRuntimeLibrary_Off(t *testing.T) {
+	env, err := DefaultEnvironment(WithRuntimeLibrary(false))
+	require.NoError(t, err)
+	_, issues := env.Compile(`runtime.newCondition({type: 'X', status: 'True', reason: '', message: ''})`)
+	assert.Error(t, issues.Err(), "Graph environments must omit the Runtime library")
+}
+
+func TestTypedEnvironmentWithIDsAndProvider(t *testing.T) {
+	schemas := map[string]*spec.Schema{
+		"schema": {
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+				},
+			},
+		},
+	}
+	env, provider, err := TypedEnvironmentWithIDsAndProvider(schemas, []string{"extra"}, WithRuntimeLibrary(false))
+	require.NoError(t, err)
+	require.NotNil(t, env)
+	require.NotNil(t, provider)
+
+	_, issues := env.Compile("schema.name")
+	assert.NoError(t, issues.Err())
+	_, issues = env.Compile("extra")
+	assert.NoError(t, issues.Err())
+	_, issues = env.Compile(`runtime.newCondition({type: 'X', status: 'True', reason: '', message: ''})`)
+	assert.Error(t, issues.Err())
 }
 
 func TestBaseEnv_Extend_PreservesLibraries(t *testing.T) {

--- a/pkg/cel/expression.go
+++ b/pkg/cel/expression.go
@@ -24,6 +24,23 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 )
 
+const (
+	// DefaultCostLimit bounds the maximum evaluation cost for CEL programs to
+	// prevent unbounded resource consumption from pathological expressions.
+	DefaultCostLimit = 10_000_000
+	// DefaultInterruptCheckFrequency defines the instruction step frequency for checking
+	// cancellation and interrupt signals during evaluation.
+	DefaultInterruptCheckFrequency = 100
+)
+
+// DefaultProgramOptions returns the standard execution bound options for CEL programs.
+func DefaultProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{
+		cel.CostLimit(DefaultCostLimit),
+		cel.InterruptCheckFrequency(DefaultInterruptCheckFrequency),
+	}
+}
+
 // Expression wraps a CEL expression with its compiled program and metadata.
 // Programs are compiled once at graph build time and reused across reconciliations.
 // The struct is immutable and thread-safe after construction. It is save to use


### PR DESCRIPTION
## Description
- Introduces `pkg/cel/ast/inspector.go` providing AST traversal helpers for extracting identifiers, member accesses, and optional chaining expressions.
- Enforces `DefaultCostLimit` (10,000,000) and `DefaultInterruptCheckFrequency` (100) on CEL programs to protect against unbounded execution.
- Adds comprehensive CEL test coverage across environment, type conversions, and expressions.
- Add dedicated optional tracking so it can be used for soft dependency declaration

## Type of change
- [x] Feature / Improvement
- [x] Test coverage

## Testing
- `make build`
- `make lint`
- `make test WHAT=unit`
- Integration test suite passed.
