### PR TITLE
fix(instance): support long instance names in child labels

### DIFF
--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -505,6 +505,9 @@ func (c *Controller) applyDecoratorMetadata(
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
+	if labels[metadata.InstanceLabel] != rcx.Instance.GetName() {
+		annotations[metadata.InstanceNameAnnotation] = rcx.Instance.GetName()
+	}
 	annotations[metadata.ApplyOrderAnnotation] = strconv.Itoa(applyOrder)
 	obj.SetAnnotations(annotations)
 }

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 
@@ -729,6 +730,7 @@ func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
 	assert.Equal(t, "yes", obj.GetLabels()["keep"])
 	assert.Equal(t, "configs", obj.GetLabels()[metadata.NodeIDLabel])
 	assert.Equal(t, "4", obj.GetAnnotations()[metadata.ApplyOrderAnnotation])
+	assert.NotContains(t, obj.GetAnnotations(), metadata.InstanceNameAnnotation)
 	assert.Equal(t, "1", obj.GetLabels()[metadata.CollectionIndexLabel])
 	assert.Equal(t, string(instance.GetUID()), obj.GetLabels()[metadata.InstanceIDLabel])
 	assert.Empty(t, obj.GetLabels()[metadata.ManagedByLabelKey])
@@ -741,6 +743,19 @@ func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
 	}))
 	stored := getStoredParentObject(t, raw)
 	assert.Equal(t, "demo", stored.GetLabels()[applyset.ApplySetParentIDLabel])
+}
+
+func TestApplyDecoratorPreservesLongInstanceName(t *testing.T) {
+	instanceName := strings.Repeat("a", 64)
+	instance := newInstanceObject(instanceName, "default")
+	controller, rcx, _ := newControllerAndContext(t, instance, newTestGraph())
+
+	obj := newConfigMapObject("demo", "default")
+	controller.applyDecoratorMetadata(rcx, obj, "configs", 1, nil)
+
+	assert.NotEqual(t, instanceName, obj.GetLabels()[metadata.InstanceLabel])
+	assert.Len(t, obj.GetLabels()[metadata.InstanceLabel], 16)
+	assert.Equal(t, instanceName, obj.GetAnnotations()[metadata.InstanceNameAnnotation])
 }
 
 func TestReconcileNodesBackfillsApplyOrderOnExistingResource(t *testing.T) {

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -17,4 +17,6 @@ package metadata
 const (
 	// ApplyOrderAnnotation persists a managed resource's reverse topological deletion wave.
 	ApplyOrderAnnotation = InternalKROPrefix + "apply-order"
+	// InstanceNameAnnotation preserves the full instance name when it is too long for a label value.
+	InstanceNameAnnotation = InternalKROPrefix + "instance-name"
 )

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strconv"
 	"strings"
 
@@ -177,7 +178,7 @@ func NewInstanceLabeler(instance *unstructured.Unstructured, namespaced bool) Ge
 	gvk := instance.GroupVersionKind()
 	labels := map[string]string{
 		InstanceIDLabel:      string(instance.GetUID()),
-		InstanceLabel:        instance.GetName(),
+		InstanceLabel:        labelSafeInstanceName(instance.GetName()),
 		InstanceGroupLabel:   gvk.Group,
 		InstanceVersionLabel: gvk.Version,
 		InstanceKindLabel:    gvk.Kind,
@@ -186,6 +187,17 @@ func NewInstanceLabeler(instance *unstructured.Unstructured, namespaced bool) Ge
 		labels[InstanceNamespaceLabel] = instance.GetNamespace()
 	}
 	return labels
+}
+
+func labelSafeInstanceName(name string) string {
+	if validation.IsValidLabelValue(name) == nil {
+		return name
+	}
+	// Instance names are DNS subdomains and may be up to 253 characters,
+	// while label values are limited to 63 characters.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(name))
+	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 // NewNodeLabeler returns a new labeler for child resources

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/release-utils/version"
 )
 
@@ -300,6 +302,25 @@ func TestNewInstanceLabeler(t *testing.T) {
 			InstanceVersionLabel: version,
 			InstanceKindLabel:    kind,
 		}, labeler)
+	})
+
+	t.Run("long instance name", func(t *testing.T) {
+		name := strings.Repeat("a", 64)
+		obj := &unstructured.Unstructured{}
+		obj.SetName(name)
+
+		labeler := NewInstanceLabeler(obj, true)
+		encoded := labeler[InstanceLabel]
+		assert.NotEqual(t, name, encoded)
+		assert.Len(t, encoded, 16)
+		assert.Empty(t, validation.IsValidLabelValue(encoded))
+		assert.Equal(t, encoded, NewInstanceLabeler(obj, true)[InstanceLabel])
+
+		obj.SetName(strings.Repeat("a", 63))
+		assert.Equal(t, obj.GetName(), NewInstanceLabeler(obj, true)[InstanceLabel])
+
+		obj.SetName(strings.Repeat("a", 63) + "b")
+		assert.NotEqual(t, encoded, NewInstanceLabeler(obj, true)[InstanceLabel])
 	})
 }
 

