### PR TITLE
fix(helm): honor service account automount setting

### DIFF
--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -10,7 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if .Values.serviceAccount.automountServiceAccountToken }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}


### PR DESCRIPTION
The chart exposes `serviceAccount.automount`, but the template reads `serviceAccount.automountServiceAccountToken`. 
Setting it to `false` is a no-op, so Kubernetes still mounts API credentials

Repro:

1. Set this in a values file:

```yaml
serviceAccount:
  automount: false
```

2. Run `helm template kro ./helm -f values.yaml`
3. Notice `automountServiceAccountToken` is missing

This uses the documented value again. 
Both `true` and `false` now render correctly

Tests:

`go run helm.sh/helm/v3/cmd/helm@v3.19.5 lint ./helm`

`go test ./pkg/...`