### PR TITLE
docs: note that lists built from maps need sort() for stable ordering

### DIFF
--- a/website/docs/docs/building-abstractions/10-single-resource-rgd.md
+++ b/website/docs/docs/building-abstractions/10-single-resource-rgd.md
@@ -234,15 +234,18 @@ resources:
         name: ${schema.spec.name}
       spec:
         # other required fields omitted for brevity
-        tags: ${merge(schema.spec.tags, {
+        tags: ${schema.spec.tags.merge({
           "managed-by": "kro",
           "tenant": schema.metadata.?labels["tenant"].orValue("shared"),
           "namespace": schema.metadata.namespace
         })}
 ```
 
-Putting the platform tags in the second argument to `merge()` makes them win on
-key conflicts, so the wrapper always injects the tags you require.
+Passing the platform tags as the argument to `merge()` makes them the second
+map, so they win on key conflicts and the wrapper always injects the tags you
+require. Note that `merge()` is a member function, so it must be called on the
+receiving map (`schema.spec.tags.merge({...})`) rather than as a global
+function (`merge(schema.spec.tags, {...})`), which does not compile.
 
 ## When Not To Wrap
 

--- a/website/docs/docs/concepts/rgd/03-cel-expressions.md
+++ b/website/docs/docs/concepts/rgd/03-cel-expressions.md
@@ -514,6 +514,14 @@ envVars: ${{ "APP": "nginx", "PORT": "8080" }.transformList(k, v, k + "=" + v)}
 # → ["APP=nginx", "PORT=8080"]
 ```
 
+:::note Order is not stable
+A list extracted from a map has non-deterministic element order, since map
+iteration order is not guaranteed. If the list feeds a template field, sort it
+(for example `.sort()` on the keys) so the rendered desired state stays stable
+across reconciles. See
+[Sort lists built from maps](./04-cel-libraries.md#lists-cel-go) for details.
+:::
+
 ### Aggregating Status
 
 Collect status from multiple resources:

--- a/website/docs/docs/concepts/rgd/04-cel-libraries.md
+++ b/website/docs/docs/concepts/rgd/04-cel-libraries.md
@@ -280,6 +280,27 @@ indices: ${lists.range(schema.spec.count)}
 flat: ${schema.spec.nestedPorts.flatten()}
 ```
 
+:::warning Sort lists built from maps
+A list built from a map has **non-deterministic element order** — the order
+comes from map iteration and can change from one reconcile to the next. When a
+template field is a list of objects derived from a map, call `sort()` on the
+keys first, or the rendered desired state changes between reconciles even when
+nothing has actually changed. kro then re-applies the field every cycle and a
+downstream controller can see a perpetual diff on a resource nobody touched.
+
+This commonly happens when a provider models a key/value collection as a list
+of objects (for example `[{key, value}]`) rather than a map, so converting a
+`map[string]string` schema field into that shape needs a sort to stay stable:
+
+```kro
+# Unstable: element order comes from map iteration
+tags: ${schema.spec.tags.map(k, {"key": k, "value": schema.spec.tags[k]})}
+
+# Stable: sort the keys before building the list
+tags: ${schema.spec.tags.map(k, k).sort().map(k, {"key": k, "value": schema.spec.tags[k]})}
+```
+:::
+
 ### Encoders
 
 Base64 encoding and decoding from [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Encoders).


### PR DESCRIPTION
Lists derived from maps have non-deterministic element order because map iteration order is not guaranteed. When such a list feeds a template field, the rendered desired state can change between reconciles even when nothing changed, causing kro to re-apply the field and downstream controllers to see a perpetual diff.

Changes:
- Add a warning near the sort()/sortBy() entries in the CEL libraries page with the common ACK map-to-tag-list example.
- Add a cross-referencing note in the transformList section of the CEL expressions page.
- Fix the broken merge() example in the single-resource-RGD guide: merge is a member function, so it must be called as schema.spec.tags.merge({...}), not as a global merge(schema.spec.tags, {...}), which fails to compile.

Fixes #1374