### PR TITLE
feat(cel): add strings.plural() for English pluralization

### DIFF
--- a/examples/graph/rgd.yaml
+++ b/examples/graph/rgd.yaml
@@ -10,8 +10,8 @@
 # shipped engine, so applying it will not fully reconcile. Kept in-tree as the
 # design's north star; the gaps below are tracked follow-up work, not bugs in
 # this PR:
-#   - simpleSchema.toOpenAPI() and plural() CEL functions are not registered in
-#     the shipped CEL environment (needed at L1 to synthesize the Kind's CRD).
+#   - The simpleSchema.toOpenAPI() CEL function is not registered in the
+#     shipped CEL environment (needed at L1 to synthesize the Kind's CRD).
 #   - .ready() on a node is deferred to KREP-006 (readiness lifecycle) — used
 #     here for status gating; there is no working replacement yet.
 #   - propagateWhen (conditional status updates) is deferred to KREP-006.
@@ -193,7 +193,7 @@ spec:
                 kind: CustomResourceDefinition
                 metadata:
                   name: >-
-                    ${"${plural(schema.spec.schema.kind).lowerAscii()}"}.${"${schema.spec.schema.group}"}
+                    ${"${strings.plural(schema.spec.schema.kind.lowerAscii())}"}.${"${schema.spec.schema.group}"}
                   labels: >-
                     ${"${schema.?spec.?schema.?metadata.?labels.orValue({})}"}
                   annotations: >-
@@ -205,7 +205,7 @@ spec:
                     kind: >-
                       ${"${schema.spec.schema.kind}"}
                     plural: >-
-                      ${"${plural(schema.spec.schema.kind).lowerAscii()}"}
+                      ${"${strings.plural(schema.spec.schema.kind.lowerAscii())}"}
                   scope: >-
                     ${"${schema.spec.schema.scope}"}
                   versions:

--- a/examples/kubernetes/cel-functions/rg.yaml
+++ b/examples/kubernetes/cel-functions/rg.yaml
@@ -55,6 +55,10 @@ spec:
                       value: ${base64.encode(hash.fnv64a(schema.spec.name))}
                     - name: HASH_SHA256_BASE64
                       value: ${base64.encode(hash.sha256(schema.spec.name))}
+                    - name: STRINGS_PLURAL
+                      value: ${strings.plural('ClusterPolicy')}
+                    - name: STRINGS_PLURAL_RESOURCE
+                      value: ${strings.plural('ClusterPolicy'.lowerAscii())}
     - id: service
       template:
         apiVersion: v1

