### PR TITLE
chore(fix): encode long instance-names and refactor node-id hashing

### DIFF
--- a/pkg/controller/graph/controller.go
+++ b/pkg/controller/graph/controller.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,6 +97,11 @@ type Reconciler struct {
 	// impersonation disabled), in which case the guard is a no-op. Any OTHER
 	// privileged SA reachable in a namespace is the operator's RBAC concern.
 	ControllerServiceAccount string
+
+	// Recorder emits Graph-scoped events. Defaulted from the manager in
+	// SetupWithManager. `nil` when a Reconciler is constructed directly (tests),
+	// in which case event emission is skipped.
+	Recorder record.EventRecorder
 
 	// backoff tracks per-Graph consecutive not-ready attempts so the soft
 	// ErrNotReady requeue delay grows (capped) instead of polling a
@@ -319,6 +325,7 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 	if cached {
 		log.FromContext(ctx).V(1).Info("compile cache hit", "nodes", len(prog.Nodes))
 	}
+	r.warnOnEncodedNodeIDs(g, prog)
 	marker.GraphCompiled(len(prog.Nodes))
 
 	var rtOpts []krotruntime.Option
@@ -776,6 +783,9 @@ func (r *Reconciler) persistManagedResources(ctx context.Context, g *expv1alpha1
 // spec updates. Same applies to the SchemaWatcher — CRD content
 // changes feed Graph re-reconciles through a second raw source.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor("kro/graph-controller")
+	}
 	b := ctrl.NewControllerManagedBy(mgr).For(&expv1alpha1.Graph{})
 	if r.MaxConcurrentReconciles > 0 {
 		b = b.WithOptions(ctrlrtcontroller.Options{

--- a/pkg/controller/graph/nodeid_event.go
+++ b/pkg/controller/graph/nodeid_event.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/validate/content"
+
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/compiler"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+)
+
+// warnOnEncodedNodeIDs emits one event per template node whose qualified path
+// is too long for kro.run/node-id label. Called every reconcile, not just on a
+// fresh compile, so the event does not age out of the apiserver's event-ttl
+// while the label is still hashed.
+func (r *Reconciler) warnOnEncodedNodeIDs(g *expv1alpha1.Graph, prog *compiler.Program) {
+	if r.Recorder == nil {
+		return
+	}
+	for _, path := range encodedNodePaths(prog, "") {
+		r.Recorder.Eventf(g, corev1.EventTypeWarning, "NodeIDEncoded",
+			"node %q exceeds the %d character label value limit once qualified; %s is set to %q "+
+				"on its managed resources, and selectors must use that value; the full path is "+
+				"preserved in the %s annotation",
+			path, content.LabelValueMaxLength, metadata.NodeIDLabel,
+			metadata.NodeIDToken(path), metadata.NodePathAnnotation)
+	}
+}
+
+// encodedNodePaths walks one compiled frame and returns the qualified paths
+// whose node-id token has to be hashed, recursing into subgraphs with the
+// frame prefix the executor's applySubgraph uses.
+func encodedNodePaths(prog *compiler.Program, prefix string) []string {
+	if prog == nil {
+		return nil
+	}
+	var out []string
+	for _, id := range prog.TopologicalOrder {
+		n := prog.Nodes[id]
+		if n == nil {
+			continue
+		}
+		qualified := prefix + id
+		if n.Kind == compiler.NodeKindGraph {
+			out = append(out, encodedNodePaths(n.SubProgram, qualified+"/")...)
+			continue
+		}
+		if n.Kind != compiler.NodeKindTemplate {
+			continue
+		}
+		if metadata.NodeIDTokenIsHashed(qualified) {
+			out = append(out, qualified)
+		}
+	}
+	return out
+}

--- a/pkg/controller/graph/nodeid_event_test.go
+++ b/pkg/controller/graph/nodeid_event_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/compiler"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/registry"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+)
+
+func progOf(nodes ...*compiler.Node) *compiler.Program {
+	p := &compiler.Program{Nodes: make(map[string]*compiler.Node, len(nodes))}
+	for _, n := range nodes {
+		p.Nodes[n.ID] = n
+		p.TopologicalOrder = append(p.TopologicalOrder, n.ID)
+	}
+	return p
+}
+
+func tmplNode(id string) *compiler.Node {
+	return &compiler.Node{ID: id, Kind: compiler.NodeKindTemplate}
+}
+
+func subNode(id string, child *compiler.Program) *compiler.Node {
+	return &compiler.Node{ID: id, Kind: compiler.NodeKindGraph, SubProgram: child}
+}
+
+func TestEncodedNodePaths_LeavesFittingPathsAlone(t *testing.T) {
+	t.Parallel()
+
+	p := progOf(tmplNode("frontend"), subNode("subA", progOf(tmplNode("res"))))
+	assert.Empty(t, encodedNodePaths(p, ""))
+}
+
+func TestEncodedNodePaths_ReportsOverLongRootID(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 64)
+	p := progOf(tmplNode("frontend"), tmplNode(long))
+	assert.Equal(t, []string{long}, encodedNodePaths(p, ""))
+}
+
+func TestEncodedNodePaths_ReportsPathsOverflowedByQualificationAlone(t *testing.T) {
+	t.Parallel()
+
+	outer, middle, leaf := strings.Repeat("a", 21), strings.Repeat("b", 21), strings.Repeat("c", 20)
+	require.False(t, metadata.NodeIDTokenIsHashed(leaf), "the leaf id alone must fit")
+
+	p := progOf(subNode(outer, progOf(subNode(middle, progOf(tmplNode(leaf))))))
+
+	got := encodedNodePaths(p, "")
+	require.Len(t, got, 1)
+	assert.Equal(t, outer+"/"+middle+"/"+leaf, got[0], "the event must name the whole path, not the leaf")
+	assert.True(t, metadata.NodeIDTokenIsHashed(got[0]))
+}
+
+func TestEncodedNodePaths_IgnoresNonTemplateKinds(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 64)
+	for _, kind := range []compiler.NodeKind{compiler.NodeKindRef, compiler.NodeKindDef, compiler.NodeKindPatch} {
+		p := progOf(&compiler.Node{ID: long, Kind: kind})
+		assert.Empty(t, encodedNodePaths(p, ""), "kind %s stamps no node-id label", kind)
+	}
+}
+
+func TestEncodedNodePaths_IsStablyOrdered(t *testing.T) {
+	t.Parallel()
+
+	a, b, c := strings.Repeat("a", 64), strings.Repeat("b", 64), strings.Repeat("c", 64)
+	p := progOf(tmplNode(a), tmplNode(b), tmplNode(c))
+
+	want := []string{a, b, c}
+	for range 20 {
+		assert.Equal(t, want, encodedNodePaths(p, ""), "order must follow TopologicalOrder, not map iteration")
+	}
+}
+
+func TestEncodedNodePaths_ToleratesMissingAndNilPrograms(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, encodedNodePaths(nil, ""))
+	assert.Empty(t, encodedNodePaths(&compiler.Program{
+		Nodes:            map[string]*compiler.Node{},
+		TopologicalOrder: []string{"ghost"},
+	}, ""))
+	assert.Empty(t, encodedNodePaths(progOf(subNode("subA", nil)), ""))
+}
+
+func TestWarnOnEncodedNodeIDs(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 64)
+	recorder := record.NewFakeRecorder(10)
+	r := &Reconciler{Recorder: recorder}
+	r.warnOnEncodedNodeIDs(graph("g"), progOf(tmplNode("frontend"), tmplNode(long)))
+
+	var got []string
+	for len(recorder.Events) > 0 {
+		got = append(got, <-recorder.Events)
+	}
+
+	require.Len(t, got, 1, "only the over-long node should warn")
+	assert.Contains(t, got[0], "Warning NodeIDEncoded")
+	assert.Contains(t, got[0], long)
+	assert.Contains(t, got[0], metadata.NodeIDToken(long))
+	assert.Contains(t, got[0], metadata.NodePathAnnotation)
+}
+
+func TestWarnOnEncodedNodeIDs_NoRecorder(t *testing.T) {
+	t.Parallel()
+
+	r := &Reconciler{}
+	assert.NotPanics(t, func() {
+		r.warnOnEncodedNodeIDs(graph("g"), progOf(tmplNode(strings.Repeat("a", 64))))
+	})
+}
+
+func TestReconcile_WarnsOnEveryReconcile(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 64)
+	g := graph("g", withFinalizer)
+	recorder := record.NewFakeRecorder(10)
+	r := &Reconciler{
+		Client:   newClient(t, g),
+		Compiler: &fakeCompiler{program: progOf(tmplNode(long))},
+		Registry: registry.New(),
+		Executor: &fakeExecutor{},
+		Recorder: recorder,
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "g"}}
+
+	for range 3 {
+		_, err := r.Reconcile(context.Background(), req)
+		require.NoError(t, err)
+	}
+
+	assert.Len(t, recorder.Events, 3,
+		"a cache hit must still warn: the label stays hashed, so the event must not age out")
+	assert.Contains(t, <-recorder.Events, "NodeIDEncoded")
+}

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -87,6 +87,7 @@ type ResourceGraphDefinitionReconciler struct {
 	graphEngineCompiler rgdadapter.Compiler
 
 	newEventRecorder func(string) record.EventRecorder
+	recorder         record.EventRecorder
 }
 
 func NewResourceGraphDefinitionReconciler(
@@ -118,6 +119,7 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 	r.clientSet.SetRESTMapper(mgr.GetRESTMapper())
 	r.instanceLogger = mgr.GetLogger()
 	r.newEventRecorder = mgr.GetEventRecorderFor
+	r.recorder = mgr.GetEventRecorderFor("kro/resourcegraphdefinition-controller")
 
 	logConstructor := func(req *reconcile.Request) logr.Logger {
 		log := mgr.GetLogger().WithName("rgd-controller").WithValues(

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -24,9 +24,11 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -87,6 +89,8 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinition(
 		mark.ResourceGraphInvalid(err.Error())
 		return ctrl.Result{}, nil, nil, err
 	}
+
+	r.warnOnEncodedResourceIDs(rgd)
 
 	graphRevisions, hasTerminating, orphanIndices, err := r.listGraphRevisions(ctx, rgd)
 	if err != nil {
@@ -318,6 +322,27 @@ func (r *ResourceGraphDefinitionReconciler) buildResourceGraphDefinition(_ conte
 	}
 
 	return processedRGD, resourcesInfoFromGraph(processedRGD), nil
+}
+
+// warnOnEncodedResourceIDs emits an event for each resource ID too long to be
+// stored verbatim in the kro.run/node-id label. Without it a hashed label is
+// silent: selectors written against the authored ID simply stop matching.
+// Called every reconcile, not just when a revision is issued, so the event does
+// not age out of the apiserver's event-ttl while the label is still hashed.
+func (r *ResourceGraphDefinitionReconciler) warnOnEncodedResourceIDs(rgd *v1alpha1.ResourceGraphDefinition) {
+	if r.recorder == nil {
+		return
+	}
+	for _, res := range rgd.Spec.Resources {
+		if !metadata.NodeIDTokenIsHashed(res.ID) {
+			continue
+		}
+		r.recorder.Eventf(rgd, corev1.EventTypeWarning, "NodeIDEncoded",
+			"resource id %q exceeds the %d character label value limit; %s is set to %q on its managed resources, "+
+				"and selectors must use that value; the full id is preserved in the %s annotation",
+			res.ID, validation.LabelValueMaxLength, metadata.NodeIDLabel,
+			metadata.NodeIDToken(res.ID), metadata.NodePathAnnotation)
+	}
 }
 
 // buildResourceInfo creates a ResourceInformation struct from name and dependencies

--- a/pkg/controller/resourcegraphdefinition/nodeid_event_test.go
+++ b/pkg/controller/resourcegraphdefinition/nodeid_event_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcegraphdefinition
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+)
+
+func rgdWithResourceIDs(ids ...string) *v1alpha1.ResourceGraphDefinition {
+	resources := make([]*v1alpha1.Resource, 0, len(ids))
+	for _, id := range ids {
+		resources = append(resources, &v1alpha1.Resource{ID: id})
+	}
+	return &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "rgd", UID: "uid"},
+		Spec:       v1alpha1.ResourceGraphDefinitionSpec{Resources: resources},
+	}
+}
+
+func TestWarnOnEncodedResourceIDs(t *testing.T) {
+	t.Parallel()
+
+	longID := "my" + strings.Repeat("Long", 20) + "NodeID"
+	require.True(t, metadata.NodeIDTokenIsHashed(longID))
+
+	recorder := record.NewFakeRecorder(10)
+	r := &ResourceGraphDefinitionReconciler{recorder: recorder}
+	r.warnOnEncodedResourceIDs(rgdWithResourceIDs("frontend", longID))
+
+	var got []string
+	for len(recorder.Events) > 0 {
+		got = append(got, <-recorder.Events)
+	}
+
+	require.Len(t, got, 1, "only the over-long id should warn")
+	assert.Contains(t, got[0], "Warning NodeIDEncoded")
+	assert.Contains(t, got[0], longID)
+	assert.Contains(t, got[0], metadata.NodeIDToken(longID))
+	assert.Contains(t, got[0], metadata.NodePathAnnotation)
+}
+
+func TestWarnOnEncodedResourceIDs_NoRecorder(t *testing.T) {
+	t.Parallel()
+
+	r := &ResourceGraphDefinitionReconciler{}
+	assert.NotPanics(t, func() {
+		r.warnOnEncodedResourceIDs(rgdWithResourceIDs(strings.Repeat("a", 100)))
+	})
+}

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -34,7 +34,6 @@ import (
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -1139,28 +1138,9 @@ func (s *Simple) qualifiedPath(id string) string {
 
 // nodeIDToken returns a bounded, label-safe rendering of a node's qualified
 // path for the kro.run/node-id label value and the collection watch selector.
-//
-// Node IDs are strictly alphanumeric (^[A-Za-z][A-Za-z0-9]*$), so '.' is an
-// unambiguous, reversible frame separator: the '.'-joined path (e.g.
-// "subA.res") is a valid label value and round-trips to the '/'-form. At the
-// root the token is just the bare node ID, preserving the documented
-// `kubectl get -l kro.run/node-id=<id>` query for top-level nodes.
-//
-// When the '.'-joined path would exceed the 63-char label-value limit (deep or
-// long-named nesting) it is replaced by a stable, collision-resistant hash so
-// the label stays valid at any depth. The full readable path is always
-// preserved in the node-path annotation regardless, so a hashed label never
-// costs debuggability. The selector is built from this same function, so it
-// matches the stamped label by construction.
+// See metadata.NodeIDToken for the encoding and its guarantees.
 func (s *Simple) nodeIDToken(id string) string {
-	dotted := strings.ReplaceAll(s.qualifiedPath(id), "/", ".")
-	if len(dotted) <= validation.LabelValueMaxLength {
-		return dotted
-	}
-	// Fallback: "h-<40 hex>" of the '/'-form. The leading letter keeps the
-	// value a valid label (must start alphanumeric) and marks it as hashed.
-	sum := sha256.Sum256([]byte(s.qualifiedPath(id)))
-	return "h-" + hex.EncodeToString(sum[:20])
+	return metadata.NodeIDToken(s.qualifiedPath(id))
 }
 
 // stampKROMeta stamps the identity metadata kro relies on: the

--- a/pkg/metadata/nodeid.go
+++ b/pkg/metadata/nodeid.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// NodeIDHashPrefix marks a NodeIDToken that had to fall back to a hash. The
+// leading letter also keeps the value a valid label value.
+const NodeIDHashPrefix = "h-"
+
+// NodeIDToken returns a bounded, label-safe rendering of a node's qualified
+// path for the NodeIDLabel value and the collection watch selector.
+//
+// Node IDs are strictly alphanumeric (^[A-Za-z][A-Za-z0-9]*$), so '.' is an
+// unambiguous, reversible frame separator: the '.'-joined path (e.g.
+// "subA.res") is a valid label value and round-trips to the '/'-form. At the
+// root the token is just the bare node ID, preserving the documented
+// `kubectl get -l kro.run/node-id=<id>` query for top-level nodes.
+//
+// When the '.'-joined path would exceed the 63-char label-value limit (deep or
+// long-named nesting) it is replaced by a stable, collision-resistant hash so
+// the label stays valid at any depth. The full readable path is always
+// preserved in the NodePathAnnotation regardless, so a hashed label never
+// costs debuggability. Selectors are built from this same function, so they
+// match the stamped label by construction.
+func NodeIDToken(qualifiedPath string) string {
+	if !NodeIDTokenIsHashed(qualifiedPath) {
+		return dottedNodePath(qualifiedPath)
+	}
+	sum := sha256.Sum256([]byte(qualifiedPath))
+	return NodeIDHashPrefix + hex.EncodeToString(sum[:20])
+}
+
+// NodeIDTokenIsHashed reports whether NodeIDToken has to hash this qualified
+// path because its label-safe rendering does not fit in a label value.
+func NodeIDTokenIsHashed(qualifiedPath string) bool {
+	return len(dottedNodePath(qualifiedPath)) > validation.LabelValueMaxLength
+}
+
+func dottedNodePath(qualifiedPath string) string {
+	return strings.ReplaceAll(qualifiedPath, "/", ".")
+}

--- a/pkg/metadata/nodeid_test.go
+++ b/pkg/metadata/nodeid_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestNodeIDToken_PassesThroughPathsThatFit(t *testing.T) {
+	t.Parallel()
+
+	for path, want := range map[string]string{
+		"res":                      "res",
+		"myBucket":                 "myBucket",
+		"subA/res":                 "subA.res",
+		"outer/inner/deeplyNested": "outer.inner.deeplyNested",
+		strings.Repeat("a", validation.LabelValueMaxLength): strings.Repeat("a", validation.LabelValueMaxLength),
+	} {
+		assert.False(t, NodeIDTokenIsHashed(path))
+		assert.Equal(t, want, NodeIDToken(path))
+	}
+}
+
+func TestNodeIDToken_HashesPathsThatOverflow(t *testing.T) {
+	t.Parallel()
+
+	id := strings.Repeat("a", validation.LabelValueMaxLength+1)
+	got := NodeIDToken(id)
+
+	assert.True(t, NodeIDTokenIsHashed(id))
+	assert.NotEqual(t, id, got)
+	assert.True(t, strings.HasPrefix(got, NodeIDHashPrefix))
+	assert.LessOrEqual(t, len(got), validation.LabelValueMaxLength)
+	assert.Empty(t, validation.IsValidLabelValue(got))
+}
+
+func TestNodeIDToken_CountsSeparatorsTowardsTheBudget(t *testing.T) {
+	t.Parallel()
+
+	seg := strings.Repeat("a", 21)
+	path := strings.Join([]string{seg, seg, seg}, "/")
+
+	assert.Len(t, path, validation.LabelValueMaxLength+2)
+	assert.True(t, NodeIDTokenIsHashed(path))
+}
+
+func TestNodeIDToken_IsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	id := "my" + strings.Repeat("Long", 40) + "NodeID"
+	assert.Equal(t, NodeIDToken(id), NodeIDToken(id))
+}
+
+func TestNodeIDToken_DistinguishesSharedPrefixes(t *testing.T) {
+	t.Parallel()
+
+	prefix := strings.Repeat("a", validation.LabelValueMaxLength*2)
+	assert.NotEqual(t, NodeIDToken(prefix+"one"), NodeIDToken(prefix+"two"))
+}
+
+func TestNodeIDToken_DistinguishesFramesFromDots(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEqual(t, NodeIDToken(strings.Repeat("sub/", 20)+"res"),
+		NodeIDToken(strings.Repeat("sub.", 20)+"res"))
+}

--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -102,18 +102,18 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 
 **Labels:**
 
-| Label | Description |
-|-------|-------------|
-| `kro.run/owned` | Set to `"true"` to indicate kro manages this resource |
-| `kro.run/kro-version` | Version of kro managing the resource |
-| `kro.run/instance-id` | UID of the instance that created this resource |
-| `kro.run/instance-name` | Name of the instance |
-| `kro.run/instance-namespace` | Namespace of the instance (only for namespaced instances) |
-| `kro.run/instance-group` | API group of the instance |
-| `kro.run/instance-version` | API version of the instance |
-| `kro.run/instance-kind` | Kind of the instance |
-| `app.kubernetes.io/managed-by` | Set to `"kro"` |
-| `kro.run/node-id` | Resource ID from the RGD |
+| Label                            | Description                                                                                    |
+|----------------------------------|------------------------------------------------------------------------------------------------|
+| `kro.run/owned`                  | Set to `"true"` to indicate kro manages this resource                                          |
+| `kro.run/kro-version`            | Version of kro managing the resource                                                           |
+| `kro.run/instance-id`            | UID of the instance that created this resource                                                 |
+| `kro.run/instance-name`          | Name of the instance                                                                           |
+| `kro.run/instance-namespace`     | Namespace of the instance (only for namespaced instances)                                      |
+| `kro.run/instance-group`         | API group of the instance                                                                      |
+| `kro.run/instance-version`       | API version of the instance                                                                    |
+| `kro.run/instance-kind`          | Kind of the instance                                                                           |
+| `app.kubernetes.io/managed-by`   | Set to `"kro"`                                                                                 |
+| `kro.run/node-id`                | Label-safe token for the resource ID from the RGD (see [long resource IDs](#long-resource-ids))|
 | `applyset.kubernetes.io/part-of` | Links the resource to its parent instance (matches the instance's `applyset.kubernetes.io/id`) |
 
 **Collection-specific labels** (only on resources created via `forEach`):
@@ -123,10 +123,47 @@ Resources created by kro (Deployments, Services, ConfigMaps, etc.) receive label
 | `kro.run/collection-index` | Position in the collection (0-indexed) |
 | `kro.run/collection-size` | Total number of items in the collection |
 
+**Annotations:**
+
+| Annotation                    | Description                                                             |
+|-------------------------------|-------------------------------------------------------------------------|
+| `internal.kro.run/node-path`  | Full, human-readable resource ID from the RGD, never truncated or hashed |
+
 These labels allow you to identify exactly which instance owns each managed resource, which is essential when multiple instances of the same RGD exist in a cluster. For collection resources, see [Collection Labels](./rgd/02-resource-definitions/04-collections.md#collection-labels) for more details.
 
 </TabItem>
 </Tabs>
+
+### Long resource IDs
+
+A Kubernetes label value is capped at 63 characters. The `kro.run/node-id`
+label therefore carries a *token* rather than the raw resource ID.
+
+For every resource in an RGD the token is the ID exactly as you wrote it, so
+the documented query keeps working:
+
+```bash
+kubectl get pods -l kro.run/node-id=frontend
+```
+
+The only exception is a resource ID longer than 63 characters. kro then
+replaces the token with a stable SHA-256 hash prefixed with `h-`, for example
+`h-9c1185a5c5e9fc54612808977ee8f548b2258d31`. The hash is deterministic for a
+given ID, so selectors built from it keep matching across reconciles.
+
+The full, readable path is always available in the
+`internal.kro.run/node-path` annotation, whether or not the label was hashed:
+
+```bash
+kubectl get pod <name> -o jsonpath='{.metadata.annotations.internal\.kro\.run/node-path}'
+```
+
+When kro hashes a resource ID it also emits a `NodeIDEncoded` warning event on
+the `ResourceGraphDefinition`, naming the value any selector needs:
+
+```bash
+kubectl describe rgd <name>
+```
 
 :::info ApplySet Specification
 kro uses the [Kubernetes ApplySet specification](https://git.k8s.io/enhancements/keps/sig-cli/3659-kubectl-apply-prune) for tracking and pruning managed resources. This enables kro to automatically prune resources that are no longer part of the instance's resource graph and prevents other tools from accidentally modifying kro-managed resources.

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/04-collections.md
@@ -809,6 +809,15 @@ identifies each collection item. These labels are managed by kro - do not
 modify them manually.
 :::
 
+:::warning
+A node ID longer than 63 characters does not fit in a label value. kro stores a
+stable `h-`-prefixed hash in the `kro.run/node-id` label instead, so
+`-l kro.run/node-id=<your long id>` will not match. The full ID is always
+available in the `internal.kro.run/node-path` annotation, and kro emits a
+`NodeIDEncoded` warning event on the RGD naming the value any selector needs.
+See [Long resource IDs](../../15-instances.md#long-resource-ids).
+:::
+
 See [Constraints & Gotchas](#constraints--gotchas) for label management notes.
 
 ## Next Steps


### PR DESCRIPTION
# Description

Graph PR changed how node-ids are actually encoded. This PR now is now threading in the event recorder in to graph and updating the docs about the node-id hashing mechanism.

It also fixes an issue with instance-names which can overflow in the same way as node-ids.


# Relevant Issue

Part of https://github.com/kubernetes-sigs/kro/issues/1055.