### PR TITLE
fix: record RGD name in an annotation; skip the label when it cannot fit

### DIFF
--- a/pkg/client/crd.go
+++ b/pkg/client/crd.go
@@ -138,7 +138,7 @@ func (w *CRDWrapper) Ensure(ctx context.Context, desired v1.CustomResourceDefini
 		}
 
 		if !nameMatch {
-			existingRGDName := existing.Labels[metadata.ResourceGraphDefinitionNameLabel]
+			existingRGDName, _ := metadata.GetResourceGraphDefinitionName(existing)
 			return fmt.Errorf(
 				"failed to update CRD %s: CRD is owned by another ResourceGraphDefinition %s",
 				desired.Name, existingRGDName,

--- a/pkg/controller/instance/context.go
+++ b/pkg/controller/instance/context.go
@@ -37,7 +37,7 @@ type ReconcileContext struct {
 	Namespaced bool
 	Client     dynamic.Interface
 	RestMapper meta.RESTMapper
-	Labeler    metadata.Labeler
+	Labeler    metadata.MetadataUpdater
 
 	Runtime  runtime.Interface
 	Instance *unstructured.Unstructured
@@ -94,7 +94,7 @@ func NewReconcileContext(
 	namespaced bool,
 	client dynamic.Interface,
 	restMapper meta.RESTMapper,
-	labeler metadata.Labeler,
+	labeler metadata.MetadataUpdater,
 	rt runtime.Interface,
 	config ReconcileConfig,
 	instance *unstructured.Unstructured,

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -103,10 +103,14 @@ type Controller struct {
 	graphResolver GraphRevisionResolver
 	namespaced    bool
 
-	instanceLabeler      metadata.Labeler
-	childResourceLabeler metadata.Labeler
-	reconcileConfig      ReconcileConfig
-	coordinator          *dynamiccontroller.WatchCoordinator
+	instanceLabeler      metadata.MetadataUpdater
+	childResourceLabeler metadata.MetadataUpdater
+	// instanceAnnotations are controller-owned annotations stamped on the
+	// instance alongside the labels. Annotations carry values that may not fit
+	// in a label (e.g. the full RGD name).
+	instanceAnnotations map[string]string
+	reconcileConfig     ReconcileConfig
+	coordinator         *dynamiccontroller.WatchCoordinator
 
 	// eventRecorder emits K8s Events on condition transitions.
 	eventRecorder record.EventRecorder
@@ -125,8 +129,8 @@ func NewController(
 	graphResolver GraphRevisionResolver,
 	namespaced bool,
 	client kroclient.SetInterface,
-	instanceLabeler metadata.Labeler,
-	childResourceLabeler metadata.Labeler,
+	instanceLabeler metadata.MetadataUpdater,
+	childResourceLabeler metadata.MetadataUpdater,
 	coord *dynamiccontroller.WatchCoordinator,
 	eventRecorder record.EventRecorder,
 ) *Controller {
@@ -398,7 +402,7 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 		}
 	}
 
-	wantLabels := c.instanceLabeler.Labels()
+	wantLabels := c.instanceLabeler.GetLabels()
 	haveLabels := obj.GetLabels()
 	needLabelPatch := false
 
@@ -409,7 +413,16 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 		}
 	}
 
-	if needPatch := needFinalizer || needLabelPatch; !needPatch {
+	haveAnnotations := obj.GetAnnotations()
+	needAnnotationPatch := false
+	for k, v := range c.instanceAnnotations {
+		if haveAnnotations[k] != v {
+			needAnnotationPatch = true
+			break
+		}
+	}
+
+	if needPatch := needFinalizer || needLabelPatch || needAnnotationPatch; !needPatch {
 		return nil, nil
 	}
 
@@ -422,6 +435,10 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 	// we patch together here because otherwise we could revert a previous patch
 	// result if only one of finalizers or labels change.
 	patchLabels := maps.Clone(wantLabels)
+	patchAnnotations := maps.Clone(c.instanceAnnotations)
+	if patchAnnotations == nil {
+		patchAnnotations = map[string]string{}
+	}
 	if needFinalizer && !hasInventoryMetadata {
 		// Install a valid empty inventory in the same write as the finalizer.
 		// This guarantees that deletion can make progress even if normal
@@ -431,9 +448,12 @@ func (c *Controller) applyManagedFinalizerAndLabels(rcx *ReconcileContext) (*uns
 			Tooling: applyset.ToolingID(),
 		}
 		maps.Copy(patchLabels, emptyInventory.Labels())
-		patch.SetAnnotations(emptyInventory.Annotations())
+		maps.Copy(patchAnnotations, emptyInventory.Annotations())
 	}
 	patch.SetLabels(patchLabels)
+	if len(patchAnnotations) > 0 {
+		patch.SetAnnotations(patchAnnotations)
+	}
 	metadata.SetInstanceFinalizer(patch)
 
 	patched, err := rcx.InstanceClient().Apply(

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -84,7 +84,7 @@ func TestApplyManagedFinalizerAndLabels(t *testing.T) {
 				metadata.SetInstanceFinalizer(instance)
 			}
 			if tt.presetLabels {
-				metadata.NewKROMetaLabeler().ApplyLabels(instance)
+				metadata.NewKROMetaLabeler().Apply(instance)
 			}
 			if tt.presetInventory {
 				addDeletionScope(instance, controllerTestDeployGVK, "other")
@@ -102,7 +102,7 @@ func TestApplyManagedFinalizerAndLabels(t *testing.T) {
 				require.NotNil(t, patched)
 			}
 			assert.True(t, metadata.HasInstanceFinalizer(patched))
-			for key, value := range metadata.NewKROMetaLabeler().Labels() {
+			for key, value := range metadata.NewKROMetaLabeler().GetLabels() {
 				assert.Equal(t, value, patched.GetLabels()[key])
 			}
 			if tt.wantInventory {
@@ -437,7 +437,7 @@ func TestReconcileGraphResolveFailureKeepsOnlyAuthorConditionsOnWire(t *testing.
 func TestReconcileManagedFastPathDoesNotLeakBuiltins(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	metadata.SetInstanceFinalizer(instance)
-	metadata.NewKROMetaLabeler().ApplyLabels(instance)
+	metadata.NewKROMetaLabeler().Apply(instance)
 	require.NoError(t, unstructured.SetNestedField(instance.Object, int64(1), "metadata", "generation"))
 	require.NoError(t, unstructured.SetNestedSlice(instance.Object, []interface{}{
 		map[string]interface{}{
@@ -488,7 +488,7 @@ func TestReconcileManagedFastPathDoesNotLeakBuiltins(t *testing.T) {
 func TestReconcileManagedFastPathSkipsNoopStatusWrite(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	metadata.SetInstanceFinalizer(instance)
-	metadata.NewKROMetaLabeler().ApplyLabels(instance)
+	metadata.NewKROMetaLabeler().Apply(instance)
 	require.NoError(t, unstructured.SetNestedField(instance.Object, int64(1), "metadata", "generation"))
 	require.NoError(t, unstructured.SetNestedField(instance.Object,
 		string(v1alpha1.InstanceStateActive), "status", "state"))
@@ -529,7 +529,7 @@ func TestReconcileManagedFastPathSkipsNoopStatusWrite(t *testing.T) {
 func TestReconcileSkipsNoopStatusWriteForWholeNumbers(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	metadata.SetInstanceFinalizer(instance)
-	metadata.NewKROMetaLabeler().ApplyLabels(instance)
+	metadata.NewKROMetaLabeler().Apply(instance)
 	require.NoError(t, unstructured.SetNestedField(instance.Object, int64(1), "metadata", "generation"))
 	require.NoError(t, unstructured.SetNestedField(instance.Object,
 		string(v1alpha1.InstanceStateActive), "status", "state"))

--- a/pkg/controller/instance/resources.go
+++ b/pkg/controller/instance/resources.go
@@ -486,7 +486,7 @@ func (c *Controller) applyDecoratorMetadata(
 		rcx.Log.V(1).Info("label merge conflict, using instance labels only", "error", err)
 		toolLabels = instanceLabeler
 	}
-	for k, v := range toolLabels.Labels() {
+	for k, v := range toolLabels.GetLabels() {
 		labels[k] = v
 	}
 

--- a/pkg/controller/instance/resources_test.go
+++ b/pkg/controller/instance/resources_test.go
@@ -717,8 +717,8 @@ func TestApplyDecoratorLabelsAndPatchMetadata(t *testing.T) {
 	instance := newInstanceObject("demo", "default")
 	controller, rcx, raw := newControllerAndContext(t, instance, newTestGraph())
 
-	conflictingLabeler := metadata.GenericLabeler{
-		metadata.InstanceIDLabel: "conflict",
+	conflictingLabeler := metadata.GenericMetadataUpdater{
+		Labels: map[string]string{metadata.InstanceIDLabel: "conflict"},
 	}
 	rcx.Labeler = conflictingLabeler
 

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -67,7 +67,7 @@ type ResourceGraphDefinitionReconciler struct {
 
 	clientSet             kroclient.SetInterface
 	crdManager            kroclient.CRDClient
-	metadataLabeler       metadata.Labeler
+	metadataLabeler       metadata.MetadataUpdater
 	rgBuilder             resourceGraphBuilder
 	dynamicController     *dynamiccontroller.DynamicController
 	revisionsRegistry     *revisions.Registry
@@ -224,7 +224,9 @@ func (r *ResourceGraphDefinitionReconciler) findRGDsForCRD(ctx context.Context, 
 		return nil
 	}
 
-	rgdName, ok := mobj.GetLabels()[metadata.ResourceGraphDefinitionNameLabel]
+	// Annotation-first: for RGD names longer than 63 characters only the
+	// annotation carries the (full) name; the label is omitted.
+	rgdName, ok := metadata.GetResourceGraphDefinitionName(mobj)
 	if !ok {
 		return nil
 	}

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -102,7 +102,7 @@ func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinitionCRD(ct
 		return nil
 	}
 
-	owner, ok := crd.GetLabels()[metadata.ResourceGraphDefinitionNameLabel]
+	owner, ok := metadata.GetResourceGraphDefinitionName(crd)
 	if !ok || owner != rgdName {
 		ctrl.LoggerFrom(ctx).V(1).Info(
 			"skipping CRD deletion, not owned by this RGD",

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -182,7 +182,7 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinition(
 func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 	rgd *v1alpha1.ResourceGraphDefinition,
 	processedRGD *graph.Graph,
-	instanceLabeler metadata.Labeler,
+	instanceLabeler metadata.MetadataUpdater,
 ) *instancectrl.Controller {
 	gvr := processedRGD.Instance.Meta.GVR
 	instanceLogger := r.instanceLogger.WithName(fmt.Sprintf("%s-controller", gvr.Resource)).WithValues(
@@ -349,7 +349,7 @@ func (r *ResourceGraphDefinitionReconciler) ensureResourceGraphDefinitionControl
 	ctx context.Context,
 	rgd *v1alpha1.ResourceGraphDefinition,
 	processedRGD *graph.Graph,
-	instanceLabeler metadata.Labeler,
+	instanceLabeler metadata.MetadataUpdater,
 ) error {
 	controller := r.setupMicroController(rgd, processedRGD, instanceLabeler)
 
@@ -382,7 +382,7 @@ func (r *ResourceGraphDefinitionReconciler) ensureServingState(
 	}
 
 	crd := processedRGD.CRD
-	instanceLabeler.ApplyLabels(&crd.ObjectMeta)
+	instanceLabeler.Apply(&crd.ObjectMeta)
 
 	log.V(1).Info("ensuring resource graph definition CRD")
 	allowBreakingChanges := rgd.Annotations[v1alpha1.AllowBreakingChangesAnnotation] == "true"
@@ -570,10 +570,7 @@ func (r *ResourceGraphDefinitionReconciler) createGraphRevision(
 	specHash string,
 ) (*internalv1alpha1.GraphRevision, error) {
 	// GraphRevisions are tracked by RGD name, so the UID label is not needed.
-	// The spec hash label is kept for user-facing queries (kubectl).
-	rgdNameLabeler := metadata.GenericLabeler{
-		metadata.ResourceGraphDefinitionNameLabel: rgd.Name,
-	}
+	rgdNameLabeler := metadata.NewResourceGraphDefinitionNameLabeler(rgd.Name)
 	graphRevisionLabeler, err := r.metadataLabeler.Merge(rgdNameLabeler)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup graph revision labels: %w", err)
@@ -599,7 +596,7 @@ func (r *ResourceGraphDefinitionReconciler) createGraphRevision(
 			},
 		},
 	}
-	graphRevisionLabeler.ApplyLabels(&graphRevision.ObjectMeta)
+	graphRevisionLabeler.Apply(&graphRevision.ObjectMeta)
 
 	if err := r.Create(ctx, graphRevision); err != nil {
 		return nil, fmt.Errorf("creating graph revision %q: %w", graphRevision.Name, err)

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile_test.go
@@ -320,7 +320,7 @@ func TestCreateGraphRevision_HashLabelMergeError(t *testing.T) {
 
 	registry := revisions.NewRegistry()
 	reconciler := &ResourceGraphDefinitionReconciler{
-		metadataLabeler:   metadata.GenericLabeler{metadata.GraphRevisionHashLabel: "existing-hash"},
+		metadataLabeler:   metadata.GenericMetadataUpdater{Labels: map[string]string{metadata.GraphRevisionHashLabel: "existing-hash"}},
 		revisionsRegistry: registry,
 	}
 
@@ -434,8 +434,8 @@ func TestEnsureServingState_LabelerSetupFailure(t *testing.T) {
 
 	rgd := newTestRGD("rgd-serving-labeler-fail")
 	reconciler := &ResourceGraphDefinitionReconciler{
-		metadataLabeler: metadata.GenericLabeler{
-			metadata.ResourceGraphDefinitionNameLabel: "conflict",
+		metadataLabeler: metadata.GenericMetadataUpdater{
+			Labels: map[string]string{metadata.ResourceGraphDefinitionNameLabel: "conflict"},
 		},
 	}
 	mark := NewConditionsMarkerFor(rgd)
@@ -784,8 +784,8 @@ func TestReconcileResourceGraphDefinition(t *testing.T) {
 				return &ResourceGraphDefinitionReconciler{
 					Client:    cl,
 					apiReader: cl,
-					metadataLabeler: metadata.GenericLabeler{
-						metadata.ResourceGraphDefinitionNameLabel: "conflict",
+					metadataLabeler: metadata.GenericMetadataUpdater{
+						Labels: map[string]string{metadata.ResourceGraphDefinitionNameLabel: "conflict"},
 					},
 					rgBuilder:         newTestBuilder(),
 					revisionsRegistry: revisions.NewRegistry(),
@@ -2466,7 +2466,7 @@ func newListedGraphRevision(rgd *v1alpha1.ResourceGraphDefinition, revision int6
 			Name: graphRevisionName(rgd.Name, revision),
 			Labels: map[string]string{
 				metadata.ResourceGraphDefinitionNameLabel: rgd.Name,
-				metadata.GraphRevisionHashLabel:           metadata.NewGraphRevisionHashLabeler(specHash)[metadata.GraphRevisionHashLabel],
+				metadata.GraphRevisionHashLabel:           metadata.NewGraphRevisionHashLabeler(specHash).GetLabels()[metadata.GraphRevisionHashLabel],
 			},
 		},
 		Spec: internalv1alpha1.GraphRevisionSpec{

--- a/pkg/controller/resourcegraphdefinition/controller_test.go
+++ b/pkg/controller/resourcegraphdefinition/controller_test.go
@@ -17,6 +17,7 @@ package resourcegraphdefinition
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -562,7 +563,7 @@ func TestNewResourceGraphDefinitionReconciler(t *testing.T) {
 	assert.Equal(t, 5*time.Second, r.cfg.ProgressRequeueDelay)
 	assert.Equal(t, 7, r.cfg.MaxConcurrentReconciles)
 	assert.Equal(t, graph.RGDConfig{MaxCollectionSize: 32}, r.cfg.RGDConfig)
-	assert.Equal(t, metadata.NewKROMetaLabeler().Labels(), r.metadataLabeler.Labels())
+	assert.Equal(t, metadata.NewKROMetaLabeler().GetLabels(), r.metadataLabeler.GetLabels())
 }
 
 func TestNewResourceGraphDefinitionReconcilerPreservesZeroInstanceRequeueInterval(t *testing.T) {
@@ -619,6 +620,41 @@ func TestFindRGDsForCRD(t *testing.T) {
 					Labels: map[string]string{
 						metadata.ManagedByLabelKey:                metadata.ManagedByKROValue,
 						metadata.ResourceGraphDefinitionNameLabel: "demo-rgd",
+					},
+				},
+			},
+			want: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Name: "demo-rgd"},
+			}},
+		},
+		{
+			name: "maps owned CRDs via annotation when rgd name exceeds label limit",
+			obj: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "owned",
+					Labels: map[string]string{
+						metadata.ManagedByLabelKey: metadata.ManagedByKROValue,
+					},
+					Annotations: map[string]string{
+						metadata.ResourceGraphDefinitionNameAnnotation: strings.Repeat("a", 100),
+					},
+				},
+			},
+			want: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Name: strings.Repeat("a", 100)},
+			}},
+		},
+		{
+			name: "prefers annotation over label",
+			obj: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "owned",
+					Labels: map[string]string{
+						metadata.ManagedByLabelKey:                metadata.ManagedByKROValue,
+						metadata.ResourceGraphDefinitionNameLabel: "stale-rgd",
+					},
+					Annotations: map[string]string{
+						metadata.ResourceGraphDefinitionNameAnnotation: "demo-rgd",
 					},
 				},
 			},

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -14,7 +14,32 @@
 
 package metadata
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 const (
 	// ApplyOrderAnnotation persists a managed resource's reverse topological deletion wave.
 	ApplyOrderAnnotation = InternalKROPrefix + "apply-order"
+
+	// ResourceGraphDefinitionNameAnnotation records the full name of the owning
+	// ResourceGraphDefinition. Unlike the label of the same name, annotation
+	// values are not limited to 63 characters, so this always holds the complete
+	// name. Readers should use GetResourceGraphDefinitionName, which prefers
+	// this annotation over the label.
+	ResourceGraphDefinitionNameAnnotation = KROPrefix + "resource-graph-definition-name"
 )
+
+
+// GetResourceGraphDefinitionName returns the owning RGD name recorded on the
+// object, preferring the annotation (always the complete name) over the label
+// (omitted when the name does not fit in a label value). Objects written
+// before the annotation existed carry only the label; for those the label is
+// necessarily the full name, since longer names could never be written.
+func GetResourceGraphDefinitionName(obj metav1.Object) (string, bool) {
+	if name, ok := obj.GetAnnotations()[ResourceGraphDefinitionNameAnnotation]; ok {
+		return name, true
+	}
+	name, ok := obj.GetLabels()[ResourceGraphDefinitionNameLabel]
+	return name, ok
+}

--- a/pkg/metadata/annotations_test.go
+++ b/pkg/metadata/annotations_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+
+
+func TestGetResourceGraphDefinitionName(t *testing.T) {
+	longName := strings.Repeat("a", 100)
+
+	cases := []struct {
+		name         string
+		labels       map[string]string
+		annotations  map[string]string
+		expectedName string
+		expectedOK   bool
+	}{
+		{
+			name:       "neither annotation nor label",
+			expectedOK: false,
+		},
+		{
+			name:         "label only (pre-annotation object)",
+			labels:       map[string]string{ResourceGraphDefinitionNameLabel: "my-rgd"},
+			expectedName: "my-rgd",
+			expectedOK:   true,
+		},
+		{
+			name:         "annotation only (over-long name)",
+			annotations:  map[string]string{ResourceGraphDefinitionNameAnnotation: longName},
+			expectedName: longName,
+			expectedOK:   true,
+		},
+		{
+			name:         "annotation preferred over label",
+			labels:       map[string]string{ResourceGraphDefinitionNameLabel: "stale"},
+			annotations:  map[string]string{ResourceGraphDefinitionNameAnnotation: "my-rgd"},
+			expectedName: "my-rgd",
+			expectedOK:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &mockObject{ObjectMeta: metav1.ObjectMeta{
+				Labels:      tc.labels,
+				Annotations: tc.annotations,
+			}}
+			name, ok := GetResourceGraphDefinitionName(obj)
+			assert.Equal(t, tc.expectedOK, ok)
+			assert.Equal(t, tc.expectedName, name)
+		})
+	}
+}

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -53,8 +54,12 @@ const (
 	InstanceVersionLabel   = KROPrefix + "instance-version"
 	InstanceKindLabel      = KROPrefix + "instance-kind"
 
-	ResourceGraphDefinitionIDLabel        = KROPrefix + "resource-graph-definition-id"
-	ResourceGraphDefinitionNameLabel      = KROPrefix + "resource-graph-definition-name"
+	ResourceGraphDefinitionIDLabel = KROPrefix + "resource-graph-definition-id"
+
+	// ResourceGraphDefinitionNameLabel is only used when the name is short enough to fit in a label.
+	// Prefer to use GetResourceGraphDefinitionName.
+	ResourceGraphDefinitionNameLabel = KROPrefix + "resource-graph-definition-name"
+
 	ResourceGraphDefinitionNamespaceLabel = KROPrefix + "resource-graph-definition-namespace"
 	ResourceGraphDefinitionVersionLabel   = KROPrefix + "resource-graph-definition-version"
 	// GraphRevisionHashLabel stores a label-safe representation of the GraphRevision spec hash.
@@ -87,10 +92,12 @@ func CompareRGDOwnership(existing, desired metav1.ObjectMeta) (kroOwned, nameMat
 		return false, false, false
 	}
 
-	existingOwnerName := existing.Labels[ResourceGraphDefinitionNameLabel]
+	// Names are read annotation-first: RGD names longer than 63 characters are
+	// only recorded in the annotation, never in the label.
+	existingOwnerName, _ := GetResourceGraphDefinitionName(&existing)
 	existingOwnerID := existing.Labels[ResourceGraphDefinitionIDLabel]
 
-	desiredOwnerName := desired.Labels[ResourceGraphDefinitionNameLabel]
+	desiredOwnerName, _ := GetResourceGraphDefinitionName(&desired)
 	desiredOwnerID := desired.Labels[ResourceGraphDefinitionIDLabel]
 
 	nameMatch = existingOwnerName == desiredOwnerName
@@ -103,68 +110,138 @@ var (
 	ErrDuplicatedLabels = errors.New("duplicate labels")
 )
 
-var _ Labeler = GenericLabeler{}
+var _ MetadataUpdater = GenericMetadataUpdater{}
 
-// Labeler is an interface that defines a set of labels that can be
-// applied to a resource.
-type Labeler interface {
-	Labels() map[string]string
-	ApplyLabels(metav1.Object)
-	Merge(Labeler) (Labeler, error)
+// MetadataUpdater is an interface that defines a set of labels and annotations
+// that can be applied to a resource.
+type MetadataUpdater interface {
+	GetLabels() map[string]string
+	GetAnnotations() map[string]string
+	Apply(metav1.Object)
+	Merge(MetadataUpdater) (MetadataUpdater, error)
 }
 
-// GenericLabeler is a map of labels that can be applied to a resource.
-// It implements the Labeler interface.
-type GenericLabeler map[string]string
+// GenericMetadataUpdater is a set of labels and annotations that are applied to a resource.
+// It implements MetadataUpdater.
+type GenericMetadataUpdater struct {
+	Labels      map[string]string
+	Annotations map[string]string
+}
 
 // Labels returns the labels.
-func (gl GenericLabeler) Labels() map[string]string {
-	return gl
+func (gl GenericMetadataUpdater) GetLabels() map[string]string {
+	return gl.Labels
 }
 
-// ApplyLabels applies the labels to the resource.
-func (gl GenericLabeler) ApplyLabels(meta metav1.Object) {
-	for k, v := range gl {
+// Annotations returns the annotations.
+func (gl GenericMetadataUpdater) GetAnnotations() map[string]string {
+	return gl.Annotations
+}
+
+// Apply applies the labels and annotations to the resource.
+func (gl GenericMetadataUpdater) Apply(meta metav1.Object) {
+	for k, v := range gl.Labels {
 		setLabel(meta, k, v)
 	}
-}
-
-// Merge merges the labels from the other labeler into the current
-// labeler. If there are any duplicate keys, an error is returned.
-func (gl GenericLabeler) Merge(other Labeler) (Labeler, error) {
-	newLabels := gl.Copy()
-	for k, v := range other.Labels() {
-		if _, ok := newLabels[k]; ok {
-			return nil, fmt.Errorf("%v: found key '%s' in both maps", ErrDuplicatedLabels, k)
+	if len(gl.Annotations) != 0 {
+		annotations := meta.GetAnnotations()
+		if annotations == nil {
+			annotations = maps.Clone(gl.Annotations)
+		} else {
+			maps.Copy(annotations, gl.Annotations)
 		}
-		newLabels[k] = v
+		meta.SetAnnotations(annotations)
 	}
-	return GenericLabeler(newLabels), nil
 }
 
-// Copy returns a copy of the labels.
-func (gl GenericLabeler) Copy() map[string]string {
-	newGenericLabeler := map[string]string{}
-	for k, v := range gl {
-		newGenericLabeler[k] = v
+// Merge merges the labels and annotations from the other labeler into the current
+// labeler. If there are any duplicate keys, an error is returned.
+func (gl GenericMetadataUpdater) Merge(other MetadataUpdater) (MetadataUpdater, error) {
+	newCopy := gl.Copy()
+	if labels := other.GetLabels(); len(labels) != 0 {
+		if newCopy.Labels == nil {
+			newCopy.Labels = make(map[string]string, len(labels))
+		}
+		for k, v := range labels {
+			if _, ok := newCopy.Labels[k]; ok {
+				return nil, fmt.Errorf("%v: found key '%s' in both label maps", ErrDuplicatedLabels, k)
+			}
+			newCopy.Labels[k] = v
+		}
 	}
-	return newGenericLabeler
+	if annotations := other.GetAnnotations(); len(annotations) != 0 {
+		if newCopy.Annotations == nil {
+			newCopy.Annotations = make(map[string]string, len(annotations))
+		}
+		for k, v := range annotations {
+			if _, ok := newCopy.Annotations[k]; ok {
+				return nil, fmt.Errorf("%v: found key '%s' in both annotation maps", ErrDuplicatedLabels, k)
+			}
+			newCopy.Annotations[k] = v
+		}
+	}
+	return newCopy, nil
 }
 
-// NewResourceGraphDefinitionLabeler returns a new labeler that sets the
-// ResourceGraphDefinitionLabel and ResourceGraphDefinitionIDLabel labels on a resource.
-func NewResourceGraphDefinitionLabeler(rgMeta metav1.Object) GenericLabeler {
-	return map[string]string{
-		ResourceGraphDefinitionIDLabel:   string(rgMeta.GetUID()),
-		ResourceGraphDefinitionNameLabel: rgMeta.GetName(),
+// Copy returns a copy of the labels and annotations.
+func (gl GenericMetadataUpdater) Copy() GenericMetadataUpdater {
+	var c GenericMetadataUpdater
+	if len(gl.Labels) != 0 {
+		c.Labels = maps.Clone(gl.Labels)
 	}
+	if len(gl.Annotations) != 0 {
+		c.Annotations = maps.Clone(gl.Annotations)
+	}
+	return c
+}
+
+// NewResourceGraphDefinitionLabeler returns a new MetadataUpdater that sets the
+// ResourceGraphDefinitionLabel and ResourceGraphDefinitionIDLabel labels on a resource,
+// alongside the ResourceGraphDefinitionNameAnnotation annotation.
+// The name label is omitted when the RGD name is not a valid label value
+// (label values are limited to 63 characters, while RGD names can be up to
+// 253); the full name is always recorded via the annotation instead.
+func NewResourceGraphDefinitionLabeler(rgMeta metav1.Object) MetadataUpdater {
+	name := rgMeta.GetName()
+	labels := map[string]string{
+		ResourceGraphDefinitionIDLabel: string(rgMeta.GetUID()),
+	}
+	if validation.IsValidLabelValue(name) == nil {
+		labels[ResourceGraphDefinitionNameLabel] = name
+	}
+	return GenericMetadataUpdater{
+		Labels: labels,
+		Annotations: map[string]string{
+			ResourceGraphDefinitionNameAnnotation: name,
+		},
+	}
+}
+
+// NewResourceGraphDefinitionNameLabeler returns a MetadataUpdater carrying only the
+// RGD name.  The label is omitted when the RGD name is not a valid label
+// value (label values are limited to 63 characters, while RGD names can be up to
+// 253); the full name is always recorded via the annotation instead.
+func NewResourceGraphDefinitionNameLabeler(name string) MetadataUpdater {
+	updater := GenericMetadataUpdater{
+		Annotations: map[string]string{
+			ResourceGraphDefinitionNameAnnotation: name,
+		},
+	}
+	if validation.IsValidLabelValue(name) == nil {
+		updater.Labels = map[string]string{
+			ResourceGraphDefinitionNameLabel: name,
+		}
+	}
+	return updater
 }
 
 // NewGraphRevisionHashLabeler returns a new labeler that sets a label-safe
 // representation of the GraphRevision spec hash on a resource.
-func NewGraphRevisionHashLabeler(specHash string) GenericLabeler {
-	return map[string]string{
-		GraphRevisionHashLabel: specHash,
+func NewGraphRevisionHashLabeler(specHash string) MetadataUpdater {
+	return GenericMetadataUpdater{
+		Labels: map[string]string{
+			GraphRevisionHashLabel: specHash,
+		},
 	}
 }
 
@@ -173,7 +250,7 @@ func NewGraphRevisionHashLabeler(specHash string) GenericLabeler {
 // and name of the instance that was reconciled to create the resource.
 // It also includes the instance's GVK to allow child
 // resource handlers to filter events by parent instance type.
-func NewInstanceLabeler(instance *unstructured.Unstructured, namespaced bool) GenericLabeler {
+func NewInstanceLabeler(instance *unstructured.Unstructured, namespaced bool) MetadataUpdater {
 	gvk := instance.GroupVersionKind()
 	labels := map[string]string{
 		InstanceIDLabel:      string(instance.GetUID()),
@@ -185,23 +262,29 @@ func NewInstanceLabeler(instance *unstructured.Unstructured, namespaced bool) Ge
 	if namespaced {
 		labels[InstanceNamespaceLabel] = instance.GetNamespace()
 	}
-	return labels
+	return GenericMetadataUpdater{
+		Labels: labels,
+	}
 }
 
 // NewNodeLabeler returns a new labeler for child resources
 // Only includes app.kubernetes.io/managed-by label, as other labels come from the parent labeler.
-func NewNodeLabeler() GenericLabeler {
-	return map[string]string{
-		ManagedByLabelKey: ManagedByKROValue,
+func NewNodeLabeler() MetadataUpdater {
+	return GenericMetadataUpdater{
+		Labels: map[string]string{
+			ManagedByLabelKey: ManagedByKROValue,
+		},
 	}
 }
 
 // NewKROMetaLabeler returns a new labeler that sets the OwnedLabel, and
 // KROVersion labels on a resource.
-func NewKROMetaLabeler() GenericLabeler {
-	return map[string]string{
-		OwnedLabel:      "true",
-		KROVersionLabel: safeVersion(version.GetVersionInfo().GitVersion),
+func NewKROMetaLabeler() MetadataUpdater {
+	return GenericMetadataUpdater{
+		Labels: map[string]string{
+			OwnedLabel:      "true",
+			KROVersionLabel: safeVersion(version.GetVersionInfo().GitVersion),
+		},
 	}
 }
 
@@ -210,11 +293,13 @@ func NewKROMetaLabeler() GenericLabeler {
 // - node-id: the resource ID from the RGD (e.g "workerPods")
 // - collection-index: the position in the collection (e.g "0", "1", "2")
 // - collection-size: the total number of items in the collection (e.g "3")
-func NewCollectionItemLabeler(nodeID string, index, size int) GenericLabeler {
-	return map[string]string{
-		NodeIDLabel:          nodeID,
-		CollectionIndexLabel: strconv.Itoa(index),
-		CollectionSizeLabel:  strconv.Itoa(size),
+func NewCollectionItemLabeler(nodeID string, index, size int) MetadataUpdater {
+	return GenericMetadataUpdater{
+		Labels: map[string]string{
+			NodeIDLabel:          nodeID,
+			CollectionIndexLabel: strconv.Itoa(index),
+			CollectionSizeLabel:  strconv.Itoa(size),
+		},
 	}
 }
 

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,12 +70,14 @@ func TestIsKROOwned(t *testing.T) {
 
 func TestCompareRGDOwnership(t *testing.T) {
 	cases := []struct {
-		name              string
-		existingLabels    map[string]string
-		desiredLabels     map[string]string
-		expectedKROOwned  bool
-		expectedNameMatch bool
-		expectedIDMatch   bool
+		name                string
+		existingLabels      map[string]string
+		existingAnnotations map[string]string
+		desiredLabels       map[string]string
+		desiredAnnotations  map[string]string
+		expectedKROOwned    bool
+		expectedNameMatch   bool
+		expectedIDMatch     bool
 	}{
 		{
 			name: "same RGD - normal update",
@@ -139,12 +142,51 @@ func TestCompareRGDOwnership(t *testing.T) {
 			expectedNameMatch: true,
 			expectedIDMatch:   false,
 		},
+		{
+			name: "over-long name recorded only in annotations - match",
+			existingLabels: map[string]string{
+				OwnedLabel:                     "true",
+				ResourceGraphDefinitionIDLabel: "test-id",
+			},
+			existingAnnotations: map[string]string{
+				ResourceGraphDefinitionNameAnnotation: strings.Repeat("a", 100),
+			},
+			desiredLabels: map[string]string{
+				OwnedLabel:                     "true",
+				ResourceGraphDefinitionIDLabel: "test-id",
+			},
+			desiredAnnotations: map[string]string{
+				ResourceGraphDefinitionNameAnnotation: strings.Repeat("a", 100),
+			},
+			expectedKROOwned:  true,
+			expectedNameMatch: true,
+			expectedIDMatch:   true,
+		},
+		{
+			name: "pre-annotation object with label only matches annotated desired",
+			existingLabels: map[string]string{
+				OwnedLabel:                       "true",
+				ResourceGraphDefinitionNameLabel: "test-rgd",
+				ResourceGraphDefinitionIDLabel:   "test-id",
+			},
+			desiredLabels: map[string]string{
+				OwnedLabel:                       "true",
+				ResourceGraphDefinitionNameLabel: "test-rgd",
+				ResourceGraphDefinitionIDLabel:   "test-id",
+			},
+			desiredAnnotations: map[string]string{
+				ResourceGraphDefinitionNameAnnotation: "test-rgd",
+			},
+			expectedKROOwned:  true,
+			expectedNameMatch: true,
+			expectedIDMatch:   true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			existing := metav1.ObjectMeta{Labels: tc.existingLabels}
-			desired := metav1.ObjectMeta{Labels: tc.desiredLabels}
+			existing := metav1.ObjectMeta{Labels: tc.existingLabels, Annotations: tc.existingAnnotations}
+			desired := metav1.ObjectMeta{Labels: tc.desiredLabels, Annotations: tc.desiredAnnotations}
 
 			kroOwned, nameMatch, idMatch := CompareRGDOwnership(existing, desired)
 
@@ -159,19 +201,19 @@ func TestGenericLabeler(t *testing.T) {
 	t.Run("ApplyLabels", func(t *testing.T) {
 		cases := []struct {
 			name         string
-			labeler      GenericLabeler
+			labeler      MetadataUpdater
 			objectLabels map[string]string
 			expected     map[string]string
 		}{
 			{
 				name:         "Apply labels to empty object",
-				labeler:      GenericLabeler{"key1": "value1", "key2": "value2"},
+				labeler:      GenericMetadataUpdater{Labels: map[string]string{"key1": "value1", "key2": "value2"}},
 				objectLabels: nil,
 				expected:     map[string]string{"key1": "value1", "key2": "value2"},
 			},
 			{
 				name:         "Apply labels to object with existing labels",
-				labeler:      GenericLabeler{"key2": "newvalue2", "key3": "value3"},
+				labeler:      GenericMetadataUpdater{Labels: map[string]string{"key2": "newvalue2", "key3": "value3"}},
 				objectLabels: map[string]string{"key1": "value1", "key2": "value2"},
 				expected:     map[string]string{"key1": "value1", "key2": "newvalue2", "key3": "value3"},
 			},
@@ -180,7 +222,7 @@ func TestGenericLabeler(t *testing.T) {
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				obj := &mockObject{ObjectMeta: metav1.ObjectMeta{Labels: tc.objectLabels}}
-				tc.labeler.ApplyLabels(obj)
+				tc.labeler.Apply(obj)
 				assert.Equal(t, tc.expected, obj.Labels)
 			})
 		}
@@ -189,22 +231,22 @@ func TestGenericLabeler(t *testing.T) {
 	t.Run("Merge", func(t *testing.T) {
 		cases := []struct {
 			name           string
-			labeler1       GenericLabeler
-			labeler2       GenericLabeler
-			expectedMerged GenericLabeler
+			labeler1       MetadataUpdater
+			labeler2       MetadataUpdater
+			expectedMerged MetadataUpdater
 			expectError    bool
 		}{
 			{
 				name:           "Merge non-overlapping labelers",
-				labeler1:       GenericLabeler{"key1": "value1", "key2": "value2"},
-				labeler2:       GenericLabeler{"key3": "value3", "key4": "value4"},
-				expectedMerged: GenericLabeler{"key1": "value1", "key2": "value2", "key3": "value3", "key4": "value4"},
+				labeler1:       GenericMetadataUpdater{Labels: map[string]string{"key1": "value1", "key2": "value2"}},
+				labeler2:       GenericMetadataUpdater{Labels: map[string]string{"key3": "value3", "key4": "value4"}},
+				expectedMerged: GenericMetadataUpdater{Labels: map[string]string{"key1": "value1", "key2": "value2", "key3": "value3", "key4": "value4"}},
 				expectError:    false,
 			},
 			{
 				name:        "Merge with duplicate keys",
-				labeler1:    GenericLabeler{"key1": "value1", "key2": "value2"},
-				labeler2:    GenericLabeler{"key2": "value3", "key3": "value4"},
+				labeler1:    GenericMetadataUpdater{Labels: map[string]string{"key1": "value1", "key2": "value2"}},
+				labeler2:    GenericMetadataUpdater{Labels: map[string]string{"key2": "value3", "key3": "value4"}},
 				expectError: true,
 			},
 		}
@@ -230,9 +272,46 @@ func TestNewResourceGraphDefinitionLabeler(t *testing.T) {
 		uid := types.UID("rgd-uid")
 		obj := &mockObject{ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid}}
 		labeler := NewResourceGraphDefinitionLabeler(obj)
-		assert.Equal(t, GenericLabeler{
-			ResourceGraphDefinitionNameLabel: name,
-			ResourceGraphDefinitionIDLabel:   string(uid),
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{
+				ResourceGraphDefinitionNameLabel: name,
+				ResourceGraphDefinitionIDLabel:   string(uid),
+			},
+		}, labeler)
+	})
+
+	t.Run("omits name label when name exceeds label value limit", func(t *testing.T) {
+		name := strings.Repeat("a", 64)
+		uid := types.UID("rgd-uid")
+		obj := &mockObject{ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid}}
+		labeler := NewResourceGraphDefinitionLabeler(obj)
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{
+				ResourceGraphDefinitionIDLabel: string(uid),
+			},
+		}, labeler)
+	})
+}
+
+func TestNewResourceGraphDefinitionNameLabeler(t *testing.T) {
+	t.Run("sets name label when short enough", func(t *testing.T) {
+		labeler := NewResourceGraphDefinitionNameLabeler("my-rgd")
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{
+				ResourceGraphDefinitionNameLabel: "my-rgd",
+			},
+			Annotations: map[string]string{
+				ResourceGraphDefinitionNameAnnotation: "my-rgd",
+			},
+		}, labeler)
+	})
+
+	t.Run("returns only annotation labeler for over-long name", func(t *testing.T) {
+		labeler := NewResourceGraphDefinitionNameLabeler(strings.Repeat("a", 64))
+		assert.Equal(t, GenericMetadataUpdater{
+			Annotations: map[string]string{
+				ResourceGraphDefinitionNameAnnotation: strings.Repeat("a", 64),
+			},
 		}, labeler)
 	})
 }
@@ -240,8 +319,8 @@ func TestNewResourceGraphDefinitionLabeler(t *testing.T) {
 func TestNewGraphRevisionHashLabeler(t *testing.T) {
 	t.Run("sets hash label directly", func(t *testing.T) {
 		labeler := NewGraphRevisionHashLabeler("hash-1")
-		assert.Equal(t, GenericLabeler{
-			GraphRevisionHashLabel: "hash-1",
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{GraphRevisionHashLabel: "hash-1"},
 		}, labeler)
 	})
 }
@@ -266,13 +345,15 @@ func TestNewInstanceLabeler(t *testing.T) {
 		})
 
 		labeler := NewInstanceLabeler(obj, true)
-		assert.Equal(t, GenericLabeler{
-			InstanceLabel:          name,
-			InstanceNamespaceLabel: namespace,
-			InstanceIDLabel:        string(uid),
-			InstanceGroupLabel:     group,
-			InstanceVersionLabel:   version,
-			InstanceKindLabel:      kind,
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{
+				InstanceLabel:          name,
+				InstanceNamespaceLabel: namespace,
+				InstanceIDLabel:        string(uid),
+				InstanceGroupLabel:     group,
+				InstanceVersionLabel:   version,
+				InstanceKindLabel:      kind,
+			},
 		}, labeler)
 	})
 
@@ -293,12 +374,14 @@ func TestNewInstanceLabeler(t *testing.T) {
 		})
 
 		labeler := NewInstanceLabeler(obj, false)
-		assert.Equal(t, GenericLabeler{
-			InstanceLabel:        name,
-			InstanceIDLabel:      string(uid),
-			InstanceGroupLabel:   group,
-			InstanceVersionLabel: version,
-			InstanceKindLabel:    kind,
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{
+				InstanceLabel:        name,
+				InstanceIDLabel:      string(uid),
+				InstanceGroupLabel:   group,
+				InstanceVersionLabel: version,
+				InstanceKindLabel:    kind,
+			},
 		}, labeler)
 	})
 }
@@ -306,9 +389,11 @@ func TestNewInstanceLabeler(t *testing.T) {
 func TestNewKROMetaLabeler(t *testing.T) {
 	t.Run("NewKROMetaLabeler", func(t *testing.T) {
 		labeler := NewKROMetaLabeler()
-		assert.Equal(t, GenericLabeler{
-			OwnedLabel:      "true",
-			KROVersionLabel: version.GetVersionInfo().GitVersion,
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{
+				OwnedLabel:      "true",
+				KROVersionLabel: version.GetVersionInfo().GitVersion,
+			},
 		}, labeler)
 	})
 }
@@ -316,8 +401,10 @@ func TestNewKROMetaLabeler(t *testing.T) {
 func TestNewNodeLabeler(t *testing.T) {
 	t.Run("NewNodeLabeler", func(t *testing.T) {
 		labeler := NewNodeLabeler()
-		assert.Equal(t, GenericLabeler{
-			ManagedByLabelKey: ManagedByKROValue,
+		assert.Equal(t, GenericMetadataUpdater{
+			Labels: map[string]string{
+				ManagedByLabelKey: ManagedByKROValue,
+			},
 		}, labeler)
 	})
 }


### PR DESCRIPTION
## Part of #1055 — the `resource-graph-definition-name` portion

    RGD names may be up to 253 characters, but label values are limited to 63.
    
    Today the kro.run/resource-graph-definition-name label is written
    onto the CRD, instances, and GraphRevisions, so
    an RGD with a name longer than 63 characters fails.
    
    This change records the full RGD name in a
    kro.run/resource-graph-definition-name *annotation*.
    Annotation values limit is much high - 256KB per object.
    
    We apply the annotation on every object that previously carried only the
    label.
    
    We omit the label when the name is not a valid label value.
    
    All controller reads now go through metadata.GetResourceGraphDefinitionName,
    which prefers the annotation and falls back to the label. The fallback
    means that all existing objects continue to work.

### Discussion: do we need the label at all?

Nothing internal requires the *label*: kro never selects on `resource-graph-definition-name` (selection by RGD uses the UID label; GraphRevision lookups use the `spec.snapshot.name` selectable field). The label is purely for external users (`kubectl get ... -l kro.run/resource-graph-definition-name=foo`), and it is documented as such. We could drop it entirely — though since it's shipped, documented, user-facing surface, that would be a deprecation exercise, and the label-migration proposal (`docs/design/proposals/label-migration.md`) suggests this label is likely headed for the `internal.kro.run` prefix anyway. That venue seems like the right place to decide its long-term fate; this PR keeps the label best-effort in the meantime.

