### PR TITLE
fix(cli): generate valid CRD manifests

### DIFF
--- a/cmd/kro/commands/generate/crd.go
+++ b/cmd/kro/commands/generate/crd.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/spf13/cobra"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -60,7 +61,7 @@ func generateCRD(rgd *v1alpha1.ResourceGraphDefinition) error {
 	}
 
 	crd := rgdGraph.CRD
-	crd.SetAnnotations(map[string]string{"kro.run/cli-version": "dev"})
+	prepareCRDForOutput(crd)
 
 	b, err := marshalObject(crd, config.outputFormat)
 	if err != nil {
@@ -70,4 +71,9 @@ func generateCRD(rgd *v1alpha1.ResourceGraphDefinition) error {
 	fmt.Println(string(b))
 
 	return nil
+}
+
+func prepareCRDForOutput(crd *extv1.CustomResourceDefinition) {
+	crd.SetGroupVersionKind(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	crd.SetAnnotations(map[string]string{"kro.run/cli-version": "dev"})
 }

--- a/cmd/kro/commands/generate/generate_utils.go
+++ b/cmd/kro/commands/generate/generate_utils.go
@@ -24,7 +24,7 @@ import (
 
 	kroclient "github.com/kubernetes-sigs/kro/pkg/client"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 func createGraphBuilder(rgd *v1alpha1.ResourceGraphDefinition) (*graph.Graph, error) {

--- a/cmd/kro/commands/generate/generate_utils_test.go
+++ b/cmd/kro/commands/generate/generate_utils_test.go
@@ -1,0 +1,66 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func TestMarshalCRDAsKubernetesManifest(t *testing.T) {
+	for _, outputFormat := range []string{"yaml", "json"} {
+		t.Run(outputFormat, func(t *testing.T) {
+			crd := &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "widgets.example.com"},
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Group: "example.com",
+				},
+			}
+			prepareCRDForOutput(crd)
+
+			manifest, err := marshalObject(crd, outputFormat)
+			require.NoError(t, err)
+
+			jsonManifest := manifest
+			if outputFormat == "yaml" {
+				jsonManifest, err = yaml.YAMLToJSON(manifest)
+				require.NoError(t, err)
+			}
+
+			var object unstructured.Unstructured
+			require.NoError(t, object.UnmarshalJSON(jsonManifest))
+			assert.Equal(t, "apiextensions.k8s.io/v1", object.GetAPIVersion())
+			assert.Equal(t, "CustomResourceDefinition", object.GetKind())
+			assert.Equal(t, "widgets.example.com", object.GetName())
+			assert.Equal(t, "dev", object.GetAnnotations()["kro.run/cli-version"])
+			group, found, err := unstructured.NestedString(object.Object, "spec", "group")
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, "example.com", group)
+
+			var fields map[string]interface{}
+			require.NoError(t, json.Unmarshal(jsonManifest, &fields))
+			assert.NotContains(t, fields, "typemeta")
+			assert.NotContains(t, fields, "objectmeta")
+		})
+	}
+}

--- a/cmd/kro/go.mod
+++ b/cmd/kro/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kubernetes-sigs/kro v0.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/apiextensions-apiserver v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad
@@ -78,7 +78,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.36.3 // indirect
-	k8s.io/apiextensions-apiserver v0.36.3 // indirect
 	k8s.io/apiserver v0.36.3 // indirect
 	k8s.io/component-base v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/cmd/kro/go.sum
+++ b/cmd/kro/go.sum
@@ -186,8 +186,6 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
`kro generate crd` emitted YAML with `typemeta` and `objectmeta`. 
Both YAML and JSON also missed `apiVersion` and `kind`, so `kubectl` rejected the output

This sets the CRD GVK and uses Kubernetes-aware YAML marshaling. 
Small fix, but generated manifests work now

Repro before this fix:

```sh
kro generate crd -f rgd.yaml > generated.yaml
kubectl apply -f generated.yaml
```

Result: `apiVersion not set, kind not set`.

Test: `cd cmd/kro && go test -race ./...`