### PR TITLE
chore: update e2e test for termination and fix ALLOW_CRD_DELETION correctly

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -1,0 +1,15 @@
+# Instance deletion in Kro is behind a finalizer flag. Deletion remove the
+# finalizer only once every child resource is gone. A Delete, therefore,
+# together with the terminationGracePeriodSeconds can take longer then that
+# on a machine with cold kind nodes. Here, we set the cleanup to longer
+# BUT we also set the grace period to 0 to make the deletion immediate
+# to avoid weird "context deadline exceeded" errors, while still failing on
+# geniuen timeouts that are blocked finalizer related.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Configuration
+metadata:
+  name: kro
+spec:
+  timeouts:
+    cleanup: 120s
+    delete: 120s

--- a/Makefile
+++ b/Makefile
@@ -329,13 +329,17 @@ start-kind:
 	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
 	$(KUBECTL) --context kind-${KIND_CLUSTER_NAME} create namespace kro-system
 
+# allowCRDDeletion controls whether kro deletes an instance CRD when its RGD is
+# deleted. Defaults to true, but is overwritten by the chainsaw e2e test.
+ALLOW_CRD_DELETION ?= true
+
 .PHONY: deploy-kind-helm
 deploy-kind-helm: export KO_DOCKER_REPO=kind.local
 deploy-kind-helm: ko start-kind
 	make install
 	# This generates deployment with ko://... used in image.
 	# ko then intercepts it builds image, pushes to kind node, replaces the image in deployment and applies it
-	${HELM} template kro ./helm --namespace kro-system --set image.pullPolicy=Never --set image.ko=true --set config.allowCRDDeletion=true | $(WITH_GOFLAGS) $(KO) apply -f -
+	${HELM} template kro ./helm --namespace kro-system --set image.pullPolicy=Never --set image.ko=true --set config.allowCRDDeletion=$(ALLOW_CRD_DELETION) | $(WITH_GOFLAGS) $(KO) apply -f -
 	kubectl wait --for=condition=ready --timeout=1m pod -n kro-system -l app.kubernetes.io/component=controller
 	$(KUBECTL) --context kind-${KIND_CLUSTER_NAME} get pods -A
 
@@ -386,7 +390,9 @@ deploy-kind: ko deploy-kind-helm ## Deploy kro to a kind cluster
 
 # Default end to end tests uses helm deployments
 .PHONY: test-e2e-kind
-test-e2e-kind: deploy-kind-helm
+test-e2e-kind: ALLOW_CRD_DELETION=false
+test-e2e-kind: chainsaw deploy-kind-helm
+	$(CHAINSAW) test ./test/e2e/chainsaw
 
 ##@ Upgrade Tests
 

--- a/test/e2e/chainsaw/check-instance-creation/rgd.yaml
+++ b/test/e2e/chainsaw/check-instance-creation/rgd.yaml
@@ -26,6 +26,8 @@ spec:
               labels:
                 app: ${schema.metadata.name}
             spec:
+              # terminate immediately for e2e tests cleanup
+              terminationGracePeriodSeconds: 0
               containers:
                 - name: main
                   image: ${schema.spec.image} 

--- a/test/e2e/chainsaw/check-instance-update/deployment-update-assert.yaml
+++ b/test/e2e/chainsaw/check-instance-update/deployment-update-assert.yaml
@@ -28,5 +28,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      terminationGracePeriodSeconds: 30
 

--- a/test/e2e/chainsaw/check-instance-update/rgd.yaml
+++ b/test/e2e/chainsaw/check-instance-update/rgd.yaml
@@ -26,6 +26,8 @@ spec:
               labels:
                 app: ${schema.metadata.name}
             spec:
+              # terminate immediately so we don't have to wait 30s.
+              terminationGracePeriodSeconds: 0
               containers:
                 - name: main
                   image: ${schema.spec.image} 

--- a/test/e2e/chainsaw/check-multi-resource-rgd/rgd.yaml
+++ b/test/e2e/chainsaw/check-multi-resource-rgd/rgd.yaml
@@ -51,6 +51,8 @@ spec:
               labels:
                 app: ${schema.spec.name}-deployment
             spec:
+              # terminate immediately so we don't have to wait 30s.
+              terminationGracePeriodSeconds: 0
               containers:
                 - name: main
                   image: ${schema.spec.image}

--- a/test/e2e/chainsaw/check-rgd-creation/rgd.yaml
+++ b/test/e2e/chainsaw/check-rgd-creation/rgd.yaml
@@ -26,6 +26,8 @@ spec:
               labels:
                 app: ${schema.metadata.name}
             spec:
+              # terminate immediately so we don't have to wait 30s.
+              terminationGracePeriodSeconds: 0
               containers:
                 - name: main
                   image: ${schema.spec.image} 

--- a/test/e2e/chainsaw/check-rgd-deletion/rgd.yaml
+++ b/test/e2e/chainsaw/check-rgd-deletion/rgd.yaml
@@ -26,6 +26,8 @@ spec:
               labels:
                 app: ${schema.metadata.name}
             spec:
+              # terminate immediately so we don't have to wait 30s.
+              terminationGracePeriodSeconds: 0
               containers:
                 - name: main
                   image: ${schema.spec.image} 


### PR DESCRIPTION
When I run these tests locally, these always failed with timeouts.

```
    --- FAIL: chainsaw/check-instance-creation (43.83s)
    --- FAIL: chainsaw/check-instance-update (46.57s)
    --- FAIL: chainsaw/check-multi-resource-rgd (57.83s)
    --- FAIL: chainsaw/check-rgd-deletion (74.13s)
FAIL
Tests Summary...
- Passed  tests 7
- Failed  tests 4
```

Eventually, I tracked it down to two things. One: chainsaw setting that increases the deletion timeout.
Two: reducing the deletion grace period for the deployments.

These together lead to a consistent test passing on each run:

```
PASS
Tests Summary...
- Passed  tests 11
- Failed  tests 0
- Skipped tests 0
Done.
```

Also, incidentally, I found that `make deploy-kind-helm ALLOW_CRD_DELETION=false` actually didn't work. :)