--- a/pkg/cel/ast/inspector_test.go
+++ b/pkg/cel/ast/inspector_test.go
@@ -834,6 +834,35 @@ func TestNewInspectorWithEnv_CustomFunctionsNotResources(t *testing.T) {
 			wantUnknownRes: nil,
 		},
 		{
+			name:       "strings.plural is a function, not a resource",
+			resources:  []string{"schema"},
+			expression: `strings.plural(schema.spec.kind.lowerAscii()) + "." + schema.spec.group`,
+			wantResources: []ResourceDependency{
+				{ID: "schema", Path: "schema.spec.kind"},
+				{ID: "schema", Path: "schema.spec.group"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "strings.plural"},
+			},
+			wantUnknownFns: nil,
+			wantUnknownRes: nil,
+		},
+		{
+			name:       "resource named 'strings' coexists with strings.plural and cel-go strings.quote",
+			resources:  []string{"strings"},
+			expression: `strings.plural(strings.spec.kind) != "" && strings.quote(strings.status.phase) != ""`,
+			wantResources: []ResourceDependency{
+				{ID: "strings", Path: "strings.spec.kind"},
+				{ID: "strings", Path: "strings.status.phase"},
+			},
+			wantFunctions: []FunctionCall{
+				{Name: "strings.plural"},
+				{Name: "strings.quote"},
+			},
+			wantUnknownFns: nil,
+			wantUnknownRes: nil,
+		},
+		{
 			name:       "multiple custom functions in one expression",
 			resources:  []string{"schema"},
 			expression: `json.marshal(json.unmarshal(random.seededString(5, schema.metadata.uid)))`,

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -145,6 +145,7 @@ func coreDeclarations() []cel.EnvOption {
 		library.JSON(),
 		library.Hash(),
 		library.Lists(),
+		library.Strings(),
 		// Omit() is registered globally so CEL can parse and type-check it
 		// everywhere. The graph builder rejects it in restricted contexts
 		// (includeWhen, readyWhen, forEach) via inspectExpressionRestricted

--- a/pkg/cel/environment_test.go
+++ b/pkg/cel/environment_test.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -293,6 +294,112 @@ func TestDefaultEnvironment_CelBind(t *testing.T) {
 	}
 }
 
+// TestDefaultEnvironment_StringsPlural evaluates the strings.plural recipes
+// from the docs through the production environment, where cel-go's
+// ext.Strings() is registered before kro's library.Strings() (the reverse of
+// the library's own tests). Both cached base environments are covered.
+func TestDefaultEnvironment_StringsPlural(t *testing.T) {
+	vars := map[string]any{
+		"schema": map[string]any{
+			"spec": map[string]any{
+				"kind":       "ClusterPolicy",
+				"apiVersion": "example.com/v1",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{
+			name: "plural resource name from a kind",
+			expr: `strings.plural(schema.spec.kind.lowerAscii())`,
+			want: "clusterpolicies",
+		},
+		{
+			name: "CRD name from a kind and apiVersion",
+			expr: `strings.plural(schema.spec.kind.lowerAscii()) + "." + schema.spec.apiVersion.split("/")[0]`,
+			want: "clusterpolicies.example.com",
+		},
+		{
+			name: "human-readable plural",
+			expr: `strings.plural(schema.spec.kind)`,
+			want: "ClusterPolicies",
+		},
+		{
+			name: "chained with cel-go strings helpers",
+			expr: `strings.quote(strings.plural(schema.spec.kind)).trim()`,
+			want: `"ClusterPolicies"`,
+		},
+		{
+			name: "optional field access",
+			expr: `strings.plural(schema.?spec.?missing.orValue('Pod'))`,
+			want: "Pods",
+		},
+	}
+
+	for _, runtimeLib := range []bool{true, false} {
+		env, err := DefaultEnvironment(WithRuntimeLibrary(runtimeLib), WithResourceIDs([]string{"schema"}))
+		require.NoError(t, err)
+		require.True(t, env.HasLibrary("kro.strings"))
+		require.True(t, env.HasLibrary("cel.lib.ext.strings"))
+
+		for _, tc := range tests {
+			t.Run(fmt.Sprintf("runtime=%t/%s", runtimeLib, tc.name), func(t *testing.T) {
+				ast, issues := env.Compile(tc.expr)
+				require.NoError(t, issues.Err(), "compile failed")
+				require.Equal(t, cel.StringType, ast.OutputType())
+
+				prog, err := env.Program(ast)
+				require.NoError(t, err, "program creation failed")
+
+				out, _, err := prog.Eval(vars)
+				require.NoError(t, err, "eval failed")
+				assert.Equal(t, tc.want, out.Value())
+			})
+		}
+	}
+}
+
+// TestTypedEnvironment_StringsPlural checks that strings.plural type-checks
+// against the OpenAPI-derived field type of a typed resource, so an RGD that
+// pluralizes a non-string field is rejected when the RGD is built, not when
+// an instance is reconciled.
+func TestTypedEnvironment_StringsPlural(t *testing.T) {
+	schemaWithKind := func(kindType string) map[string]*spec.Schema {
+		return map[string]*spec.Schema{
+			"schema": {
+				SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+					Properties: map[string]spec.Schema{
+						"spec": {
+							SchemaProps: spec.SchemaProps{
+								Type: []string{"object"},
+								Properties: map[string]spec.Schema{
+									"kind": {SchemaProps: spec.SchemaProps{Type: []string{kindType}}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	env, err := TypedEnvironment(schemaWithKind("string"))
+	require.NoError(t, err)
+	_, issues := env.Compile(`strings.plural(schema.spec.kind.lowerAscii())`)
+	assert.NoError(t, issues.Err())
+
+	env, err = TypedEnvironment(schemaWithKind("integer"))
+	require.NoError(t, err)
+	_, issues = env.Compile(`strings.plural(schema.spec.kind)`)
+	require.Error(t, issues.Err())
+	assert.Contains(t, issues.Err().Error(), "found no matching overload for 'strings.plural' applied to '(int)'")
+}
+
 func TestBaseDeclarations_ReturnsSameSlice(t *testing.T) {
 	a := BaseDeclarations()
 	b := BaseDeclarations()
@@ -398,6 +505,10 @@ func Test_CELEnvHasFunction(t *testing.T) {
 		"random.seededString",
 		"json.unmarshal",
 		"json.marshal",
+		"strings.plural",
+		// cel-go ext.Strings() shares the `strings.` namespace with kro's
+		// library.Strings(); both must be present in the same environment.
+		"strings.quote",
 	}
 	for _, fn := range expectedFns {
 		t.Run(fn, func(t *testing.T) {

--- a/pkg/cel/library/errors_coverage_test.go
+++ b/pkg/cel/library/errors_coverage_test.go
@@ -53,6 +53,15 @@ func TestHashRejectsNonStringArguments(t *testing.T) {
 	}
 }
 
+func TestStringsPluralRejectsNonStringArguments(t *testing.T) {
+	t.Parallel()
+
+	assertCELErr(t, stringsPlural(types.Bool(true)), "strings.plural")
+	assertCELErr(t, stringsPlural(types.Int(1)), "strings.plural")
+	assertCELErr(t, stringsPlural(types.NewRefValList(
+		types.DefaultTypeAdapter, []ref.Val{types.String("Pod")})), "strings.plural")
+}
+
 func TestJSONErrorPaths(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cel/library/strings.go
+++ b/pkg/cel/library/strings.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"reflect"
+
+	"github.com/gobuffalo/flect"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// Strings returns a CEL library that provides kro-specific string functions.
+//
+// The functions live in the `strings.` namespace alongside cel-go's
+// ext.Strings() (which provides strings.quote and the <string>.method
+// helpers). CEL has no real namespaces: both libraries simply register
+// fully-qualified function names, and cel-go de-duplicates libraries by
+// LibraryName(), so the two can coexist in one environment.
+//
+// Library functions:
+//
+// strings.plural(word: string) -> string
+//
+// Returns the English plural form of word, using the same inflection rules
+// kro uses to derive CRD resource names from kinds. The input is not trimmed
+// or otherwise normalised: only the final word is inflected, so separators
+// are kept ('cluster-policy' -> 'cluster-policies') and whitespace-only or
+// symbol-only input yields an empty string. Input that already looks plural
+// is usually returned unchanged, but that detection is heuristic.
+//
+//	strings.plural('Pod')            // 'Pods'
+//	strings.plural('ClusterPolicy')  // 'ClusterPolicies'
+//	strings.plural('Ingress')        // 'Ingresses'
+//	strings.plural('deployment')     // 'deployments'
+//	strings.plural('Endpoints')      // 'Endpoints' (already plural)
+//	strings.plural('')               // ''
+//
+// Case handling: lowercase and CamelCase words keep their case
+// ('ClusterPolicy' -> 'ClusterPolicies'). All-caps words are not handled
+// well ('POLICY' -> 'POLICYs') and irregular nouns come back in dictionary
+// case ('PERSON' -> 'People'), so lowercase first when the case of the input
+// is not under your control.
+//
+// To build a CRD name or plural resource name, lowercase the kind first and
+// then pluralize. That is the exact operation kro performs when it names the
+// CRD for a ResourceGraphDefinition, so the result always matches:
+//
+//	strings.plural(schema.spec.kind.lowerAscii()) + '.' + group
+//
+// Pluralizing before lowercasing gives a different result for kinds ending
+// in an upper-case acronym or written in all caps: 'ServiceDNS' ->
+// 'ServiceDNSes' -> 'servicednses' and 'POLICY' -> 'POLICYs' -> 'policys',
+// whereas kro's CRD names are 'servicedns' and 'policies'.
+func Strings() cel.EnvOption {
+	return cel.Lib(&stringsLibrary{})
+}
+
+type stringsLibrary struct{}
+
+// LibraryName implements the cel.SingletonLibrary interface method.
+//
+// cel-go de-duplicates singleton libraries by this name, so it must differ
+// from every other registered library, including cel-go's ext.Strings()
+// ("cel.lib.ext.strings") which shares the `strings.` function namespace.
+// The "kro." prefix follows kro.lists, kro.omit and kro.runtime.
+func (l *stringsLibrary) LibraryName() string {
+	return "kro.strings"
+}
+
+func (l *stringsLibrary) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("strings.plural",
+			cel.Overload("strings.plural_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(stringsPlural),
+			),
+		),
+	}
+}
+
+func (l *stringsLibrary) ProgramOptions() []cel.ProgramOption {
+	return nil
+}
+
+// stringsPlural implements strings.plural(string) -> string.
+func stringsPlural(value ref.Val) ref.Val {
+	native, err := value.ConvertToNative(reflect.TypeFor[string]())
+	if err != nil {
+		return types.NewErr("strings.plural argument must be a string")
+	}
+
+	word, ok := native.(string)
+	if !ok {
+		return types.NewErr("strings.plural argument must be a string")
+	}
+
+	return types.String(flect.Pluralize(word))
+}

--- a/pkg/cel/library/strings_test.go
+++ b/pkg/cel/library/strings_test.go
@@ -1,0 +1,335 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/kubernetes-sigs/kro/pkg/graph/crd"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+)
+
+// newStringsEnv builds an environment with both kro's Strings() library and
+// cel-go's ext.Strings(). Both register functions in the `strings.` namespace,
+// so every test in this file also exercises their coexistence.
+func newStringsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
+	t.Helper()
+	env, err := cel.NewEnv(append([]cel.EnvOption{Strings(), ext.Strings()}, opts...)...)
+	require.NoError(t, err)
+	return env
+}
+
+func evalString(t *testing.T, env *cel.Env, expr string, vars map[string]any) string {
+	t.Helper()
+	ast, issues := env.Compile(expr)
+	require.NoError(t, issues.Err(), "compile %q", expr)
+	require.Equal(t, cel.StringType, ast.OutputType(), "output type of %q", expr)
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+	out, _, err := prg.Eval(vars)
+	require.NoError(t, err, "eval %q", expr)
+	s, ok := out.Value().(string)
+	require.True(t, ok, "expected string result for %q, got %T", expr, out.Value())
+	return s
+}
+
+func TestStringsPlural(t *testing.T) {
+	env := newStringsEnv(t)
+
+	testCases := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{name: "simple kind", expr: `strings.plural('Pod')`, want: "Pods"},
+		{name: "multi-word kind", expr: `strings.plural('ClusterPolicy')`, want: "ClusterPolicies"},
+		{name: "y to ies", expr: `strings.plural('NetworkPolicy')`, want: "NetworkPolicies"},
+		{name: "vowel y stays", expr: `strings.plural('Gateway')`, want: "Gateways"},
+		{name: "ss to sses", expr: `strings.plural('Ingress')`, want: "Ingresses"},
+		{name: "compound ss to sses", expr: `strings.plural('IngressClass')`, want: "IngressClasses"},
+		{name: "x to xes", expr: `strings.plural('Box')`, want: "Boxes"},
+		{name: "leading acronym preserved", expr: `strings.plural('HTTPRoute')`, want: "HTTPRoutes"},
+		{name: "irregular noun", expr: `strings.plural('Person')`, want: "People"},
+		{name: "lowercase input stays lowercase", expr: `strings.plural('deployment')`, want: "deployments"},
+		{name: "already plural (trailing s)", expr: `strings.plural('Endpoints')`, want: "Endpoints"},
+		{name: "already plural (rule form)", expr: `strings.plural('Pods')`, want: "Pods"},
+		{name: "empty string", expr: `strings.plural('')`, want: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, evalString(t, env, tc.expr, nil))
+		})
+	}
+}
+
+// TestStringsPluralInflectorBehaviour pins the edges of the underlying
+// inflector that the docs describe (or deliberately leave undefined): input is
+// not trimmed or normalised, only the last word is inflected, all-caps input
+// is not case-preserving, and already-plural detection is heuristic. RGD
+// authors now see these directly, and a change in any of them would also
+// rename the CRDs kro derives from kinds, so a dependency bump that alters
+// them must be a conscious decision.
+func TestStringsPluralInflectorBehaviour(t *testing.T) {
+	env := newStringsEnv(t, cel.Variable("x", cel.StringType))
+
+	testCases := map[string]string{
+		// Whitespace is neither trimmed nor treated as part of the word.
+		" ":     "",
+		"   ":   "",
+		" Pod":  " Pods",
+		"Pod ":  "Pod s",
+		" Pod ": " Pod s",
+		// Symbol-only input has no word to inflect.
+		"🚀": "",
+		// Separators are kept; only the final segment is inflected.
+		"cluster-policy": "cluster-policies",
+		"cluster_policy": "cluster_policies",
+		"cluster.policy": "cluster.policies",
+		"cluster policy": "cluster policies",
+		"Cluster-Policy": "Cluster-Policies",
+		// Digits are part of the word.
+		"pod1":        "pod1s",
+		"v1":          "v1s",
+		"EC2Instance": "EC2Instances",
+		// Trailing upper-case acronyms take the acronym's suffix rule.
+		"ServiceDNS":  "ServiceDNSes",
+		"servicedns":  "servicedns",
+		"ServiceCIDR": "ServiceCIDRs",
+		"API":         "APIs",
+		// All-caps input is not case-preserving.
+		"POLICY":    "POLICYs",
+		"BOX":       "BOXs",
+		"INGRESS":   "INGRESSes",
+		"PERSON":    "People",
+		"INDEX":     "Indices",
+		"PODS":      "PODSes",
+		"ENDPOINTS": "ENDPOINTSes",
+		// Irregular and Latin-derived nouns.
+		"Child":  "Children",
+		"Datum":  "Data",
+		"Index":  "Indices",
+		"Status": "Statuses",
+		"Schema": "Schemas",
+		"Radius": "Radii",
+		"Medium": "Media",
+		"Repo":   "Repoes",
+		"Kro":    "Kroes",
+		// Words ending in -s are treated as already plural.
+		"Kubernetes": "Kubernetes",
+		"Analytics":  "Analytics",
+		"Redis":      "Redis",
+		"Series":     "Series",
+		// Already-plural forms are returned unchanged.
+		"Policies":        "Policies",
+		"Ingresses":       "Ingresses",
+		"People":          "People",
+		"Data":            "Data",
+		"clusterpolicies": "clusterpolicies",
+		// Non-ASCII input just gets an 's'.
+		"Pöd": "Pöds",
+		"ポッド": "ポッドs",
+	}
+
+	for in, want := range testCases {
+		t.Run(fmt.Sprintf("%q", in), func(t *testing.T) {
+			assert.Equal(t, want, evalString(t, env, `strings.plural(x)`, map[string]any{"x": in}))
+		})
+	}
+
+	t.Run("long input", func(t *testing.T) {
+		long := strings.Repeat("a", 10000)
+		assert.Equal(t, long+"s", evalString(t, env, `strings.plural(x)`, map[string]any{"x": long}))
+	})
+}
+
+// TestStringsPluralCRDNameContract pins the documented recipe for deriving a
+// CRD name from a kind,
+//
+//	strings.plural(kind.lowerAscii()) + '.' + group
+//
+// to the Go code kro actually uses to name the CRD for a
+// ResourceGraphDefinition (crd.SynthesizeCRD) and to address its instances
+// (metadata.GetResourceGraphDefinitionInstanceGVR). If the CEL recipe and
+// either call site ever disagree, this test fails.
+func TestStringsPluralCRDNameContract(t *testing.T) {
+	env := newStringsEnv(t,
+		cel.Variable("kind", cel.StringType),
+		cel.Variable("group", cel.StringType),
+	)
+
+	const expr = `strings.plural(kind.lowerAscii()) + '.' + group`
+	const group = "kro.run"
+	const version = "v1alpha1"
+
+	kinds := []string{
+		"Pod", "Deployment", "ClusterPolicy", "NetworkPolicy", "Gateway",
+		"Ingress", "IngressClass", "HTTPRoute", "Endpoints", "WebApplication",
+		"ComponentStatus", "FlowSchema", "StorageClass", "PodDisruptionBudget",
+		"CustomResourceDefinition", "ResourceGraphDefinition", "EndpointSlice",
+		"IPAddress", "ServiceCIDR", "CSIStorageCapacity", "ValidatingAdmissionPolicy",
+		"EC2Instance", "S3Bucket", "IAMRole",
+		// Kinds ending in an upper-case acronym: pluralizing before lowercasing
+		// would give "servicednses", but kro's CRD name is "servicedns".
+		"ServiceDNS",
+		// All-caps kinds: pluralizing before lowercasing would give "policys".
+		"POLICY",
+	}
+
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			got := evalString(t, env, expr, map[string]any{"kind": kind, "group": group})
+
+			synthesized := crd.SynthesizeCRD(group, version, kind,
+				extv1.JSONSchemaProps{}, extv1.JSONSchemaProps{}, false, extv1.NamespaceScoped, nil)
+			assert.Equal(t, synthesized.Name, got, "CRD metadata.name")
+			assert.Equal(t, synthesized.Spec.Names.Plural+"."+group, got, "CRD spec.names.plural")
+
+			gvr := metadata.GetResourceGraphDefinitionInstanceGVR(group, version, kind)
+			assert.Equal(t, gvr.Resource+"."+group, got, "instance GVR resource")
+		})
+	}
+
+	// Sanity-check the two documented divergences so the guidance in the docs
+	// stays honest: lowercase-first and pluralize-first are not interchangeable.
+	t.Run("operand order matters for ServiceDNS", func(t *testing.T) {
+		vars := map[string]any{"kind": "ServiceDNS", "group": group}
+		assert.Equal(t, "servicedns.kro.run", evalString(t, env, expr, vars))
+		assert.Equal(t, "servicednses.kro.run",
+			evalString(t, env, `strings.plural(kind).lowerAscii() + '.' + group`, vars))
+	})
+	t.Run("operand order matters for POLICY", func(t *testing.T) {
+		vars := map[string]any{"kind": "POLICY", "group": group}
+		assert.Equal(t, "policies.kro.run", evalString(t, env, expr, vars))
+		assert.Equal(t, "policys.kro.run",
+			evalString(t, env, `strings.plural(kind).lowerAscii() + '.' + group`, vars))
+	})
+}
+
+// TestStringsPluralCoexistsWithCelGoStrings verifies that kro's `strings.`
+// functions and cel-go's ext.Strings() (strings.quote and the <string>
+// member helpers) work side by side in one environment, including when they
+// are chained in a single expression.
+func TestStringsPluralCoexistsWithCelGoStrings(t *testing.T) {
+	env := newStringsEnv(t)
+
+	assert.Equal(t, "clusterpolicies", evalString(t, env, `strings.plural('ClusterPolicy').lowerAscii()`, nil))
+	assert.Equal(t, `"Pods"`, evalString(t, env, `strings.quote(strings.plural('Pod'))`, nil))
+	assert.Equal(t, "Pods, Deployments",
+		evalString(t, env, `['Pod', 'Deployment'].map(k, strings.plural(k)).join(', ')`, nil))
+}
+
+func TestStringsPluralCompileErrors(t *testing.T) {
+	env := newStringsEnv(t)
+
+	testCases := []struct {
+		name    string
+		expr    string
+		wantErr string
+	}{
+		{name: "int argument", expr: `strings.plural(1)`, wantErr: "found no matching overload"},
+		{name: "null argument", expr: `strings.plural(null)`, wantErr: "found no matching overload"},
+		{name: "bytes argument", expr: `strings.plural(b'Pod')`, wantErr: "found no matching overload"},
+		{name: "list argument", expr: `strings.plural(['Pod'])`, wantErr: "found no matching overload"},
+		{name: "no arguments", expr: `strings.plural()`, wantErr: "found no matching overload"},
+		{name: "too many arguments", expr: `strings.plural('Pod', 'Deployment')`, wantErr: "found no matching overload"},
+		{name: "not a member function", expr: `'Pod'.plural()`, wantErr: "undeclared reference to 'plural'"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, issues := env.Compile(tc.expr)
+			require.Error(t, issues.Err())
+			assert.Contains(t, issues.String(), tc.wantErr)
+		})
+	}
+}
+
+// TestStringsPluralRuntimeTypeGuard covers arguments whose static type is dyn
+// (as every field of an untyped resource is). cel-go's runtime overload guard
+// rejects a non-string before the binding runs, so the author still sees an
+// error that names the function.
+func TestStringsPluralRuntimeTypeGuard(t *testing.T) {
+	env := newStringsEnv(t, cel.Variable("v", cel.DynType))
+	ast, issues := env.Compile(`strings.plural(v)`)
+	require.NoError(t, issues.Err())
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]any{"v": "Pod"})
+	require.NoError(t, err)
+	assert.Equal(t, "Pods", out.Value())
+
+	for name, v := range map[string]any{
+		"int":   int64(3),
+		"bytes": []byte("Pod"),
+		"map":   map[string]any{"kind": "Pod"},
+		"list":  []any{"Pod"},
+		"bool":  true,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := prg.Eval(map[string]any{"v": v})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no such overload: strings.plural(")
+		})
+	}
+}
+
+// The inflector guards its dictionaries with a package-level lock, and one
+// compiled program is shared by every reconcile that evaluates it.
+func TestStringsPluralConcurrentEvaluation(t *testing.T) {
+	env := newStringsEnv(t, cel.Variable("x", cel.StringType))
+	ast, issues := env.Compile(`strings.plural(x)`)
+	require.NoError(t, issues.Err())
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	inputs := map[string]string{
+		"Pod": "Pods", "ClusterPolicy": "ClusterPolicies", "Ingress": "Ingresses",
+		"Person": "People", "ServiceDNS": "ServiceDNSes", "": "",
+	}
+
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 16 {
+				for in, want := range inputs {
+					out, _, err := prg.Eval(map[string]any{"x": in})
+					if err != nil || out.Value() != want {
+						t.Errorf("strings.plural(%q) = %v, %v; want %q", in, out, err, want)
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestStringsLibraryName(t *testing.T) {
+	lib := &stringsLibrary{}
+	assert.Equal(t, "kro.strings", lib.LibraryName())
+}

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -755,6 +755,61 @@ func TestGraphBuilder_Validation(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "crds can derive their name from a kind with strings.plural",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]any{
+						"kind":  "string",
+						"group": "string",
+					},
+					nil,
+				),
+				generator.WithResource("somecrd", map[string]any{
+					"apiVersion": "apiextensions.k8s.io/v1",
+					"kind":       "CustomResourceDefinition",
+					"metadata": map[string]any{
+						"name": `${strings.plural(schema.spec.kind.lowerAscii()) + "." + schema.spec.group}`,
+					},
+					"spec": map[string]any{
+						"group":   "ec2.services.k8s.aws",
+						"version": "v1alpha1",
+						"names": map[string]any{
+							"kind":     "VPC",
+							"listKind": "VPCList",
+							"singular": "vpc",
+							"plural":   "vpcs",
+						},
+						"scope": "Namespaced",
+					},
+				}, nil, nil),
+			},
+			wantErr: false,
+		},
+		{
+			name: "resource id 'strings' coexists with the strings.* functions",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]any{
+						"kind": "string",
+					},
+					map[string]any{
+						"plural": "${strings.plural(schema.spec.kind)}",
+						"quoted": "${strings.quote(strings.metadata.name)}",
+					},
+				),
+				generator.WithResource("strings", map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name": "${strings.plural(schema.spec.kind.lowerAscii())}",
+					},
+				}, []string{"${strings.plural(strings.metadata.name) != ''}"}, nil),
+			},
+			wantErr: false,
+		},
+		{
 			name: "crds with dynamic external references work",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(

--- a/pkg/graphengine/compiler/compiler_test.go
+++ b/pkg/graphengine/compiler/compiler_test.go
@@ -756,6 +756,107 @@ func TestCompile(t *testing.T) {
 	}
 }
 
+// ---- TestCompile_StringsPlural ----------------------------------------------
+
+// TestCompile_StringsPlural covers the Graph compiler's handling of the
+// namespaced strings.plural() function: the inspector must treat `strings` as
+// a function namespace rather than an unknown node id (even when a node is
+// literally named `strings`), the dependency on the def node feeding the call
+// must be recorded, and a non-string argument must be rejected at compile
+// time.
+func TestCompile_StringsPlural(t *testing.T) {
+	t.Parallel()
+
+	rgdSchema := map[string]any{"kind": "ClusterPolicy", "group": "example.com"}
+
+	cases := []struct {
+		name    string
+		graph   *expv1alpha1.Graph
+		wantErr string // substring; empty means success
+		after   func(t *testing.T, prog *Program)
+	}{
+		{
+			name: "def-fed call records a hard dependency",
+			graph: generator.NewGraph("g",
+				generator.WithDef("rgdSchema", rgdSchema),
+				generator.WithTemplate("cm", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "${strings.plural(rgdSchema.kind.lowerAscii())}"},
+					"data": map[string]any{
+						"crdName": `${strings.plural(rgdSchema.kind.lowerAscii()) + "." + rgdSchema.group}`,
+						"label":   "${strings.plural(rgdSchema.kind)}",
+					},
+				}),
+			),
+			after: func(t *testing.T, prog *Program) {
+				assert.Equal(t, []string{"rgdSchema"}, prog.Nodes["cm"].HardDepIDs())
+				assert.Equal(t, []string{"rgdSchema", "cm"}, prog.TopologicalOrder)
+			},
+		},
+		{
+			name: "CRD name derived from a def records a hard dependency",
+			graph: generator.NewGraph("g",
+				generator.WithDef("rgdSchema", rgdSchema),
+				generator.WithTemplate("crd", map[string]any{
+					"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition",
+					"metadata": map[string]any{
+						"name": `${strings.plural(rgdSchema.kind.lowerAscii()) + "." + rgdSchema.group}`,
+					},
+					"spec": map[string]any{
+						"group": "example.com",
+						"names": map[string]any{"kind": "ClusterPolicy", "plural": "clusterpolicies"},
+						"scope": "Namespaced",
+					},
+				}),
+			),
+			after: func(t *testing.T, prog *Program) {
+				assert.Equal(t, []string{"rgdSchema"}, prog.Nodes["crd"].HardDepIDs())
+			},
+		},
+		{
+			name: "def node named 'strings' does not shadow the function",
+			graph: generator.NewGraph("g",
+				generator.WithDef("strings", rgdSchema),
+				generator.WithTemplate("cm", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "${strings.plural(strings.kind.lowerAscii())}"},
+					"data":     map[string]any{"quoted": "${strings.quote(strings.kind)}"},
+				}),
+			),
+			after: func(t *testing.T, prog *Program) {
+				assert.Equal(t, []string{"strings"}, prog.Nodes["cm"].HardDepIDs())
+			},
+		},
+		{
+			name:    "non-string argument is rejected at compile time",
+			wantErr: "found no matching overload for 'strings.plural' applied to '(int)'",
+			graph: generator.NewGraph("g",
+				generator.WithDef("rgdSchema", map[string]any{"replicas": int64(3)}),
+				generator.WithTemplate("cm", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "cm"},
+					"data":     map[string]any{"bad": "${strings.plural(rgdSchema.replicas)}"},
+				}),
+			),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			prog, err := newTestCompiler(t).Compile(tc.graph)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, prog)
+			tc.after(t, prog)
+		})
+	}
+}
+
 // ---- TestCompile_PreservesInput --------------------------------------------
 
 func TestCompile_PreservesInputGraph(t *testing.T) {

--- a/test/e2e/chainsaw/cel-strings-plural/assert-configmap.yaml
+++ b/test/e2e/chainsaw/cel-strings-plural/assert-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plural-fn-app
+  namespace: default
+data:
+  pluralKind: ClusterPolicies
+  pluralResource: clusterpolicies
+  crdName: clusterpolicies.example.com

--- a/test/e2e/chainsaw/cel-strings-plural/assert-instance-ready.yaml
+++ b/test/e2e/chainsaw/cel-strings-plural/assert-instance-ready.yaml
@@ -1,0 +1,10 @@
+apiVersion: test.kro.run/v1alpha1
+kind: PluralFnApp
+metadata:
+  name: plural-fn-app
+status:
+  # filter conditions array to keep elements where `type == 'Ready'`
+  # and assert there's a single element matching the filter
+  # and that this element status is `True`
+  (conditions[?type == 'Ready']):
+  - status: "True"

--- a/test/e2e/chainsaw/cel-strings-plural/assert-rgd-active.yaml
+++ b/test/e2e/chainsaw/cel-strings-plural/assert-rgd-active.yaml
@@ -1,0 +1,6 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: cel-strings-plural
+status:
+  state: Active

--- a/test/e2e/chainsaw/cel-strings-plural/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/cel-strings-plural/chainsaw-test.yaml
@@ -1,0 +1,20 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cel-strings-plural
+spec:
+  steps:
+  - name: Apply RGD
+    try:
+    - apply:
+        file: rgd.yaml
+    - assert:
+        file: assert-rgd-active.yaml
+  - name: Create instance
+    try:
+    - apply:
+        file: instance.yaml
+    - assert:
+        file: assert-instance-ready.yaml
+    - assert:
+        file: assert-configmap.yaml

--- a/test/e2e/chainsaw/cel-strings-plural/instance.yaml
+++ b/test/e2e/chainsaw/cel-strings-plural/instance.yaml
@@ -1,0 +1,8 @@
+apiVersion: test.kro.run/v1alpha1
+kind: PluralFnApp
+metadata:
+  name: plural-fn-app
+spec:
+  namespace: default
+  kind: ClusterPolicy
+  group: example.com

--- a/test/e2e/chainsaw/cel-strings-plural/rgd.yaml
+++ b/test/e2e/chainsaw/cel-strings-plural/rgd.yaml
@@ -1,0 +1,25 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: cel-strings-plural
+spec:
+  schema:
+    apiVersion: v1alpha1
+    group: test.kro.run
+    kind: PluralFnApp
+    spec:
+      namespace: string
+      kind: string
+      group: string
+  resources:
+  - id: cm
+    template:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: plural-fn-app
+        namespace: ${schema.spec.namespace}
+      data:
+        pluralKind: ${strings.plural(schema.spec.kind)}
+        pluralResource: ${strings.plural(schema.spec.kind.lowerAscii())}
+        crdName: ${strings.plural(schema.spec.kind.lowerAscii()) + "." + schema.spec.group}

--- a/website/docs/docs/concepts/rgd/04-cel-libraries.md
+++ b/website/docs/docs/concepts/rgd/04-cel-libraries.md
@@ -15,8 +15,9 @@ kro includes a rich set of CEL function libraries from three sources: kro's own 
 | Random                      | kro        | [kro](#random), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Random) |
 | Maps                        | kro        | [kro](#maps), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Maps) |
 | Index Mutation              | kro        | [kro](#index-mutation), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Lists) |
+| Strings (kro)               | kro        | [kro](#strings-kro), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Strings) |
 | Omit                        | kro        | [kro](#omit), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Omit) |
-| Strings                     | cel-go     | [kro](#strings), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#Strings) |
+| Strings (cel-go)            | cel-go     | [kro](#strings-cel-go), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#Strings) |
 | Lists (cel-go)              | cel-go     | [kro](#lists-cel-go), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#Lists) |
 | Encoders                    | cel-go     | [kro](#encoders), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#Encoders) |
 | Two-Variable Comprehensions | cel-go     | [kro](#two-variable-comprehensions), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#TwoVarComprehensions) |
@@ -143,6 +144,50 @@ ports: ${lists.removeAtIndex(schema.spec.ports, 0)}
 swapped: ${lists.setAtIndex(lists.setAtIndex(schema.spec.items, 0, schema.spec.items[1]), 1, schema.spec.items[0])}
 ```
 
+### Strings (kro)
+
+kro-specific string functions. These live in the same `strings.` namespace as the [cel-go Strings](#strings-cel-go) extension and can be used together with it.
+
+| Function | Returns | Description |
+| --- | --- | --- |
+| `strings.plural(string)` | `string` | English plural of a word, using the same inflection rules kro uses to derive CRD resource names from kinds. Lowercase and CamelCase input keeps its case (`ClusterPolicy` -> `ClusterPolicies`). Input that is already plural is usually returned unchanged (`Endpoints` -> `Endpoints`), but this is heuristic, not guaranteed. |
+
+**Examples** (the instance schema here declares `kind` and `apiVersion` fields, as an RGD that emits a CRD would):
+
+```kro
+# Plural resource name from a kind
+plural: ${strings.plural(schema.spec.kind.lowerAscii())}
+# ClusterPolicy -> clusterpolicies
+
+# Build a CRD name (<plural>.<group>) from a kind and apiVersion
+name: ${strings.plural(schema.spec.kind.lowerAscii()) + "." + schema.spec.apiVersion.split("/")[0]}
+# ClusterPolicy + example.com/v1 -> clusterpolicies.example.com
+
+# Human-readable plural
+label: ${strings.plural(schema.spec.kind)}
+# Ingress -> Ingresses
+```
+
+:::note Lowercase first for resource names
+To reproduce the plural resource name kro assigns to a ResourceGraphDefinition's
+CRD, lowercase the kind *before* pluralizing: `strings.plural(kind.lowerAscii())`.
+Pluralizing first and lowercasing afterwards gives a different result for kinds
+that end in an upper-case acronym or are written in all caps. For example,
+`ServiceDNS` becomes `servicedns` with lowercase-first, but `servicednses` with
+pluralize-first, and `POLICY` becomes `policies` versus `policys`.
+
+The same applies to any input whose case you do not control: all-caps words are
+not pluralized well (`POLICY` -> `POLICYs`) and irregular nouns come back in
+dictionary case (`PERSON` -> `People`).
+:::
+
+:::note
+`strings.plural` does not trim its input: leading or trailing whitespace stays
+in place and whitespace-only input returns an empty string. Call `.trim()`
+first on user-supplied values. Only the last word is inflected, so separators
+are kept (`cluster-policy` -> `cluster-policies`).
+:::
+
 ### Omit
 
 The `omit()` sentinel tells kro to remove a field from the rendered resource. This is useful for conditionally excluding fields.
@@ -188,9 +233,9 @@ See [Custom Status Conditions](./06-status-conditions.md) for details.
 
 ## cel-go Libraries
 
-### Strings
+### Strings (cel-go)
 
-Extended string manipulation functions from [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
+Extended string manipulation functions from [cel-go/ext](https://pkg.go.dev/github.com/google/cel-go/ext#Strings). See [Strings (kro)](#strings-kro) for kro's additions to the `strings.` namespace.
 
 | Function | Returns | Description |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

Adds a kro CEL library exposing **`strings.plural(string) -> string`**, backed by the same `flect.Pluralize` inflection kro already uses to derive CRD resource names from kinds (`pkg/graph/crd/crd.go`, `pkg/metadata/groupversion.go`, `pkg/controller/resourcegraphdefinition/controller_cleanup.go`).

Motivation: expressing the RGD `schema` -> CRD translation as a graph node needs a way to turn a kind into its plural resource name, e.g.

```yaml
metadata:
  name: ${strings.plural(schema.spec.kind.lowerAscii()) + "." + schema.spec.apiVersion.split("/")[0]}
spec:
  names:
    kind: ${schema.spec.kind}
    plural: ${strings.plural(schema.spec.kind.lowerAscii())}
```

## Behaviour

| Expression | Result |
|---|---|
| `strings.plural('Pod')` | `Pods` |
| `strings.plural('ClusterPolicy')` | `ClusterPolicies` |
| `strings.plural('Ingress')` | `Ingresses` |
| `strings.plural('deployment')` | `deployments` |
| `strings.plural('Endpoints')` | `Endpoints` (already plural; heuristic) |
| `strings.plural('')` | `` (empty) |
| `strings.plural(1)` | compile error (`found no matching overload`) |

- **General purpose**, lowercase and CamelCase input keeps its case. All-caps input is *not* handled well (`POLICY` -> `POLICYs`) and irregular nouns come back in dictionary case (`PERSON` -> `People`), so lowercase first when the case of the input is not under your control.
- **Not trimmed or normalised**: only the last word is inflected, separators are kept (`cluster-policy` -> `cluster-policies`), leading/trailing whitespace stays in place and whitespace-only input returns `""`. Call `.trim()` first on user-supplied values.
- **Lowercase first** to reproduce kro's CRD naming exactly: `strings.plural(kind.lowerAscii())`. The order matters for kinds ending in an upper-case acronym or written in all caps (`ServiceDNS` -> `servicedns` vs `servicednses`; `POLICY` -> `policies` vs `policys`). A contract test pins the CEL recipe to the CRD name produced by `crd.SynthesizeCRD` and the resource of `metadata.GetResourceGraphDefinitionInstanceGVR` across ~25 kinds, and the docs call the ordering out.
- For valid RGD kinds (`^[A-Z][a-zA-Z0-9]*$`) `lowerAscii()` and Go's `strings.ToLower` are equivalent, so the CEL recipe and kro's Go code agree by construction.

## Design notes

- Registered as library **`kro.strings`** so it coexists with cel-go's `ext.Strings()` (`cel.lib.ext.strings`), which also owns the `strings.` namespace via `strings.quote`. cel-go de-duplicates singleton libraries by `LibraryName()`, so a clashing name would be silently dropped; the `kro.` prefix follows `kro.lists` / `kro.omit` / `kro.runtime`. Tests build an env with both libraries and chain them (`strings.plural(k).lowerAscii()`, `strings.quote(strings.plural(k))`), and a `DefaultEnvironment()` test covers the production registration order in both cached base environments.
- The AST inspector derives known functions from `env.Functions()`, so `strings.plural` is recognised as a function (not a resource reference) with no allowlist changes. Tests cover a resource / def node literally named `strings` alongside `strings.plural` and `strings.quote` at the inspector, RGD builder and Graph compiler levels.
- Non-string arguments are rejected at RGD/Graph build time by the type checker (`found no matching overload for 'strings.plural' applied to '(int)'`, also against typed `schema` fields). At runtime, `dyn` values of the wrong type hit cel-go's overload guard (`no such overload: strings.plural(int)`) before the binding runs.
- Only `plural()` is added. `singular()`, whitespace trimming, and refactoring the three existing Go `flect.Pluralize` call sites onto a shared helper are intentionally out of scope.
- No new dependencies (`github.com/gobuffalo/flect` is already direct).