### PR TITLE
Mention allow-breaking-changes annotation in CRD update error

### DIFF
--- a/pkg/client/crd.go
+++ b/pkg/client/crd.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	crdcompat "github.com/kubernetes-sigs/kro/pkg/graph/crd/compat"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 )
@@ -171,7 +172,12 @@ func (w *CRDWrapper) Ensure(ctx context.Context, desired v1.CustomResourceDefini
 		if !report.IsCompatible() {
 			log.Info("Breaking changes detected in CRD update", "name", desired.Name, "breakingChanges", len(report.BreakingChanges), "summary", report)
 			if !allowBreakingChanges {
-				return fmt.Errorf("cannot update CRD %s: breaking changes detected: %s", desired.Name, report)
+				return fmt.Errorf(
+					"cannot update CRD %s: breaking changes detected: %s. "+
+						"Set the %s annotation to \"true\" on the ResourceGraphDefinition "+
+						"to apply it; this can invalidate existing instances that violate the new schema",
+					desired.Name, report, v1alpha1.AllowBreakingChangesAnnotation,
+				)
 			}
 			log.Info("Allowing breaking changes", "name", desired.Name)
 		}

--- a/pkg/client/crd_test.go
+++ b/pkg/client/crd_test.go
@@ -26,6 +26,7 @@ import (
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 )
 
@@ -61,6 +62,19 @@ func TestEnsureClearsCRDNames(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, got.Spec.Names.ShortNames)
 	assert.Empty(t, got.Spec.Names.Categories)
+}
+
+func TestEnsureBreakingChangeErrorMentionsAnnotation(t *testing.T) {
+	existing := testCRD()
+	desired := existing.DeepCopy()
+	desired.Spec.Versions[0].Served = false
+
+	wrapper := newTestCRDWrapper(existing)
+
+	err := wrapper.Ensure(context.Background(), *desired, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), v1alpha1.AllowBreakingChangesAnnotation)
+	assert.Contains(t, err.Error(), "breaking changes detected")
 }
 
 func TestCRDMergePatchClearsEmptyNames(t *testing.T) {


### PR DESCRIPTION
Motivation:
When kro blocks a breaking CRD schema update, the error surfaced on the
ResourceGraphDefinition only said "breaking changes detected: <report>"
and never mentioned kro.run/allow-breaking-changes, the annotation that
exists specifically to let an operator apply the change deliberately.
Reading only the error, an operator could reasonably conclude the only
way forward is to delete and recreate the RGD, which is far more
disruptive and can be unsafe on a live cluster (e.g. RGDs that manage
per-AZ resources).

Approach:
Extend the error returned from CRDWrapper.Ensure in pkg/client/crd.go
to name the v1alpha1.AllowBreakingChangesAnnotation constant and note
its caveat, so the escape hatch is visible directly on the RGD's
condition instead of only in source comments.

Validation:
- go build ./... passes.
- go test ./pkg/client/... -v: all tests pass, including a new
  TestEnsureBreakingChangeErrorMentionsAnnotation that triggers a real
  breaking change (version.served true->false) and asserts the error
  contains the annotation name. Verified this test fails on the
  pre-change code and passes after the change.
- go vet ./pkg/client/... is clean.
- golangci-lint run ./pkg/client/... (v2.12.2, the version pinned in
  this repo's Makefile) reports 0 issues.
- Confirmed this branch's HEAD already contains upstream/main's tip,
  and upstream/main's 5 most recent CI runs are all green.

This is a copy change only; it does not alter when breaking changes
are blocked or allowed, only the text of the error message.

Report: https://github.com/kubernetes-sigs/kro/issues/1395
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

---
AI assistance: this change was drafted with Claude Code.

Fixes #1395

```release-note
Mention allow-breaking-changes annotation in CRD update error
```