--- a/test/integration/suites/core/annotation_label_test.go
+++ b/test/integration/suites/core/annotation_label_test.go
@@ -16,6 +16,7 @@ package core_test
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
@@ -104,7 +106,7 @@ var _ = Describe("Labels and Annotations", func() {
 				"apiVersion": apiVersion,
 				"kind":       kind,
 				"metadata": map[string]interface{}{
-					"name":      "instance",
+					"name":      strings.Repeat("a", 64),
 					"namespace": namespace,
 				},
 				"spec": map[string]interface{}{
@@ -160,7 +162,7 @@ var _ = Describe("Labels and Annotations", func() {
 		Expect(cfgMap.GetLabels()).To(SatisfyAll(
 			HaveKeyWithValue(applyset.ApplysetPartOfLabel, applyset.ID(instance)),
 			HaveKeyWithValue(metadata.InstanceNamespaceLabel, instance.GetNamespace()),
-			HaveKeyWithValue(metadata.InstanceLabel, instance.GetName()),
+			HaveKey(metadata.InstanceLabel),
 			HaveKeyWithValue(metadata.InstanceIDLabel, string(instance.GetUID())),
 			HaveKeyWithValue(metadata.InstanceGroupLabel, krov1alpha1.KRODomainName),
 			HaveKeyWithValue(metadata.InstanceVersionLabel, "v1alpha1"),
@@ -168,6 +170,9 @@ var _ = Describe("Labels and Annotations", func() {
 			HaveKeyWithValue(metadata.KROVersionLabel, "devel"),
 			HaveKeyWithValue(metadata.OwnedLabel, "true"),
 		), "config map should be created as part of apply set managed by instance created through rgd")
+		Expect(validation.IsValidLabelValue(cfgMap.GetLabels()[metadata.InstanceLabel])).To(BeEmpty())
+		Expect(cfgMap.GetLabels()[metadata.InstanceLabel]).ToNot(Equal(instance.GetName()))
+		Expect(cfgMap.GetAnnotations()).To(HaveKeyWithValue(metadata.InstanceNameAnnotation, instance.GetName()))
 		Expect(cfgMap.GetLabels()).ToNot(HaveKey(metadata.ResourceGraphDefinitionIDLabel),
 			"child resource should not have RGD ID label (RGD labels are only applied to CRDs)")
 		Expect(cfgMap.GetLabels()).ToNot(HaveKey(metadata.ResourceGraphDefinitionNameLabel),

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -107,7 +107,7 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `kro.run/owned` | Set to `"true"` to indicate kro manages this resource |
 | `kro.run/kro-version` | Version of kro managing the resource |
 | `kro.run/instance-id` | UID of the instance that created this resource |
-| `kro.run/instance-name` | Name of the instance |
+| `kro.run/instance-name` | Name of the instance, or a stable hash when the name exceeds the Kubernetes label value limit |
 | `kro.run/instance-namespace` | Namespace of the instance (only for namespaced instances) |
 | `kro.run/instance-group` | API group of the instance |
 | `kro.run/instance-version` | API version of the instance |
@@ -115,6 +115,12 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `app.kubernetes.io/managed-by` | Set to `"kro"` |
 | `kro.run/node-id` | Resource ID from the RGD |
 | `applyset.kubernetes.io/part-of` | Links the resource to its parent instance (matches the instance's `applyset.kubernetes.io/id`) |
+
+**Annotations:**
+
+| Annotation | Description |
+|------------|-------------|
+| `internal.kro.run/instance-name` | Full instance name when `kro.run/instance-name` contains a hash |
 
 **Collection-specific labels** (only on resources created via `forEach`):
 


### PR DESCRIPTION
Problem

Kubernetes accepts custom resource names longer than 63 characters, but label values stop at 63. 
kro copied the instance name into `kro.run/instance-name`, so child apply failed for a valid long named instance. 
yes, it's an edge case, but I guess it's worth fixing

Fix

Short names stay unchanged. 
Long names get a stable FNV64 label value, while `internal.kro.run/instance-name` keeps the full readable name. 
No migration is needed because these children could not be created before

Repro

Create an instance with this valid 64 character name:

```yaml
metadata:
  name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

Before this change its managed child fails with `must be no more than 63 bytes`. 
Afterward the child reconciles normally

Tests

`make test WHAT=unit`

Focused Labels and Annotations integration suite

`make lint`