### PR TITLE
fix(crd): detect additionalPrinterColumns changes when updating CRDs

### DIFF
--- a/pkg/graph/crd/compat/changes.go
+++ b/pkg/graph/crd/compat/changes.go
@@ -46,12 +46,13 @@ const (
 	MaxItemsDecreased  ChangeType = "MAX_ITEMS_DECREASED"
 
 	// Non-breaking change types
-	PropertyAdded      ChangeType = "PROPERTY_ADDED"
-	DescriptionChanged ChangeType = "DESCRIPTION_CHANGED"
-	DefaultChanged     ChangeType = "DEFAULT_CHANGED"
-	RequiredRemoved    ChangeType = "REQUIRED_REMOVED"
-	EnumExpanded       ChangeType = "ENUM_EXPANDED"
-	PatternRemoved     ChangeType = "PATTERN_REMOVED"
+	PropertyAdded                   ChangeType = "PROPERTY_ADDED"
+	DescriptionChanged              ChangeType = "DESCRIPTION_CHANGED"
+	DefaultChanged                  ChangeType = "DEFAULT_CHANGED"
+	RequiredRemoved                 ChangeType = "REQUIRED_REMOVED"
+	EnumExpanded                    ChangeType = "ENUM_EXPANDED"
+	PatternRemoved                  ChangeType = "PATTERN_REMOVED"
+	AdditionalPrinterColumnsChanged ChangeType = "ADDITIONAL_PRINTER_COLUMNS_CHANGED"
 
 	// Non-breaking - constraint relaxed
 	MinimumRemoved     ChangeType = "MINIMUM_REMOVED"
@@ -191,6 +192,8 @@ func (c Change) Description() string {
 		return fmt.Sprintf("Description field was changed from %s to %s", c.OldValue, c.NewValue)
 	case DefaultChanged:
 		return fmt.Sprintf("Default value was changed from %s to %s", c.OldValue, c.NewValue)
+	case AdditionalPrinterColumnsChanged:
+		return "Additional printer columns were changed"
 	default:
 		return c.constraintDescription()
 	}

--- a/pkg/graph/crd/compat/compat.go
+++ b/pkg/graph/crd/compat/compat.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // CompareVersions compares CRD versions and returns a compatibility report.
@@ -68,6 +69,12 @@ func CompareVersions(oldVersions, newVersions []v1.CustomResourceDefinitionVersi
 	newHasStatus := newVersion.Subresources != nil && newVersion.Subresources.Status != nil
 	if oldHasStatus && !newHasStatus {
 		report.AddBreakingChange("version.subresources.status", PropertyRemoved, "", "")
+	}
+
+	// Additional printer columns are not part of the schema, so they wouldn't
+	// otherwise be caught above. Record any change so the CRD still gets updated.
+	if !equality.Semantic.DeepEqual(oldVersion.AdditionalPrinterColumns, newVersion.AdditionalPrinterColumns) {
+		report.AddNonBreakingChange("version.additionalPrinterColumns", AdditionalPrinterColumnsChanged, "", "")
 	}
 
 	return report, nil

--- a/pkg/graph/crd/compat/compat_test.go
+++ b/pkg/graph/crd/compat/compat_test.go
@@ -209,6 +209,35 @@ func TestCompareVersions(t *testing.T) {
 			expectBreaking:   false,
 			nonBreakingCount: 1,
 		},
+		{
+			name: "non-breaking change - additional printer columns changed",
+			oldVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{Type: "object"},
+					},
+					AdditionalPrinterColumns: []v1.CustomResourceColumnDefinition{
+						{Name: "Replicas", Type: "integer", JSONPath: ".spec.replicas"},
+					},
+				},
+			},
+			newVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{Type: "object"},
+					},
+					AdditionalPrinterColumns: []v1.CustomResourceColumnDefinition{
+						{Name: "Replicas", Type: "integer", JSONPath: ".spec.replicas"},
+						{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+					},
+				},
+			},
+			expectError:      false,
+			expectBreaking:   false,
+			nonBreakingCount: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When a ResourceGraphDefinition's `spec.schema.additionalPrinterColumns` changes and is reapplied, the backing CRD isn't updated — kubectl output keeps showing the old columns.

`crdcompat.CompareVersions()` only compared the OpenAPI schema, `served`, and the status subresource, so a printer-columns-only diff reported no changes and `Ensure()` in `pkg/client/crd.go` skipped patching the CRD. This adds a comparison of `AdditionalPrinterColumns` (new `AdditionalPrinterColumnsChanged` non-breaking change type) so `Ensure()` proceeds to patch when only the columns changed.

Tested with `go test ./pkg/graph/crd/compat/... ./pkg/client/...`, including a new case in `TestCompareVersions`. Not validated against a live cluster.

Fixes #1377

```release-note
fix(crd): detect additionalPrinterColumns changes when updating CRDs
```
