### PR TITLE
feat: simpleschema.toOpenAPI CEL function and CEL anywhere in CRD templates - #3

### DIFF
--- a/examples/graph/rgd.yaml
+++ b/examples/graph/rgd.yaml
@@ -10,8 +10,12 @@
 # shipped engine, so applying it will not fully reconcile. Kept in-tree as the
 # design's north star; the gaps below are tracked follow-up work, not bugs in
 # this PR:
-#   - simpleSchema.toOpenAPI() and plural() CEL functions are not registered in
-#     the shipped CEL environment (needed at L1 to synthesize the Kind's CRD).
+#   - plural() is not a registered CEL function (needed at L1 for the Kind's
+#     CRD name and plural).
+#   - The L1 CRD's status schema is weaker than the RGD controller's: fields
+#     whose value is a CEL expression are emitted as preserve-unknown-fields
+#     because simpleschema.toOpenAPI() cannot infer their types from the
+#     referenced resources the way the controller does.
 #   - .ready() on a node is deferred to KREP-006 (readiness lifecycle) — used
 #     here for status gating; there is no working replacement yet.
 #   - propagateWhen (conditional status updates) is deferred to KREP-006.
@@ -42,7 +46,7 @@
 #   (def: nodes check reserved words, naming conventions, duplicate IDs, and
 #   schema validity), creates the Kind's CRD (gated on validation passing), and
 #   watches instances of the user's Kind. The CRD's OpenAPI schema is
-#   synthesized from the RGD's spec.schema using simpleSchema.toOpenAPI().
+#   synthesized from the RGD's spec.schema using simpleschema.toOpenAPI().
 #
 #   The rgdStatus node writes Ready/state/conditions back to the RGD via patch:.
 #   It is the single writer for these fields, keeping the status pipeline to
@@ -216,8 +220,12 @@ spec:
                       subresources:
                         status: {}
                       schema:
+                        # The RGD's spec.schema block converted whole; kro's default
+                        # instance status fields (state, conditions) are merged in
+                        # first, replacing the RGD's expression-valued conditions
+                        # list with a typed declaration, as the RGD controller does.
                         openAPIV3Schema: >-
-                          ${"${simpleSchema.toOpenAPI(schema.spec.schema, has(schema.spec.resources) ? schema.spec.resources : [])}"}
+                          ${"${simpleschema.toOpenAPI(schema.spec.schema.deepMerge({'status': {'state': 'string', 'conditions': '[]KroCondition'}, 'types': {'KroCondition': {'type': 'string', 'status': 'string', 'reason': 'string', 'message': 'string', 'lastTransitionTime': 'string', 'observedGeneration': 'integer'}}}))}"}
                       additionalPrinterColumns: >-
                         ${"${schema.?spec.?schema.?additionalPrinterColumns.orValue([])}"}
 

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -142,6 +142,7 @@ func coreDeclarations() []cel.EnvOption {
 		k8scellib.SemverLib(),
 		library.Random(),
 		library.Maps(),
+		library.SimpleSchema(),
 		library.JSON(),
 		library.Hash(),
 		library.Lists(),

--- a/pkg/cel/environment_test.go
+++ b/pkg/cel/environment_test.go
@@ -22,7 +22,10 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	celunstructured "github.com/kubernetes-sigs/kro/pkg/cel/unstructured"
 )
 
 func TestWithResourceIDs(t *testing.T) {
@@ -384,6 +387,114 @@ func BenchmarkDefaultEnvironment(b *testing.B) {
 	}
 }
 
+// TestTypedEnvironment_SimpleSchemaToOpenAPI exercises the real call
+// path for simpleschema.toOpenAPI: the argument is a typed variable's
+// spec.schema whose spec/types/status blocks are x-kubernetes-preserve-unknown-
+// fields objects (the shape of ResourceGraphDefinition.spec.schema), the checker
+// sees it as an object type rather than a map, and the runtime value is a
+// schema-aware unstructured map. Type-check, conversion and the handling of
+// absent blocks must all go through.
+func TestTypedEnvironment_SimpleSchemaToOpenAPI(t *testing.T) {
+	preserveUnknown := func() spec.Schema {
+		return spec.Schema{
+			SchemaProps: spec.SchemaProps{Type: []string{"object"}},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{"x-kubernetes-preserve-unknown-fields": true},
+			},
+		}
+	}
+	rgdSchema := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"spec": {SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"schema": {SchemaProps: spec.SchemaProps{
+						Type: []string{"object"},
+						Properties: map[string]spec.Schema{
+							"kind":   {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+							"spec":   preserveUnknown(),
+							"types":  preserveUnknown(),
+							"status": preserveUnknown(),
+						},
+					}},
+				},
+			}},
+		},
+	}}
+
+	env, _, err := TypedEnvironmentWithProvider(map[string]*spec.Schema{"rgd": rgdSchema})
+	require.NoError(t, err)
+
+	const expr = `simpleschema.toOpenAPI(rgd.spec.schema)`
+	ast, issues := env.Compile(expr)
+	require.NoError(t, issues.Err(), "must type-check against the object-typed schema block")
+	assert.Equal(t, cel.DynType.String(), ast.OutputType().String())
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	eval := func(t *testing.T, schemaBlock map[string]any) map[string]any {
+		t.Helper()
+		obj := map[string]any{"spec": map[string]any{"schema": schemaBlock}}
+		out, _, err := prg.Eval(map[string]any{
+			"rgd": celunstructured.UnstructuredToVal(obj, &openapi.Schema{Schema: rgdSchema}),
+		})
+		require.NoError(t, err)
+		root, ok := out.Value().(map[string]any)
+		require.True(t, ok, "result must be a map, got %T", out.Value())
+		return root["properties"].(map[string]any)
+	}
+
+	t.Run("full block", func(t *testing.T) {
+		props := eval(t, map[string]any{
+			"kind": "App",
+			"spec": map[string]any{
+				"name":  "string | required=true",
+				"owner": "Owner",
+			},
+			"types": map[string]any{
+				"Owner": map[string]any{"team": "string"},
+			},
+			"status": map[string]any{
+				"count": "integer",
+				"url":   "${service.spec.clusterIP}",
+			},
+		})
+		assert.Equal(t, map[string]any{
+			"type":     "object",
+			"required": []any{"name"},
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+				"owner": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"team": map[string]any{"type": "string"}},
+				},
+			},
+		}, props["spec"])
+		assert.Equal(t, map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"count": map[string]any{"type": "integer"},
+				"url":   map[string]any{"x-kubernetes-preserve-unknown-fields": true},
+			},
+		}, props["status"])
+		assert.Equal(t, map[string]any{"type": "string"}, props["kind"], "the block's own kind key is ignored; the root's kind is the CRD's")
+	})
+
+	t.Run("absent types and status blocks", func(t *testing.T) {
+		props := eval(t, map[string]any{
+			"kind": "App",
+			"spec": map[string]any{"name": "string | required=true"},
+		})
+		assert.Equal(t, map[string]any{
+			"type":       "object",
+			"required":   []any{"name"},
+			"properties": map[string]any{"name": map[string]any{"type": "string"}},
+		}, props["spec"])
+		assert.Equal(t, map[string]any{"type": "object"}, props["status"])
+	})
+}
+
 func Test_CELEnvHasFunction(t *testing.T) {
 	env, err := DefaultEnvironment()
 	require.NoError(t, err, "failed to create CEL env")
@@ -395,6 +506,7 @@ func Test_CELEnvHasFunction(t *testing.T) {
 		// types
 		"int", "uint", "double", "bool", "string", "bytes", "timestamp", "duration", "type",
 		// Custom functions
+		"simpleschema.toOpenAPI",
 		"random.seededString",
 		"json.unmarshal",
 		"json.marshal",

--- a/pkg/cel/library/errors_coverage_test.go
+++ b/pkg/cel/library/errors_coverage_test.go
@@ -89,6 +89,49 @@ func TestMergeRejectsNonMaps(t *testing.T) {
 	assertCELErr(t, mergeVals(m, types.String("not-a-map")), "no such overload")
 }
 
+func TestSimpleSchemaToOpenAPIErrorPaths(t *testing.T) {
+	t.Parallel()
+	block := types.DefaultTypeAdapter.NativeToValue(map[string]any{
+		"spec": map[string]any{"name": "string"},
+	})
+
+	t.Run("rejects a non-map argument", func(t *testing.T) {
+		t.Parallel()
+		assertCELErr(t, toOpenAPI(types.String("spec: {}")),
+			"simpleschema.toOpenAPI: schema argument must be a map")
+		assertCELErr(t, toOpenAPI(types.Int(1)),
+			"simpleschema.toOpenAPI: schema argument must be a map")
+		assertCELErr(t, toOpenAPI(types.NullValue),
+			"simpleschema.toOpenAPI: schema argument must be a map")
+	})
+
+	t.Run("propagates an error argument unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := types.NewErr("upstream failure")
+		assert.Equal(t, in, toOpenAPI(in))
+	})
+
+	t.Run("reports SimpleSchema conversion failures with the block key", func(t *testing.T) {
+		t.Parallel()
+		bad := types.DefaultTypeAdapter.NativeToValue(map[string]any{
+			"spec": map[string]any{"name": "nope"},
+		})
+		assertCELErr(t, toOpenAPI(bad), "simpleschema.toOpenAPI: spec: field name: unknown type: nope")
+	})
+
+	t.Run("converts a valid block", func(t *testing.T) {
+		t.Parallel()
+		out := toOpenAPI(block)
+		require.False(t, types.IsError(out), "got %v", out)
+		root, ok := out.Value().(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"name": map[string]any{"type": "string"}},
+		}, root["properties"].(map[string]any)["spec"])
+	})
+}
+
 func TestSeededIntArgumentValidation(t *testing.T) {
 	t.Parallel()
 	seed := types.String("s")

--- a/pkg/cel/library/simpleschema.go
+++ b/pkg/cel/library/simpleschema.go
@@ -1,0 +1,275 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8sjson "k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/kubernetes-sigs/kro/pkg/cel/conversion"
+	"github.com/kubernetes-sigs/kro/pkg/simpleschema"
+)
+
+const simpleSchemaToOpenAPIFn = "simpleschema.toOpenAPI"
+
+// Keys of the schema block converted by simpleschema.toOpenAPI.
+const (
+	schemaBlockSpecKey   = "spec"
+	schemaBlockTypesKey  = "types"
+	schemaBlockStatusKey = "status"
+)
+
+// schemaBlockKeys identify a map as an RGD-style schema block: the converted
+// keys plus the keys that describe the CRD rather than its schema (the other
+// fields of ResourceGraphDefinition.spec.schema, and the names a Kind
+// definition held in a def node carries). Descriptor keys are ignored by the
+// conversion, but their presence lets a spec-less RGD schema convert to an
+// empty root instead of being mistaken for a bare field map.
+var schemaBlockKeys = []string{
+	schemaBlockSpecKey, schemaBlockTypesKey, schemaBlockStatusKey,
+	"apiVersion", "kind", "group", "scope", "plural", "shortNames", "categories", "metadata", "additionalPrinterColumns",
+}
+
+// SimpleSchema returns a CEL library that converts kro's SimpleSchema format
+// into OpenAPI v3 JSON schema.
+//
+// This is the same conversion the ResourceGraphDefinition controller applies to
+// spec.schema when it synthesizes the instance CRD. Exposing it in CEL lets a
+// Graph that holds or reads an RGD-like schema block build a
+// CustomResourceDefinition's openAPIV3Schema itself instead of relying on the
+// RGD controller.
+//
+// # ToOpenAPI
+//
+// Converts a whole RGD-style schema block into the root openAPIV3Schema of a
+// CustomResourceDefinition, returned as a CEL map shaped like a JSONSchemaProps
+// object:
+//
+//	simpleschema.toOpenAPI(schema dyn) -> dyn
+//
+// The block is a map with the optional keys "spec", "types" and "status" — the
+// shape of ResourceGraphDefinition.spec.schema, or of a Kind definition held in
+// a def node:
+//   - spec: field name -> SimpleSchema type expression (e.g. "string | required=true")
+//     or a nested map for inline objects.
+//   - types: custom type name -> definition (alias string or struct map), shared
+//     by spec and status.
+//   - status: like spec. A field whose value is a CEL expression — a string
+//     whose type position (the text before any "|" marker separator) contains
+//     "${", or a list of such strings such as kro's status.conditions block —
+//     cannot be typed here, because its type depends on the resources it
+//     references, and is emitted as {"x-kubernetes-preserve-unknown-fields": true},
+//     which accepts whatever the expression evaluates to.
+//
+// Other keys (apiVersion, kind, group, scope, additionalPrinterColumns, ...)
+// describe the CRD rather than its schema and are ignored, so an RGD's
+// spec.schema can be passed as-is. A non-empty block with none of those keys
+// and none of the three schema keys is rejected: it is almost certainly a bare
+// field map that should be wrapped in {"spec": ...}. The result is
+//
+//	{"type": "object", "properties": {
+//	  "apiVersion": {"type": "string"}, "kind": {"type": "string"}, "metadata": {"type": "object"},
+//	  "spec":   <spec converted with types>,
+//	  "status": <status converted with types>}}
+//
+// where an absent spec or status yields {"type": "object"}. Each converted block
+// has type "object" and, when fields are present, a "properties" map and a
+// sorted "required" list; numeric values (defaults, minimum/maximum, minLength,
+// ...) are int or double, never strings. kro's default instance status fields
+// (state, conditions) are not injected; declare them in the status block if
+// needed.
+//
+// Example usage:
+//
+//	// {"type": "object", "properties": {"apiVersion": ..., "kind": ..., "metadata": ...,
+//	//   "spec": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+//	//   "status": {"type": "object"}}}
+//	simpleschema.toOpenAPI({"spec": {"name": "string | required=true"}})
+//
+//	// Whole CRD schema from a Kind definition held in a def node, or from an
+//	// RGD read via ref:
+//	simpleschema.toOpenAPI(kindSpec)
+//	simpleschema.toOpenAPI(rgd.spec.schema)
+//
+//	// Just the spec sub-schema, to compose a root by hand
+//	simpleschema.toOpenAPI(kindSpec).properties.spec
+//
+// In a CustomResourceDefinition template:
+//
+//	openAPIV3Schema: ${simpleschema.toOpenAPI(kindSpec)}
+//
+// The parameter is dyn rather than map(string, dyn) on purpose: a schema block
+// read from a typed resource (e.g. an RGD's spec.schema, whose spec/types/status
+// are x-kubernetes-preserve-unknown-fields objects) type-checks as an object
+// type, not a map type, and would be rejected by a map(K, V) signature. See the
+// deepMerge overload in maps.go for the same trade-off.
+func SimpleSchema() cel.EnvOption {
+	return cel.Lib(&simpleSchemaLibrary{})
+}
+
+type simpleSchemaLibrary struct{}
+
+func (l *simpleSchemaLibrary) LibraryName() string {
+	return "kro.simpleschema"
+}
+
+func (l *simpleSchemaLibrary) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		// simpleschema.toOpenAPI(schema dyn) -> dyn
+		cel.Function(simpleSchemaToOpenAPIFn,
+			cel.Overload(simpleSchemaToOpenAPIFn+"_dyn",
+				[]*cel.Type{cel.DynType},
+				cel.DynType,
+				cel.UnaryBinding(toOpenAPI),
+			),
+		),
+	}
+}
+
+func (l *simpleSchemaLibrary) ProgramOptions() []cel.ProgramOption {
+	return nil
+}
+
+// toOpenAPI implements simpleschema.toOpenAPI: it reads the spec,
+// types and status sub-blocks of the schema block and composes the root
+// openAPIV3Schema of a CRD from them.
+func toOpenAPI(block ref.Val) ref.Val {
+	if types.IsUnknownOrError(block) {
+		return block
+	}
+	root, err := openAPISchemaFromBlock(block)
+	if err != nil {
+		return types.NewErr("%s: %s", simpleSchemaToOpenAPIFn, err.Error())
+	}
+	return types.DefaultTypeAdapter.NativeToValue(root)
+}
+
+func openAPISchemaFromBlock(block ref.Val) (map[string]any, error) {
+	native, err := conversion.GoNativeType(block)
+	if err != nil {
+		return nil, fmt.Errorf("schema argument must be a map with string keys: %w", err)
+	}
+	blockMap, ok := native.(map[string]any)
+	if !ok {
+		// CEL null is rejected rather than treated as an empty block so that a
+		// missing schema surfaces as a clear error instead of an empty CRD schema.
+		return nil, fmt.Errorf("schema argument must be a map with string keys, got %s", block.Type().TypeName())
+	}
+	if isBareFieldMap(blockMap) {
+		return nil, fmt.Errorf("schema block has none of the keys %q, %q or %q; wrap SimpleSchema fields in {%q: {...}}",
+			schemaBlockSpecKey, schemaBlockTypesKey, schemaBlockStatusKey, schemaBlockSpecKey)
+	}
+
+	typesMap, err := schemaBlockSubMap(blockMap, schemaBlockTypesKey)
+	if err != nil {
+		return nil, err
+	}
+	// Every conversion below loads the custom types; check them once here so a
+	// bad type is reported under "types" rather than under whichever block is
+	// converted first.
+	if _, err := simpleschema.ToOpenAPISpec(nil, typesMap); err != nil {
+		return nil, fmt.Errorf("%s: %w", schemaBlockTypesKey, err)
+	}
+	specSchema, err := convertSchemaBlock(blockMap, schemaBlockSpecKey, typesMap)
+	if err != nil {
+		return nil, err
+	}
+	statusSchema, err := convertSchemaBlock(blockMap, schemaBlockStatusKey, typesMap, simpleschema.AllowExpressionFields())
+	if err != nil {
+		return nil, err
+	}
+
+	// Same root shape the RGD controller synthesizes for instance CRDs (see
+	// pkg/graph/crd newCRDSchema), minus the default state/conditions status
+	// fields, which are controller policy rather than part of the schema.
+	root := &extv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]extv1.JSONSchemaProps{
+			"apiVersion": {Type: "string"},
+			"kind":       {Type: "string"},
+			"metadata":   {Type: "object"},
+			"spec":       *specSchema,
+			"status":     *statusSchema,
+		},
+	}
+
+	// Round-trip through JSON so the CEL value has exactly the shape the API
+	// server expects in a CRD (honours the custom marshalers of JSON,
+	// JSONSchemaPropsOrBool and JSONSchemaPropsOrArray, and drops zero-valued
+	// fields via omitempty). The apimachinery decoder keeps integral numbers as
+	// int64 rather than float64, so a marker such as default=3 is a CEL int, as
+	// it is when kro reads the same CRD back from the cluster.
+	raw, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode schema: %w", err)
+	}
+	result := map[string]any{}
+	if err := k8sjson.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode schema: %w", err)
+	}
+	return result, nil
+}
+
+// isBareFieldMap reports whether a non-empty block has no recognised key. Such
+// a map is almost certainly a spec field map passed without its {"spec": ...}
+// wrapper, which would otherwise silently convert to an empty spec.
+func isBareFieldMap(block map[string]any) bool {
+	if len(block) == 0 {
+		return false
+	}
+	for key := range block {
+		if slices.Contains(schemaBlockKeys, key) {
+			return false
+		}
+	}
+	return true
+}
+
+// convertSchemaBlock converts the SimpleSchema field map at block[key] (an
+// absent key is an empty map) against the shared custom types, attributing any
+// error to the key so the author knows which block to fix.
+func convertSchemaBlock(block map[string]any, key string, customTypes map[string]any, opts ...simpleschema.Option) (*extv1.JSONSchemaProps, error) {
+	fields, err := schemaBlockSubMap(block, key)
+	if err != nil {
+		return nil, err
+	}
+	schema, err := simpleschema.ToOpenAPISpec(fields, customTypes, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	return schema, nil
+}
+
+// schemaBlockSubMap returns block[key] as a string-keyed map. An absent or null
+// key yields an empty map; any other non-map value is an error naming the key.
+func schemaBlockSubMap(block map[string]any, key string) (map[string]any, error) {
+	raw, ok := block[key]
+	if !ok || raw == nil {
+		return map[string]any{}, nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema block key %q must be a map with string keys, got %s",
+			key, types.DefaultTypeAdapter.NativeToValue(raw).Type().TypeName())
+	}
+	return m, nil
+}

--- a/pkg/cel/library/simpleschema_test.go
+++ b/pkg/cel/library/simpleschema_test.go
@@ -1,0 +1,777 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package library
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+func newSimpleSchemaEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
+	t.Helper()
+	env, err := cel.NewEnv(append([]cel.EnvOption{SimpleSchema()}, opts...)...)
+	require.NoError(t, err)
+	return env
+}
+
+// untypedSchema is what an expression-valued status field converts to: any
+// value is accepted at that position.
+var untypedSchema = map[string]any{"x-kubernetes-preserve-unknown-fields": true}
+
+// emptyObjectSchema is what an absent spec or status block converts to.
+var emptyObjectSchema = map[string]any{"type": "object"}
+
+// rootWith returns the expected root schema for the given spec and status.
+func rootWith(spec, status map[string]any) map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec":       spec,
+			"status":     status,
+		},
+	}
+}
+
+// evalRoot evaluates expr and returns the result as a root schema map after
+// checking it is a valid structural CRD schema — the check the API server
+// performs on admission — so untyped (preserve-unknown-fields) properties
+// without a type and every marker we emit are really accepted.
+func evalRoot(t *testing.T, env *cel.Env, expr string, vars any) map[string]any {
+	t.Helper()
+	out := evalCELWithVars(t, env, expr, vars)
+	root, ok := out.Value().(map[string]any)
+	require.True(t, ok, "result must be a map, got %T", out.Value())
+
+	raw, err := json.Marshal(root)
+	require.NoError(t, err)
+	var v1props extv1.JSONSchemaProps
+	require.NoError(t, json.Unmarshal(raw, &v1props))
+	convScheme := k8sruntime.NewScheme()
+	apiextinstall.Install(convScheme)
+	var internal apiextensions.JSONSchemaProps
+	require.NoError(t, convScheme.Convert(&v1props, &internal, nil))
+	structural, err := structuralschema.NewStructural(&internal)
+	require.NoError(t, err)
+	assert.Empty(t, structuralschema.ValidateStructural(nil, structural))
+	return root
+}
+
+// specOf returns the spec sub-schema of a root schema.
+func specOf(t *testing.T, root map[string]any) map[string]any {
+	t.Helper()
+	spec, ok := root["properties"].(map[string]any)["spec"].(map[string]any)
+	require.True(t, ok, "root has no spec property: %v", root)
+	return spec
+}
+
+// TestSimpleSchemaToOpenAPI covers how the schema block is read: which
+// keys are converted, how they share custom types, how status expressions are
+// handled, and which keys are ignored.
+func TestSimpleSchemaToOpenAPI(t *testing.T) {
+	env := newSimpleSchemaEnv(t)
+
+	cases := []struct {
+		name string
+		expr string
+		want map[string]any
+	}{
+		{
+			name: "empty block",
+			expr: `simpleschema.toOpenAPI({})`,
+			want: rootWith(emptyObjectSchema, emptyObjectSchema),
+		},
+		{
+			name: "spec only",
+			expr: `simpleschema.toOpenAPI({"spec": {"name": "string | required=true"}})`,
+			want: rootWith(
+				map[string]any{
+					"type":       "object",
+					"required":   []any{"name"},
+					"properties": map[string]any{"name": map[string]any{"type": "string"}},
+				},
+				emptyObjectSchema,
+			),
+		},
+		{
+			name: "custom types are shared by spec and status",
+			expr: `simpleschema.toOpenAPI({
+				"types": {"Condition": {"type": "string | required=true", "status": "string | required=true"}},
+				"spec": {"expected": "Condition"},
+				"status": {"items": "integer", "conditions": "[]Condition"}
+			})`,
+			want: rootWith(
+				map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"expected": map[string]any{
+							"type":     "object",
+							"required": []any{"status", "type"},
+							"properties": map[string]any{
+								"type":   map[string]any{"type": "string"},
+								"status": map[string]any{"type": "string"},
+							},
+						},
+					},
+				},
+				map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"items": map[string]any{"type": "integer"},
+						"conditions": map[string]any{
+							"type": "array",
+							"items": map[string]any{
+								"type":     "object",
+								"required": []any{"status", "type"},
+								"properties": map[string]any{
+									"type":   map[string]any{"type": "string"},
+									"status": map[string]any{"type": "string"},
+								},
+							},
+						},
+					},
+				},
+			),
+		},
+		{
+			name: "status expressions become untyped properties",
+			expr: `simpleschema.toOpenAPI({
+				"spec": {"name": "string"},
+				"status": {
+					"ready": "${deployment.status.readyReplicas > 0}",
+					"url": "http://${service.spec.clusterIP}",
+					"conditions": ["${runtime.newCondition({type: 'Ready', status: 'True'})}"],
+					"count": "integer"
+				}
+			})`,
+			want: rootWith(
+				map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"name": map[string]any{"type": "string"}},
+				},
+				map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"ready":      untypedSchema,
+						"url":        untypedSchema,
+						"conditions": untypedSchema,
+						"count":      map[string]any{"type": "integer"},
+					},
+				},
+			),
+		},
+		{
+			name: "null and CRD-descriptor keys are ignored",
+			expr: `simpleschema.toOpenAPI({
+				"apiVersion": "example.com/v1alpha1",
+				"kind": "App",
+				"group": "example.com",
+				"scope": "Namespaced",
+				"additionalPrinterColumns": [{"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"}],
+				"spec": {"name": "string"},
+				"types": null,
+				"status": null
+			})`,
+			want: rootWith(
+				map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"name": map[string]any{"type": "string"}},
+				},
+				emptyObjectSchema,
+			),
+		},
+		{
+			// An RGD may declare a Kind with no spec, types or status at all;
+			// its spec.schema must still convert rather than be mistaken for a
+			// bare field map.
+			name: "spec-less RGD schema block",
+			expr: `simpleschema.toOpenAPI({"apiVersion": "v1alpha1", "kind": "Singleton", "group": "kro.run", "scope": "Namespaced"})`,
+			want: rootWith(emptyObjectSchema, emptyObjectSchema),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, evalRoot(t, env, tc.expr, cel.NoVars()))
+		})
+	}
+}
+
+// TestSimpleSchemaToOpenAPISpecBlockShapes checks that SimpleSchema features
+// survive the CEL boundary with the shape the RGD controller writes into
+// instance CRDs, decoded into native CEL values: int for integral numbers,
+// nested maps for objects, lists for enum/required.
+func TestSimpleSchemaToOpenAPISpecBlockShapes(t *testing.T) {
+	env := newSimpleSchemaEnv(t)
+
+	cases := []struct {
+		name  string
+		spec  string // CEL map literal for the spec block
+		types string // CEL map literal for the types block
+		want  map[string]any
+	}{
+		{
+			name: "atomic types",
+			spec: `{'name': 'string', 'count': 'integer', 'ratio': 'float', 'enabled': 'boolean'}`,
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":    map[string]any{"type": "string"},
+					"count":   map[string]any{"type": "integer"},
+					"ratio":   map[string]any{"type": "number"},
+					"enabled": map[string]any{"type": "boolean"},
+				},
+			},
+		},
+		{
+			name: "markers: required, default, description, minimum, maximum",
+			spec: `{
+				'name': 'string | required=true default=web description="Resource name"',
+				'replicas': 'integer | default=3 minimum=1 maximum=10'
+			}`,
+			want: map[string]any{
+				"type":     "object",
+				"required": []any{"name"},
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type":        "string",
+						"default":     "web",
+						"description": "Resource name",
+					},
+					"replicas": map[string]any{
+						"type":    "integer",
+						"default": int64(3),
+						"minimum": int64(1),
+						"maximum": int64(10),
+					},
+				},
+			},
+		},
+		{
+			name: "required list is sorted",
+			spec: `{'zeta': 'string | required=true', 'alpha': 'string | required=true', 'mid': 'string | required=true'}`,
+			want: map[string]any{
+				"type":     "object",
+				"required": []any{"alpha", "mid", "zeta"},
+				"properties": map[string]any{
+					"zeta":  map[string]any{"type": "string"},
+					"alpha": map[string]any{"type": "string"},
+					"mid":   map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			name: "enum and validation markers",
+			spec: `{
+				'env': 'string | enum="dev,prod"',
+				'level': 'integer | enum="1,2,3"',
+				'id': 'string | immutable=true'
+			}`,
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"env":   map[string]any{"type": "string", "enum": []any{"dev", "prod"}},
+					"level": map[string]any{"type": "integer", "enum": []any{int64(1), int64(2), int64(3)}},
+					"id": map[string]any{
+						"type": "string",
+						"x-kubernetes-validations": []any{
+							map[string]any{"rule": "self == oldSelf", "message": "field is immutable"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nested inline object propagates default",
+			spec: `{'config': {'host': 'string', 'port': 'integer | default=8080'}}`,
+			want: map[string]any{
+				"type":    "object",
+				"default": map[string]any{},
+				"properties": map[string]any{
+					"config": map[string]any{
+						"type":    "object",
+						"default": map[string]any{},
+						"properties": map[string]any{
+							"host": map[string]any{"type": "string"},
+							"port": map[string]any{"type": "integer", "default": int64(8080)},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "arrays and maps",
+			spec: `{'tags': '[]string', 'labels': 'map[string]string', 'matrix': '[][]integer'}`,
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+					"labels": map[string]any{
+						"type":                 "object",
+						"additionalProperties": map[string]any{"type": "string"},
+					},
+					"matrix": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "integer"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "object type preserves unknown fields",
+			spec: `{'raw': 'object'}`,
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"raw": map[string]any{
+						"type":                                 "object",
+						"x-kubernetes-preserve-unknown-fields": true,
+					},
+				},
+			},
+		},
+		{
+			name:  "custom types: struct and required alias",
+			spec:  `{'owner': 'Person', 'nickname': 'Name'}`,
+			types: `{'Person': {'name': 'Name', 'age': 'integer'}, 'Name': 'string | required=true'}`,
+			want: map[string]any{
+				"type":     "object",
+				"required": []any{"nickname"},
+				"properties": map[string]any{
+					"nickname": map[string]any{"type": "string"},
+					"owner": map[string]any{
+						"type":     "object",
+						"required": []any{"name"},
+						"properties": map[string]any{
+							"name": map[string]any{"type": "string"},
+							"age":  map[string]any{"type": "integer"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			types := tc.types
+			if types == "" {
+				types = "{}"
+			}
+			root := evalRoot(t, env, `simpleschema.toOpenAPI({"spec": `+tc.spec+`, "types": `+types+`})`, cel.NoVars())
+			assert.Equal(t, tc.want, specOf(t, root))
+		})
+	}
+}
+
+// TestSimpleSchemaToOpenAPIResultIsCELMap verifies the result behaves as
+// a regular CEL map so authors can post-process it (index, has(), size(), or
+// pull out a sub-schema to compose a root by hand).
+func TestSimpleSchemaToOpenAPIResultIsCELMap(t *testing.T) {
+	env := newSimpleSchemaEnv(t)
+
+	const block = `{'spec': {'name': 'string | required=true', 'replicas': 'integer | default=3'}}`
+	evalTrue(t, env, `simpleschema.toOpenAPI(`+block+`).type == 'object'`)
+	evalTrue(t, env, `simpleschema.toOpenAPI(`+block+`).properties.spec.properties.name.type == 'string'`)
+	evalTrue(t, env, `simpleschema.toOpenAPI(`+block+`).properties.spec.required == ['name']`)
+	evalTrue(t, env, `simpleschema.toOpenAPI(`+block+`).properties.spec.properties.replicas.default == 3`)
+	evalTrue(t, env, `size(simpleschema.toOpenAPI(`+block+`).properties.spec.properties) == 2`)
+	evalTrue(t, env, `simpleschema.toOpenAPI(`+block+`).properties.status == {'type': 'object'}`)
+	evalTrue(t, env, `!has(simpleschema.toOpenAPI({'spec': {}}).properties.spec.properties)`)
+}
+
+// TestSimpleSchemaToOpenAPIOutputType pins the declared return type: dyn,
+// so the result is assignable to any typed field of a resource template.
+func TestSimpleSchemaToOpenAPIOutputType(t *testing.T) {
+	env := newSimpleSchemaEnv(t)
+
+	ast, iss := env.Compile(`simpleschema.toOpenAPI({'spec': {'name': 'string'}})`)
+	require.NoError(t, iss.Err())
+	assert.Equal(t, cel.DynType.String(), ast.OutputType().String())
+}
+
+// TestSimpleSchemaToOpenAPIObjectTypedArgCompiles verifies that an
+// argument typed as an opaque object (the shape a typed environment gives an
+// RGD's spec.schema, whose blocks are x-kubernetes-preserve-unknown-fields
+// objects) passes type-checking. A map(string, dyn) signature would reject it.
+func TestSimpleSchemaToOpenAPIObjectTypedArgCompiles(t *testing.T) {
+	env := newSimpleSchemaEnv(t, cel.Variable("schemaBlock", cel.ObjectType("rgd.schema")))
+
+	pAst, iss := env.Parse(`simpleschema.toOpenAPI(schemaBlock)`)
+	require.NoError(t, iss.Err())
+	_, iss = env.Check(pAst)
+	require.NoError(t, iss.Err(), "toOpenAPI must type-check against an object-typed argument")
+}
+
+// TestSimpleSchemaToOpenAPIDynVariable is the runtime path kro uses: the
+// block is a dyn variable bound to a native map[string]interface{} read from an
+// unstructured object.
+func TestSimpleSchemaToOpenAPIDynVariable(t *testing.T) {
+	env := newSimpleSchemaEnv(t, cel.Variable("kindSpec", cel.DynType))
+
+	block := map[string]any{
+		"kind": "App",
+		"spec": map[string]any{
+			"name":     "string | required=true",
+			"replicas": "integer | default=1 minimum=0",
+			"owner":    "Owner",
+			"labels":   "map[string]string",
+			"nested":   map[string]any{"enabled": "boolean | default=true"},
+		},
+		"types": map[string]any{
+			"Owner": map[string]any{"team": "string | required=true", "email": "string"},
+		},
+		"status": map[string]any{"ready": "boolean"},
+	}
+	vars := map[string]any{"kindSpec": block}
+
+	got := evalRoot(t, env, `simpleschema.toOpenAPI(kindSpec)`, vars)
+
+	want := rootWith(
+		map[string]any{
+			"type":     "object",
+			"required": []any{"name"},
+			"properties": map[string]any{
+				"name":     map[string]any{"type": "string"},
+				"replicas": map[string]any{"type": "integer", "default": int64(1), "minimum": int64(0)},
+				"labels": map[string]any{
+					"type":                 "object",
+					"additionalProperties": map[string]any{"type": "string"},
+				},
+				"owner": map[string]any{
+					"type":     "object",
+					"required": []any{"team"},
+					"properties": map[string]any{
+						"team":  map[string]any{"type": "string"},
+						"email": map[string]any{"type": "string"},
+					},
+				},
+				"nested": map[string]any{
+					"type":    "object",
+					"default": map[string]any{},
+					"properties": map[string]any{
+						"enabled": map[string]any{"type": "boolean", "default": true},
+					},
+				},
+			},
+		},
+		map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"ready": map[string]any{"type": "boolean"}},
+		},
+	)
+	assert.Equal(t, want, got)
+
+	// The input must not be mutated by the conversion.
+	assert.Equal(t, "string | required=true", block["spec"].(map[string]any)["name"])
+}
+
+// TestSimpleSchemaToOpenAPIKindDefinition converts the schema block of a
+// Graph-native Kind definition — spec, status and custom types written in
+// SimpleSchema, the way the graph-native RGD design declares its own CRD. Every
+// SimpleSchema feature used there (custom types, array-of-map, unquoted pattern,
+// object/array defaults, required markers) must survive, and the result must be
+// a valid structural schema.
+func TestSimpleSchemaToOpenAPIKindDefinition(t *testing.T) {
+	env := newSimpleSchemaEnv(t)
+
+	root := evalRoot(t, env, `simpleschema.toOpenAPI({
+		"types": {
+			"Node": {
+				"id": "string",
+				"template": "object",
+				"ref": "object",
+				"forEach": "[]map[string]string",
+				"includeWhen": "[]string",
+				"readyWhen": "[]string"
+			},
+			"PrinterColumn": {
+				"name": "string | required=true",
+				"type": "string | required=true",
+				"jsonPath": "string | required=true",
+				"priority": "integer"
+			},
+			"Condition": {
+				"type": "string | required=true",
+				"status": "string | required=true",
+				"reason": "string",
+				"message": "string",
+				"lastTransitionTime": "string",
+				"observedGeneration": "integer"
+			}
+		},
+		"spec": {
+			"scope": "string | default=Namespaced",
+			"schema": {
+				"apiVersion": "string | required=true pattern=^[a-z][a-z0-9.-]*/[a-z][a-z0-9]*$",
+				"kind": "string | required=true",
+				"spec": "object",
+				"status": "object | default={}",
+				"types": "object"
+			},
+			"nodes": "[]Node",
+			"additionalPrinterColumns": "[]PrinterColumn | default=[]"
+		},
+		"status": {
+			"items": "integer",
+			"conditions": "[]Condition"
+		}
+	})`, cel.NoVars())
+
+	props := root["properties"].(map[string]any)
+	spec := props["spec"].(map[string]any)
+	specProps := spec["properties"].(map[string]any)
+	assert.Equal(t, map[string]any{}, spec["default"], "a child default propagates default: {} to the parent")
+	assert.Equal(t, map[string]any{"type": "string", "default": "Namespaced"}, specProps["scope"])
+
+	schema := specProps["schema"].(map[string]any)
+	assert.Equal(t, []any{"apiVersion", "kind"}, schema["required"])
+	schemaProps := schema["properties"].(map[string]any)
+	assert.Equal(t, map[string]any{"type": "string", "pattern": "^[a-z][a-z0-9.-]*/[a-z][a-z0-9]*$"}, schemaProps["apiVersion"])
+	assert.Equal(t, map[string]any{"type": "object", "x-kubernetes-preserve-unknown-fields": true, "default": map[string]any{}}, schemaProps["status"])
+
+	nodes := specProps["nodes"].(map[string]any)
+	nodeProps := nodes["items"].(map[string]any)["properties"].(map[string]any)
+	assert.Equal(t, map[string]any{
+		"type":  "array",
+		"items": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
+	}, nodeProps["forEach"])
+
+	columns := specProps["additionalPrinterColumns"].(map[string]any)
+	assert.Equal(t, []any{}, columns["default"])
+	assert.Equal(t, []any{"jsonPath", "name", "type"}, columns["items"].(map[string]any)["required"])
+
+	status := props["status"].(map[string]any)
+	statusProps := status["properties"].(map[string]any)
+	assert.Equal(t, map[string]any{"type": "integer"}, statusProps["items"])
+	conditionProps := statusProps["conditions"].(map[string]any)["items"].(map[string]any)["properties"].(map[string]any)
+	assert.Len(t, conditionProps, 6)
+	assert.Equal(t, map[string]any{"type": "integer"}, conditionProps["observedGeneration"])
+}
+
+// TestSimpleSchemaToOpenAPIRGDSchema feeds the function an actual
+// ResourceGraphDefinition spec.schema block, as a Graph reading RGDs would
+// (`simpleschema.toOpenAPI(rgd.spec.schema)`), and shows how kro's default
+// instance status fields are added on top with deepMerge before conversion.
+func TestSimpleSchemaToOpenAPIRGDSchema(t *testing.T) {
+	env := newSimpleSchemaEnv(t, Maps(), cel.Variable("rgdSchema", cel.DynType))
+
+	vars := map[string]any{"rgdSchema": map[string]any{
+		"apiVersion": "v1alpha1",
+		"kind":       "WebApp",
+		"group":      "kro.run",
+		"scope":      "Namespaced",
+		"spec": map[string]any{
+			"name":     "string | required=true",
+			"replicas": "integer | default=1",
+			"owner":    "Owner",
+		},
+		"types": map[string]any{
+			"Owner": map[string]any{"team": "string"},
+		},
+		"status": map[string]any{
+			"availableReplicas": "${deployment.status.availableReplicas}",
+			"url":               "http://${service.spec.clusterIP}",
+			"conditions":        []any{"${runtime.newCondition({type: 'AppReady', status: 'True', reason: '', message: ''})}"},
+		},
+	}}
+
+	t.Run("as-is", func(t *testing.T) {
+		root := evalRoot(t, env, `simpleschema.toOpenAPI(rgdSchema)`, vars)
+
+		spec := specOf(t, root)
+		assert.Equal(t, []any{"name"}, spec["required"])
+		specProps := spec["properties"].(map[string]any)
+		assert.Equal(t, map[string]any{"type": "integer", "default": int64(1)}, specProps["replicas"])
+		assert.Equal(t, map[string]any{"type": "string"}, specProps["owner"].(map[string]any)["properties"].(map[string]any)["team"])
+
+		status := root["properties"].(map[string]any)["status"].(map[string]any)
+		assert.Equal(t, map[string]any{
+			"availableReplicas": untypedSchema,
+			"url":               untypedSchema,
+			"conditions":        untypedSchema,
+		}, status["properties"], "RGD status values are expressions and cannot be typed without the referenced schemas")
+	})
+
+	t.Run("with kro default status fields merged in", func(t *testing.T) {
+		// deepMerge replaces the expression-valued conditions list with a typed
+		// SimpleSchema declaration and adds state, mirroring crd.SetCRDStatus.
+		const expr = `simpleschema.toOpenAPI(rgdSchema.deepMerge({
+			"status": {"state": "string", "conditions": "[]KroCondition"},
+			"types": {"KroCondition": {"type": "string", "status": "string", "reason": "string", "message": "string", "lastTransitionTime": "string", "observedGeneration": "integer"}}
+		}))`
+		root := evalRoot(t, env, expr, vars)
+
+		statusProps := root["properties"].(map[string]any)["status"].(map[string]any)["properties"].(map[string]any)
+		assert.Equal(t, map[string]any{"type": "string"}, statusProps["state"])
+		assert.Equal(t, untypedSchema, statusProps["availableReplicas"], "author status fields are preserved")
+		conditions := statusProps["conditions"].(map[string]any)
+		assert.Equal(t, "array", conditions["type"])
+		assert.Len(t, conditions["items"].(map[string]any)["properties"], 6)
+		assert.Contains(t, specOf(t, root)["properties"], "owner", "existing custom types survive the merge")
+	})
+}
+
+func TestSimpleSchemaToOpenAPIErrors(t *testing.T) {
+	env := newSimpleSchemaEnv(t, cel.Variable("anyVal", cel.DynType))
+
+	cases := []struct {
+		name    string
+		expr    string
+		vars    map[string]any
+		wantErr string
+	}{
+		{
+			name:    "block is a string",
+			expr:    `simpleschema.toOpenAPI('spec: {}')`,
+			wantErr: "simpleschema.toOpenAPI: schema argument must be a map with string keys, got string",
+		},
+		{
+			name:    "block is a list",
+			expr:    `simpleschema.toOpenAPI([{'spec': {}}])`,
+			wantErr: "simpleschema.toOpenAPI: schema argument must be a map with string keys, got list",
+		},
+		{
+			name:    "block is null",
+			expr:    `simpleschema.toOpenAPI(anyVal)`,
+			vars:    map[string]any{"anyVal": nil},
+			wantErr: "simpleschema.toOpenAPI: schema argument must be a map with string keys, got null_type",
+		},
+		{
+			name:    "non-string map key",
+			expr:    `simpleschema.toOpenAPI({1: {}})`,
+			wantErr: "simpleschema.toOpenAPI: schema argument must be a map with string keys: map key must be string",
+		},
+		{
+			name:    "a bare field map is not a schema block",
+			expr:    `simpleschema.toOpenAPI({"name": "string | required=true"})`,
+			wantErr: `simpleschema.toOpenAPI: schema block has none of the keys "spec", "types" or "status"; wrap SimpleSchema fields in {"spec": {...}}`,
+		},
+		{
+			name:    "spec is not a map",
+			expr:    `simpleschema.toOpenAPI({"spec": "string"})`,
+			wantErr: `simpleschema.toOpenAPI: schema block key "spec" must be a map with string keys, got string`,
+		},
+		{
+			name:    "types is a list",
+			expr:    `simpleschema.toOpenAPI({"spec": {}, "types": []})`,
+			wantErr: `simpleschema.toOpenAPI: schema block key "types" must be a map with string keys, got list`,
+		},
+		{
+			name:    "spec does not accept expressions",
+			expr:    `simpleschema.toOpenAPI({"spec": {"ready": "${deployment.status.readyReplicas > 0}"}})`,
+			wantErr: "simpleschema.toOpenAPI: spec: field ready:",
+		},
+		{
+			name:    "unknown type",
+			expr:    `simpleschema.toOpenAPI({"spec": {"name": "strng"}})`,
+			wantErr: "simpleschema.toOpenAPI: spec: field name: unknown type: strng",
+		},
+		{
+			name:    "unknown marker",
+			expr:    `simpleschema.toOpenAPI({"spec": {"name": "string | requird=true"}})`,
+			wantErr: `simpleschema.toOpenAPI: spec: field name: invalid marker key "requird": unknown marker`,
+		},
+		{
+			name:    "field value is not a string or map",
+			expr:    `simpleschema.toOpenAPI({"spec": {"name": 1}})`,
+			wantErr: "simpleschema.toOpenAPI: spec: field name: unexpected type: int64",
+		},
+		{
+			name:    "cyclic custom types are attributed to types",
+			expr:    `simpleschema.toOpenAPI({"spec": {"a": "A"}, "types": {"A": {"b": "B"}, "B": {"a": "A"}}})`,
+			wantErr: "simpleschema.toOpenAPI: types: cyclic dependency in type",
+		},
+		{
+			name:    "invalid custom type is attributed to types even without a spec block",
+			expr:    `simpleschema.toOpenAPI({"status": {"a": "A"}, "types": {"A": "string | requird=true"}})`,
+			wantErr: "simpleschema.toOpenAPI: types: building schema for A:",
+		},
+		{
+			name:    "enum on unsupported type",
+			expr:    `simpleschema.toOpenAPI({"spec": {"flag": "boolean | enum=\"true,false\""}})`,
+			wantErr: "simpleschema.toOpenAPI: spec: field flag: enum values only supported for string and integer types",
+		},
+		{
+			name:    "status type errors are attributed to status",
+			expr:    `simpleschema.toOpenAPI({"status": {"items": "Foo"}})`,
+			wantErr: "simpleschema.toOpenAPI: status: field items: unknown type: Foo",
+		},
+		{
+			name:    "status list that is not an expression list",
+			expr:    `simpleschema.toOpenAPI({"status": {"items": ["integer"]}})`,
+			wantErr: "simpleschema.toOpenAPI: status: field items: a list value must contain only CEL expressions",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, iss := env.Compile(tc.expr)
+			require.NoError(t, iss.Err(), "compile %q", tc.expr)
+			prg, err := env.Program(ast)
+			require.NoError(t, err)
+
+			vars := tc.vars
+			if vars == nil {
+				vars = map[string]any{"anyVal": map[string]any{}}
+			}
+			out, _, err := prg.Eval(vars)
+			require.Error(t, err, "expected eval error for %q", tc.expr)
+			require.True(t, types.IsError(out), "expected a CEL error value, got %v", out)
+			assert.Contains(t, out.(*types.Err).String(), tc.wantErr)
+		})
+	}
+}
+
+// TestSimpleSchemaToOpenAPIWrongArity checks the checker rejects calls
+// that do not match the single (dyn) overload; in particular a two-argument
+// (spec, types) call is not an overload.
+func TestSimpleSchemaToOpenAPIWrongArity(t *testing.T) {
+	env := newSimpleSchemaEnv(t)
+
+	for _, expr := range []string{
+		`simpleschema.toOpenAPI()`,
+		`simpleschema.toOpenAPI({'name': 'string'}, {})`,
+		`simpleschema.toOpenAPI({'spec': {}}, {}, {})`,
+	} {
+		_, iss := env.Compile(expr)
+		require.Error(t, iss.Err(), "expected compile error for %q", expr)
+		assert.Contains(t, iss.Err().Error(), "found no matching overload")
+	}
+}
+
+func TestSimpleSchemaLibraryName(t *testing.T) {
+	lib := &simpleSchemaLibrary{}
+	assert.Equal(t, "kro.simpleschema", lib.LibraryName())
+	assert.Nil(t, lib.ProgramOptions())
+}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -475,15 +475,14 @@ func (b *Builder) buildResourceNode(
 			return nil, nil, fmt.Errorf("failed to parse external ref resource %s: %w", rs.ID, err)
 		}
 	} else if gvk.Group == "apiextensions.k8s.io" && gvk.Version == "v1" && gvk.Kind == "CustomResourceDefinition" {
+		// CRDs are parsed schemalessly: the apiextensions OpenAPI document
+		// models openAPIV3Schema as the recursive JSONSchemaProps and the
+		// resolver collapses its self-references to {type: object}, so the
+		// typed parser cannot walk a real schema. Expressions found at any
+		// path are still type-checked via expectedTypeForField.
 		fieldDescriptors, _, err = parser.ParseSchemalessResource(rs.Object)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse schemaless resource %s: %w", rs.ID, err)
-		}
-
-		for _, expr := range fieldDescriptors {
-			if !strings.HasPrefix(expr.Path, "metadata.") {
-				return nil, nil, fmt.Errorf("CEL expressions in CRDs are only supported for metadata fields, found in path %q, resource %s", expr.Path, rs.ID)
-			}
 		}
 	} else {
 		fieldDescriptors, err = p.ParseResource(rs.Object, resourceSchema)

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -692,7 +692,11 @@ func TestGraphBuilder_Validation(t *testing.T) {
 			errMsg:  "expected array type for path spec.cidrBlocks, got string",
 		},
 		{
-			name: "crds aren't allowed to have variables in their spec fields",
+			// CRD templates used to accept CEL only under metadata.*; expressions
+			// are now allowed anywhere in the template (see
+			// TestGraphBuilder_CRDTemplateExpressions for type-checking against
+			// the real CRD schema).
+			name: "crds may use CEL expressions in spec fields",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
@@ -720,8 +724,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 					},
 				}, nil, nil),
 			},
-			wantErr: true,
-			errMsg:  "CEL expressions in CRDs are only supported for metadata fields",
+			wantErr: false,
 		},
 		{
 			name: "crds are allowed to have CEL expressions in metadata.name",
@@ -924,6 +927,111 @@ func TestGraphBuilder_Validation(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestGraphBuilder_CRDTemplateExpressions covers CEL expressions in
+// CustomResourceDefinition resources on the RGD path, against the real
+// apiextensions CRD schema. CRD templates are parsed schemalessly (the typed
+// parser cannot walk the recursive JSONSchemaProps) and used to be limited to
+// metadata.*; expressions are now accepted anywhere and still type-checked
+// where the CRD schema resolves their path.
+func TestGraphBuilder_CRDTemplateExpressions(t *testing.T) {
+	fakeResolver, fakeDiscovery, err := k8s.NewFakeResolverWithRealCRDSchema()
+	require.NoError(t, err)
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory2.NewMemCacheClient(fakeDiscovery))
+	builder := &Builder{
+		schemaResolver: fakeResolver,
+		restMapper:     restMapper,
+	}
+
+	// An RGD whose instances describe a Kind: the instance carries the Kind's
+	// openAPIV3Schema as an opaque object and the graph places it into the CRD.
+	schemaOpt := generator.WithSchema(
+		"KindFactory", "v1alpha1",
+		map[string]any{
+			"kind":            "string | required=true",
+			"group":           "string | default=example.com",
+			"replicas":        "integer | default=1",
+			"openAPIV3Schema": "object",
+		},
+		map[string]any{
+			"established": "${crd.status.conditions.exists(c, c.type == 'Established' && c.status == 'True')}",
+		},
+	)
+	crdTemplate := func(overrides map[string]any) map[string]any {
+		tmpl := map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata":   map[string]any{"name": "${schema.spec.kind.lowerAscii() + 's.' + schema.spec.group}"},
+			"spec": map[string]any{
+				"group": "${schema.spec.group}",
+				"names": map[string]any{
+					"kind":   "${schema.spec.kind}",
+					"plural": "${schema.spec.kind.lowerAscii() + 's'}",
+				},
+				"scope": "Namespaced",
+				"versions": []any{map[string]any{
+					"name": "v1alpha1", "served": true, "storage": true,
+					"schema": map[string]any{
+						"openAPIV3Schema": "${schema.spec.openAPIV3Schema}",
+					},
+				}},
+			},
+		}
+		for k, v := range overrides {
+			tmpl["spec"].(map[string]any)[k] = v
+		}
+		return tmpl
+	}
+
+	t.Run("openAPIV3Schema from the instance spec is accepted", func(t *testing.T) {
+		rgd := generator.NewResourceGraphDefinition("kind-factory", schemaOpt,
+			generator.WithResource("crd", crdTemplate(nil), nil, nil))
+		g, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		require.NoError(t, err)
+
+		node := g.Resources["crd"]
+		require.NotNil(t, node)
+		paths := make([]string, 0, len(node.Variables))
+		for _, v := range node.Variables {
+			paths = append(paths, v.Path)
+		}
+		assert.ElementsMatch(t, []string{
+			"metadata.name", "spec.group", "spec.names.kind", "spec.names.plural",
+			"spec.versions[0].schema.openAPIV3Schema",
+		}, paths)
+	})
+
+	t.Run("non-metadata expressions are type-checked against the CRD schema", func(t *testing.T) {
+		rgd := generator.NewResourceGraphDefinition("kind-factory", schemaOpt,
+			generator.WithResource("crd", crdTemplate(map[string]any{"group": "${schema.spec.replicas}"}), nil, nil))
+		_, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `path "spec.group"`)
+		assert.Contains(t, err.Error(), `returns type "int" but expected "string"`)
+	})
+
+	t.Run("backwards compatible: metadata-only CRD expressions still build", func(t *testing.T) {
+		rgd := generator.NewResourceGraphDefinition("kind-factory", schemaOpt,
+			generator.WithResource("crd", map[string]any{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata":   map[string]any{"name": "${schema.spec.kind.lowerAscii() + 's.' + schema.spec.group}"},
+				"spec": map[string]any{
+					"group": "example.com",
+					"names": map[string]any{"kind": "Widget", "plural": "widgets"},
+					"scope": "Namespaced",
+					"versions": []any{map[string]any{
+						"name": "v1alpha1", "served": true, "storage": true,
+						"schema": map[string]any{"openAPIV3Schema": map[string]any{"type": "object", "x-kubernetes-preserve-unknown-fields": true}},
+					}},
+				},
+			}, nil, nil))
+		g, err := builder.NewResourceGraphDefinition(rgd, defaultRGDConfig)
+		require.NoError(t, err)
+		require.Len(t, g.Resources["crd"].Variables, 1)
+		assert.Equal(t, "metadata.name", g.Resources["crd"].Variables[0].Path)
+	})
 }
 
 func TestGraphBuilder_DependencyValidation(t *testing.T) {
@@ -4141,9 +4249,9 @@ spec:
 		assert.Contains(t, err.Error(), "failed to parse schemaless resource")
 	})
 
-	t.Run("crd only allows metadata expressions", func(t *testing.T) {
+	t.Run("crd extracts expressions outside metadata", func(t *testing.T) {
 		builder := newUnitTestBuilder()
-		_, err := buildRGResourceForTest(builder, testParser, &krov1alpha1.Resource{
+		node, err := buildRGResourceForTest(builder, testParser, &krov1alpha1.Resource{
 			ID: "crd",
 			Template: rawExt(`
 apiVersion: apiextensions.k8s.io/v1
@@ -4152,10 +4260,20 @@ metadata:
   name: tests.kro.run
 spec:
   group: ${schema.spec.group}
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema: ${schema.spec.openAPIV3Schema}
 `),
 		}, true)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "only supported for metadata fields")
+		require.NoError(t, err)
+		paths := make([]string, 0, len(node.Variables))
+		for _, v := range node.Variables {
+			paths = append(paths, v.Path)
+		}
+		assert.ElementsMatch(t, []string{"spec.group", "spec.versions[0].schema.openAPIV3Schema"}, paths)
 	})
 
 	t.Run("schema based parsing error", func(t *testing.T) {

--- a/pkg/graphengine/compiler/context.go
+++ b/pkg/graphengine/compiler/context.go
@@ -282,15 +282,12 @@ func (ctx *CompilationContext) buildNode(p *parser.Parser, n *expv1alpha1.Node, 
 	var descriptors []variable.FieldDescriptor
 	if kind == NodeKindTemplate || kind == NodeKindPatch {
 		if kind == NodeKindTemplate && gvk.Group == "apiextensions.k8s.io" && gvk.Kind == "CustomResourceDefinition" {
+			// CRDs are parsed schemalessly: the apiextensions OpenAPI document
+			// models openAPIV3Schema as the recursive JSONSchemaProps and the
+			// resolver collapses its self-references to {type: object}, so the
+			// typed parser cannot walk a real schema. Expressions found at any
+			// path are still type-checked via expectedTypeForField.
 			descriptors, _, err = parser.ParseSchemalessResource(payload)
-			if err != nil {
-				return nil, nil, fmt.Errorf("parse %s payload: %w", kind, err)
-			}
-			for _, expr := range descriptors {
-				if !strings.HasPrefix(expr.Path, "metadata.") {
-					return nil, nil, fmt.Errorf("CEL expressions in CRDs are only supported for metadata fields, found in path %q, resource %s", expr.Path, n.ID)
-				}
-			}
 		} else {
 			// A patch body is a partial manifest shaped like the target, so it
 			// type-checks against the target schema exactly as a template does.

--- a/pkg/graphengine/compiler/crd_test.go
+++ b/pkg/graphengine/compiler/crd_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	memory "k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
+	testk8s "github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
+)
+
+// newRealCRDSchemaCompiler returns a test compiler whose resolver serves the
+// real apiextensions CustomResourceDefinition schema (spec.versions and the
+// recursive JSONSchemaProps under openAPIV3Schema) instead of the minimal
+// hand-written one, so CRD templates are type-checked against the shape a
+// live cluster reports.
+func newRealCRDSchemaCompiler(t *testing.T) *Compiler {
+	t.Helper()
+	resolver, disco, err := testk8s.NewFakeResolverWithRealCRDSchema()
+	require.NoError(t, err)
+	rm := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disco))
+	return &Compiler{schemaResolver: resolver, restMapper: rm}
+}
+
+// crdTemplate builds a CustomResourceDefinition template whose
+// versions[0].schema.openAPIV3Schema is set to schema (a static map or a CEL
+// expression string).
+func crdTemplate(name string, openAPIV3Schema any, overrides map[string]any) map[string]any {
+	tmpl := map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition",
+		"metadata": map[string]any{"name": name},
+		"spec": map[string]any{
+			"group": "example.com",
+			"names": map[string]any{"kind": "App", "plural": "apps"},
+			"scope": "Namespaced",
+			"versions": []any{map[string]any{
+				"name": "v1alpha1", "served": true, "storage": true,
+				"schema": map[string]any{"openAPIV3Schema": openAPIV3Schema},
+			}},
+		},
+	}
+	for k, v := range overrides {
+		tmpl["spec"].(map[string]any)[k] = v
+	}
+	return tmpl
+}
+
+// TestCompile_CRDTemplateExpressions covers CEL expressions in
+// CustomResourceDefinition templates. CRDs are parsed schemalessly because the
+// typed parser cannot walk the recursive JSONSchemaProps schema; the compiler
+// used to additionally reject any expression outside metadata.*, which made it
+// impossible for a Graph to synthesize a Kind's openAPIV3Schema. Expressions are
+// now accepted anywhere and still type-checked against the real CRD schema where
+// the path resolves.
+func TestCompile_CRDTemplateExpressions(t *testing.T) {
+	t.Parallel()
+
+	rgdSchemaDef := map[string]any{
+		"kind": "App", "group": "example.com", "version": "v1alpha1",
+	}
+	// A heterogeneous map literal is map(string, dyn) and therefore assignable
+	// to the JSONSchemaProps-typed openAPIV3Schema field.
+	const specSchema = `{"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}`
+
+	t.Run("openAPIV3Schema from a CEL expression compiles against the real CRD schema", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("rgdSchema", rgdSchemaDef),
+			generator.WithTemplate("crd", crdTemplate(
+				"${rgdSchema.kind.lowerAscii() + 's.' + rgdSchema.group}",
+				`${{"type": "object", "properties": {"apiVersion": {"type": "string"}, "kind": {"type": "string"}, "metadata": {"type": "object"}, "spec": `+specSchema+`}}}`,
+				map[string]any{
+					"group": "${rgdSchema.group}",
+					"names": map[string]any{"kind": "${rgdSchema.kind}", "plural": "${rgdSchema.kind.lowerAscii() + 's'}"},
+				},
+			)),
+		)
+		prog, err := newRealCRDSchemaCompiler(t).Compile(g)
+		require.NoError(t, err)
+		crd := prog.Nodes["crd"]
+		assert.Equal(t, []string{"rgdSchema"}, crd.HardDepIDs())
+		paths := make([]string, 0, len(crd.Variables))
+		for _, v := range crd.Variables {
+			paths = append(paths, v.Path)
+		}
+		assert.ElementsMatch(t, []string{
+			"metadata.name", "spec.group", "spec.names.kind", "spec.names.plural",
+			"spec.versions[0].schema.openAPIV3Schema",
+		}, paths, "every expression in the CRD template must be extracted, not just metadata.*")
+	})
+
+	t.Run("expression nested inside a static openAPIV3Schema compiles", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("rgdSchema", rgdSchemaDef),
+			generator.WithTemplate("crd", crdTemplate("apps.example.com", map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"apiVersion": map[string]any{"type": "string"},
+					"kind":       map[string]any{"type": "string"},
+					"metadata":   map[string]any{"type": "object"},
+					"spec":       "${" + specSchema + "}",
+					"status":     map[string]any{"type": "object", "x-kubernetes-preserve-unknown-fields": true},
+				},
+			}, nil)),
+		)
+		prog, err := newRealCRDSchemaCompiler(t).Compile(g)
+		require.NoError(t, err)
+		require.Len(t, prog.Nodes["crd"].Variables, 1)
+		assert.Equal(t, "spec.versions[0].schema.openAPIV3Schema.properties.spec", prog.Nodes["crd"].Variables[0].Path)
+	})
+
+	t.Run("non-metadata expressions are still type-checked against the CRD schema", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("rgdSchema", rgdSchemaDef),
+			generator.WithTemplate("crd", crdTemplate("apps.example.com",
+				map[string]any{"type": "object", "x-kubernetes-preserve-unknown-fields": true},
+				map[string]any{"group": "${1 + 1}"},
+			)),
+		)
+		_, err := newRealCRDSchemaCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `type mismatch in node "crd" at path "spec.group"`)
+		assert.Contains(t, err.Error(), `returns "int" but expected "string"`)
+	})
+
+	t.Run("homogeneous map literal is rejected against the JSONSchemaProps type", func(t *testing.T) {
+		// A CEL map literal whose values are all strings has type
+		// map(string, string); JSONSchemaProps has non-string fields, so the
+		// structural check refuses it. Authors must produce a dyn-valued map
+		// (heterogeneous literal or dyn(...)). Pinned so the documentation's
+		// guidance stays accurate.
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("rgdSchema", rgdSchemaDef),
+			generator.WithTemplate("crd", crdTemplate("apps.example.com", `${{"type": "object"}}`, nil)),
+		)
+		_, err := newRealCRDSchemaCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `returns "map(string, string)"`)
+
+		g = generator.NewGraph("g",
+			generator.WithDef("rgdSchema", rgdSchemaDef),
+			generator.WithTemplate("crd", crdTemplate("apps.example.com", `${dyn({"type": "object"})}`, nil)),
+		)
+		_, err = newRealCRDSchemaCompiler(t).Compile(g)
+		require.NoError(t, err, "wrapping the literal in dyn() must be accepted")
+	})
+
+	t.Run("backwards compatible: metadata-only and static CRD templates compile unchanged", func(t *testing.T) {
+		t.Parallel()
+		for _, c := range []*Compiler{newTestCompiler(t), newRealCRDSchemaCompiler(t)} {
+			g := generator.NewGraph("g",
+				generator.WithDef("rgdSchema", rgdSchemaDef),
+				generator.WithTemplate("dynamicName", crdTemplate("${rgdSchema.kind.lowerAscii() + 's.' + rgdSchema.group}",
+					map[string]any{"type": "object", "x-kubernetes-preserve-unknown-fields": true}, nil)),
+				generator.WithTemplate("static", crdTemplate("widgets.example.com",
+					map[string]any{"type": "object", "x-kubernetes-preserve-unknown-fields": true},
+					map[string]any{"names": map[string]any{"kind": "Widget", "plural": "widgets"}})),
+			)
+			prog, err := c.Compile(g)
+			require.NoError(t, err)
+			require.Len(t, prog.Nodes["dynamicName"].Variables, 1)
+			assert.Equal(t, "metadata.name", prog.Nodes["dynamicName"].Variables[0].Path)
+			assert.Equal(t, []string{"rgdSchema"}, prog.Nodes["dynamicName"].HardDepIDs())
+			assert.Empty(t, prog.Nodes["static"].Variables)
+			assert.Empty(t, prog.Nodes["static"].HardDepIDs())
+		}
+	})
+
+	t.Run("malformed expression inside a CRD is still a parse error", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithTemplate("crd", crdTemplate("apps.example.com",
+				map[string]any{"type": "object", "x-kubernetes-preserve-unknown-fields": true},
+				map[string]any{"group": "${outer(${inner})}"},
+			)),
+		)
+		_, err := newRealCRDSchemaCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse template payload")
+	})
+}

--- a/pkg/graphengine/compiler/simpleschema_test.go
+++ b/pkg/graphengine/compiler/simpleschema_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
+)
+
+// TestCompile_SimpleSchemaToOpenAPI covers the Graph compiler's handling
+// of the namespaced simpleschema.toOpenAPI() function: the inspector must
+// treat `simpleschema` as a function namespace rather than an unknown node id,
+// the typed env must accept object-typed def fields as arguments, and the
+// dependency on the def node feeding the call must still be recorded.
+func TestCompile_SimpleSchemaToOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	rgdSchemaDef := map[string]any{
+		"kind": "App",
+		"spec": map[string]any{
+			"name":     "string | required=true",
+			"replicas": "integer | default=1",
+			"owner":    "Owner",
+		},
+		"types": map[string]any{
+			"Owner": map[string]any{"team": "string"},
+		},
+	}
+
+	t.Run("def-fed call inside a non-CRD template compiles", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("rgdSchema", rgdSchemaDef),
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "schema-${rgdSchema.kind.lowerAscii()}"},
+				"data": map[string]any{
+					"openapi":         "${json.marshal(simpleschema.toOpenAPI(rgdSchema))}",
+					"propertyCount":   "${string(size(simpleschema.toOpenAPI(rgdSchema).properties.spec.properties))}",
+					"literalArgument": "${json.marshal(simpleschema.toOpenAPI({'spec': {'name': 'string'}}))}",
+				},
+			}),
+		)
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+		require.NotNil(t, prog)
+		assert.Equal(t, []string{"rgdSchema"}, prog.Nodes["cm"].HardDepIDs(),
+			"the def feeding the conversion must be a hard dependency")
+		assert.Equal(t, []string{"rgdSchema", "cm"}, prog.TopologicalOrder)
+	})
+
+	t.Run("wrong arity is rejected at compile time", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("rgdSchema", rgdSchemaDef),
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "schema"},
+				"data": map[string]any{
+					// Two arguments: the function takes the whole schema block.
+					"openapi": "${json.marshal(simpleschema.toOpenAPI(rgdSchema.spec, rgdSchema.types))}",
+				},
+			}),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "found no matching overload")
+	})
+}

--- a/pkg/graphengine/runtime/node_test.go
+++ b/pkg/graphengine/runtime/node_test.go
@@ -16,10 +16,17 @@ package runtime
 
 import (
 	"errors"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	memory "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
 
@@ -506,6 +513,160 @@ func TestNode_Resolve(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mustCompilerWithRealCRDSchema is mustCompiler with the resolver serving the
+// real apiextensions CustomResourceDefinition schema, so CRD templates are
+// type-checked and rendered against the shape a live cluster reports.
+func mustCompilerWithRealCRDSchema(t *testing.T) *compiler.Compiler {
+	t.Helper()
+	r, disco, err := testk8s.NewFakeResolverWithRealCRDSchema()
+	require.NoError(t, err)
+	rm := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disco))
+	return compiler.NewCompilerWithDependencies(r, rm)
+}
+
+// kindCRDTemplate returns a CustomResourceDefinition template whose names and
+// version come from a def node "kindSpec" (group, kind, plural, version) and
+// whose versions[0].schema.openAPIV3Schema is set to openAPIV3Schema — a
+// static map, a CEL expression string, or a map containing expressions.
+func kindCRDTemplate(openAPIV3Schema any) map[string]any {
+	return map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition",
+		"metadata": map[string]any{"name": "${kindSpec.plural + '.' + kindSpec.group}"},
+		"spec": map[string]any{
+			"group": "${kindSpec.group}",
+			"names": map[string]any{"kind": "${kindSpec.kind}", "plural": "${kindSpec.plural}"},
+			"scope": "Namespaced",
+			"versions": []any{map[string]any{
+				"name": "${kindSpec.version}", "served": true, "storage": true,
+				"subresources": map[string]any{"status": map[string]any{}},
+				"schema":       map[string]any{"openAPIV3Schema": openAPIV3Schema},
+			}},
+		},
+	}
+}
+
+// renderCRD compiles g against the real CRD schema, publishes every def node,
+// renders node "crd" and returns it decoded into a typed CRD. Along the way it
+// checks what every apply path relies on: the rendered object is JSON-safe (it
+// survives the unstructured deep copy) and its schema passes the apiextensions
+// structural-schema validation the API server applies on admission.
+func renderCRD(t *testing.T, g *expv1alpha1.Graph) (*extv1.CustomResourceDefinition, map[string]any) {
+	t.Helper()
+	prog, err := mustCompilerWithRealCRDSchema(t).Compile(g)
+	require.NoError(t, err)
+	rt := New(prog, g)
+	for _, id := range prog.TopologicalOrder {
+		if prog.Nodes[id].Kind == compiler.NodeKindDef {
+			setFirst(rt, id)
+		}
+	}
+
+	objs, err := rt.Node("crd").Resolve()
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+	assert.Equal(t, objs[0].Object, objs[0].DeepCopy().Object, "rendered object must be JSON-safe")
+
+	var crd extv1.CustomResourceDefinition
+	require.NoError(t, k8sruntime.DefaultUnstructuredConverter.FromUnstructured(objs[0].Object, &crd))
+	require.Len(t, crd.Spec.Versions, 1)
+	require.NotNil(t, crd.Spec.Versions[0].Schema)
+	require.NotNil(t, crd.Spec.Versions[0].Schema.OpenAPIV3Schema)
+
+	// The API server converts to the internal type and validates the structural
+	// schema on admission; v1 -> internal hoists a single version's schema to
+	// spec.validation.
+	convScheme := k8sruntime.NewScheme()
+	apiextinstall.Install(convScheme)
+	var internal apiextensions.CustomResourceDefinition
+	require.NoError(t, convScheme.Convert(&crd, &internal, nil))
+	require.NotNil(t, internal.Spec.Validation)
+	structural, err := structuralschema.NewStructural(internal.Spec.Validation.OpenAPIV3Schema)
+	require.NoError(t, err)
+	assert.Empty(t, structuralschema.ValidateStructural(nil, structural))
+
+	return &crd, objs[0].Object
+}
+
+// kindSpecNames is the def node every CRD render test reads its names from.
+var kindSpecNames = map[string]any{
+	"group": "example.com", "kind": "App", "plural": "apps", "version": "v1alpha1",
+}
+
+// assertKindCRD checks the CRD fields that come from the kindSpecNames def.
+func assertKindCRD(t *testing.T, crd *extv1.CustomResourceDefinition) {
+	t.Helper()
+	assert.Equal(t, "apps.example.com", crd.Name)
+	assert.Equal(t, "example.com", crd.Spec.Group)
+	assert.Equal(t, "App", crd.Spec.Names.Kind)
+	assert.Equal(t, "apps", crd.Spec.Names.Plural)
+	assert.Equal(t, "v1alpha1", crd.Spec.Versions[0].Name)
+	root := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+	assert.Equal(t, "object", root.Type)
+	assert.ElementsMatch(t, []string{"apiVersion", "kind", "metadata", "spec", "status"}, slices.Collect(maps.Keys(root.Properties)))
+}
+
+// TestNode_Resolve_CRDTemplateSchemaFromCEL renders a CustomResourceDefinition
+// whose openAPIV3Schema is produced by CEL, for both authoring styles: the
+// whole openAPIV3Schema as one expression, and a static root with the spec and
+// status sub-schemas as expressions. Both must render the same CRD, decode into
+// a typed CRD and pass structural validation.
+func TestNode_Resolve_CRDTemplateSchemaFromCEL(t *testing.T) {
+	t.Parallel()
+
+	const specSchema = `{"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}, "replicas": {"type": "integer", "default": 1, "minimum": 0}}}`
+	const statusSchema = `{"type": "object", "properties": {"readyReplicas": {"type": "integer"}}}`
+	wantSpecSchema := extv1.JSONSchemaProps{
+		Type:     "object",
+		Required: []string{"name"},
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name":     {Type: "string"},
+			"replicas": {Type: "integer", Default: &extv1.JSON{Raw: []byte("1")}, Minimum: new(float64(0))},
+		},
+	}
+	wantStatusSchema := extv1.JSONSchemaProps{
+		Type:       "object",
+		Properties: map[string]extv1.JSONSchemaProps{"readyReplicas": {Type: "integer"}},
+	}
+
+	templates := map[string]map[string]any{
+		"whole openAPIV3Schema is one expression": kindCRDTemplate(
+			`${{"type": "object", "properties": {"apiVersion": {"type": "string"}, "kind": {"type": "string"}, "metadata": {"type": "object"}, "spec": ` + specSchema + `, "status": ` + statusSchema + `}}}`,
+		),
+		"sub-schemas nested inside a static root": kindCRDTemplate(map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"apiVersion": map[string]any{"type": "string"},
+				"kind":       map[string]any{"type": "string"},
+				"metadata":   map[string]any{"type": "object"},
+				"spec":       "${" + specSchema + "}",
+				"status":     "${" + statusSchema + "}",
+			},
+		}),
+	}
+
+	rendered := map[string]map[string]any{}
+	for name, tmpl := range templates {
+		t.Run(name, func(t *testing.T) {
+			g := generator.NewGraph("g",
+				generator.WithDef("kindSpec", kindSpecNames),
+				generator.WithTemplate("crd", tmpl),
+			)
+			crd, obj := renderCRD(t, g)
+			rendered[name] = obj
+			assertKindCRD(t, crd)
+			root := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+			assert.Equal(t, wantSpecSchema, root.Properties["spec"])
+			assert.Equal(t, wantStatusSchema, root.Properties["status"])
+		})
+	}
+
+	require.Len(t, rendered, 2)
+	assert.Equal(t,
+		rendered["whole openAPIV3Schema is one expression"],
+		rendered["sub-schemas nested inside a static root"],
+		"both authoring styles must render the same CRD")
 }
 
 func TestNode_TolerateDataPending(t *testing.T) {

--- a/pkg/graphengine/runtime/node_test.go
+++ b/pkg/graphengine/runtime/node_test.go
@@ -669,6 +669,66 @@ func TestNode_Resolve_CRDTemplateSchemaFromCEL(t *testing.T) {
 		"both authoring styles must render the same CRD")
 }
 
+// TestNode_Resolve_SimpleSchemaToOpenAPI renders a CustomResourceDefinition
+// whose openAPIV3Schema comes from simpleschema.toOpenAPI() applied to a
+// SimpleSchema block (spec, types, status) held in a def node — the graph-native
+// way to define a Kind. The CEL result must land in the rendered object as
+// JSON-safe values, decode into a typed CRD and pass structural validation.
+func TestNode_Resolve_SimpleSchemaToOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	kindSpec := map[string]any{
+		"types": map[string]any{
+			"Owner": map[string]any{"team": "string | required=true"},
+		},
+		"spec": map[string]any{
+			"name":     "string | required=true",
+			"replicas": "integer | default=1 minimum=0",
+			"owner":    "Owner",
+		},
+		"status": map[string]any{
+			"readyReplicas": "integer",
+			// Deferred: the def evaluates to the literal string
+			// "${service.spec.clusterIP}", which the function then sees as an
+			// expression-valued status field.
+			"url": "${'${service.spec.clusterIP}'}",
+		},
+	}
+	for k, v := range kindSpecNames {
+		kindSpec[k] = v
+	}
+
+	g := generator.NewGraph("g",
+		generator.WithDef("kindSpec", kindSpec),
+		generator.WithTemplate("crd", kindCRDTemplate("${simpleschema.toOpenAPI(kindSpec)}")),
+	)
+	crd, _ := renderCRD(t, g)
+	assertKindCRD(t, crd)
+
+	root := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+	assert.Equal(t, extv1.JSONSchemaProps{
+		Type:     "object",
+		Required: []string{"name"},
+		Properties: map[string]extv1.JSONSchemaProps{
+			"name":     {Type: "string"},
+			"replicas": {Type: "integer", Default: &extv1.JSON{Raw: []byte("1")}, Minimum: new(float64(0))},
+			"owner": {
+				Type:       "object",
+				Required:   []string{"team"},
+				Properties: map[string]extv1.JSONSchemaProps{"team": {Type: "string"}},
+			},
+		},
+	}, root.Properties["spec"])
+	assert.Equal(t, extv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]extv1.JSONSchemaProps{
+			"readyReplicas": {Type: "integer"},
+			// An expression-valued status field cannot be typed by the function.
+			"url": {XPreserveUnknownFields: new(true)},
+		},
+	}, root.Properties["status"])
+}
+
 func TestNode_TolerateDataPending(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/simpleschema/expressions_test.go
+++ b/pkg/simpleschema/expressions_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simpleschema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// An RGD-style status block mixes SimpleSchema types with CEL expressions. The
+// expressions' types depend on the resources they reference, which a converter
+// without a schema resolver cannot know; with AllowExpressionFields they must
+// become untyped (preserve-unknown-fields) properties while everything else is
+// converted exactly as in a spec block.
+func TestToOpenAPISpecAllowExpressionFields(t *testing.T) {
+	untyped := extv1.JSONSchemaProps{XPreserveUnknownFields: new(true)}
+
+	status := map[string]any{
+		"items":       "integer",
+		"conditions":  "[]Condition",
+		"ready":       "${deployment.status.readyReplicas > 0}",
+		"url":         "http://${service.spec.clusterIP}:8080",
+		"withPipes":   "${a || b}",
+		"kroList":     []any{"${runtime.newCondition({type: 'Ready'})}", "${runtime.newCondition({type: 'Other'})}"},
+		"nested":      map[string]any{"count": "integer", "phase": "${deployment.status.phase}"},
+		"requiredTag": "string | required=true",
+		// "${" inside a marker value is not an expression: the type position
+		// holds a real type, so the field stays typed and keeps its marker.
+		"literalDefault": `string | default="${x}"`,
+		"described":      `[]string | description="set from ${VAR}"`,
+	}
+	customTypes := map[string]any{
+		"Condition": map[string]any{
+			"type":   "string | required=true",
+			"status": "string | required=true",
+		},
+	}
+
+	got, err := ToOpenAPISpec(status, customTypes, AllowExpressionFields())
+	require.NoError(t, err)
+
+	assert.Equal(t, "object", got.Type)
+	assert.Equal(t, []string{"requiredTag"}, got.Required)
+	assert.Equal(t, extv1.JSONSchemaProps{Type: "integer"}, got.Properties["items"])
+	assert.Equal(t, extv1.JSONSchemaProps{Type: "string"}, got.Properties["requiredTag"])
+	assert.Equal(t, "array", got.Properties["conditions"].Type, "custom types resolve in status blocks too")
+	assert.Equal(t, []string{"status", "type"}, got.Properties["conditions"].Items.Schema.Required)
+
+	for _, field := range []string{"ready", "url", "withPipes", "kroList"} {
+		assert.Equal(t, untyped, got.Properties[field], "field %q holds an expression and must be untyped", field)
+	}
+	nested := got.Properties["nested"]
+	assert.Equal(t, "object", nested.Type)
+	assert.Equal(t, extv1.JSONSchemaProps{Type: "integer"}, nested.Properties["count"])
+	assert.Equal(t, untyped, nested.Properties["phase"], "expression handling must apply at every nesting level")
+
+	assert.Equal(t, extv1.JSONSchemaProps{Type: "string", Default: &extv1.JSON{Raw: []byte(`"${x}"`)}}, got.Properties["literalDefault"])
+	assert.Equal(t, "array", got.Properties["described"].Type)
+	assert.Equal(t, "set from ${VAR}", got.Properties["described"].Description)
+}
+
+func TestToOpenAPISpecAllowExpressionFieldsRejectsOtherLists(t *testing.T) {
+	for name, value := range map[string]any{
+		"list of type names":     []any{"string", "integer"},
+		"list with a non-string": []any{"${a}", 1},
+		"empty list":             []any{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ToOpenAPISpec(map[string]any{"f": value}, nil, AllowExpressionFields())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "field f: a list value must contain only CEL expressions")
+		})
+	}
+}
+
+// Without the option the behaviour is unchanged: an expression is not a type.
+func TestToOpenAPISpecRejectsExpressionsByDefault(t *testing.T) {
+	_, err := ToOpenAPISpec(map[string]any{"ready": "${deployment.status.readyReplicas > 0}"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field ready:")
+
+	_, err = ToOpenAPISpec(map[string]any{"conditions": []any{"${runtime.newCondition({type: 'Ready'})}"}}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field conditions: unexpected type: []interface {}")
+}
+
+// The option must not leak into custom type definitions: a "${" inside a type
+// can only be a mistake, and types are shared with the strictly-parsed spec.
+func TestToOpenAPISpecAllowExpressionFieldsKeepsCustomTypesStrict(t *testing.T) {
+	customTypes := map[string]any{
+		"Owner": map[string]any{"team": "${schema.spec.team}"},
+	}
+	_, err := ToOpenAPISpec(map[string]any{"owner": "Owner"}, customTypes, AllowExpressionFields())
+	require.Error(t, err)
+	// The expression is read as a type name: the dependency DAG rejects it as an
+	// unknown type before any schema is built.
+	assert.Contains(t, err.Error(), "${schema.spec.team}")
+}

--- a/pkg/simpleschema/simpleschema.go
+++ b/pkg/simpleschema/simpleschema.go
@@ -18,6 +18,19 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
+// Option configures ToOpenAPISpec.
+type Option func(*transformer)
+
+// AllowExpressionFields emits fields whose value is a CEL expression (a string
+// with "${" in its type position, or a list of such strings) as untyped schemas
+// with x-kubernetes-preserve-unknown-fields instead of rejecting them as unknown
+// types. Meant for RGD-style status blocks; custom types stay strictly parsed.
+func AllowExpressionFields() Option {
+	return func(t *transformer) {
+		t.allowExpressions = true
+	}
+}
+
 // ToOpenAPISpec converts a SimpleSchema object to an OpenAPI schema.
 //
 // The first input obj is a map[string]interface{} where the key is the field
@@ -26,10 +39,14 @@ import (
 // The second input customTypes is a map[string]interface{} where the key is
 // the type name and the value its specification. These custom types will be
 // available as predefined types in the transformer.
-func ToOpenAPISpec(obj map[string]any, customTypes map[string]any) (*extv1.JSONSchemaProps, error) {
+func ToOpenAPISpec(obj map[string]any, customTypes map[string]any, opts ...Option) (*extv1.JSONSchemaProps, error) {
 	t, err := newTransformer(customTypes)
 	if err != nil {
 		return nil, err
+	}
+	// Applied after the custom types are built so options only affect obj.
+	for _, opt := range opts {
+		opt(t)
 	}
 	return t.buildSchema(obj)
 }

--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -33,6 +34,10 @@ type customType struct {
 
 type transformer struct {
 	customTypes map[string]customType
+
+	// allowExpressions makes buildFieldSchema treat CEL-expression values as
+	// untyped fields instead of type names. See AllowExpressionFields.
+	allowExpressions bool
 }
 
 // newTransformer creates a new transformer with the given custom types.
@@ -169,12 +174,56 @@ func (t *transformer) buildSchema(spec map[string]any) (*extv1.JSONSchemaProps, 
 func (t *transformer) buildFieldSchema(name string, spec any, parent *extv1.JSONSchemaProps) (*extv1.JSONSchemaProps, error) {
 	switch val := spec.(type) {
 	case string:
+		// Checked before ParseField: an expression may contain '|' (e.g. "||"),
+		// which ParseField would otherwise read as the marker separator.
+		if t.allowExpressions && isExpression(val) {
+			return untypedSchema(), nil
+		}
 		return t.buildFieldFromString(name, val, parent)
 	case map[string]any:
 		return t.buildSchema(val)
+	case []any:
+		if t.allowExpressions {
+			if isExpressionList(val) {
+				return untypedSchema(), nil
+			}
+			return nil, errors.New("a list value must contain only CEL expressions")
+		}
+		return nil, fmt.Errorf("unexpected type: %T", spec)
 	default:
 		return nil, fmt.Errorf("unexpected type: %T", spec)
 	}
+}
+
+// isExpression reports whether a field value is a CEL expression (or a string
+// interpolating one) rather than a SimpleSchema type. Only the type position is
+// inspected — the text before the first '|', where ParseField reads the type —
+// so a marker whose value contains "${" (default="${x}") still yields a typed
+// field.
+func isExpression(s string) bool {
+	typ, _, _ := strings.Cut(s, "|")
+	return strings.Contains(typ, "${")
+}
+
+// isExpressionList reports whether a list value consists solely of CEL
+// expression strings, the shape of an RGD status block's `conditions:` list.
+func isExpressionList(items []any) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok || !isExpression(s) {
+			return false
+		}
+	}
+	return true
+}
+
+// untypedSchema accepts a value of any type at this position. The API server
+// permits a property without a type when it preserves unknown fields.
+func untypedSchema() *extv1.JSONSchemaProps {
+	return &extv1.JSONSchemaProps{XPreserveUnknownFields: new(true)}
 }
 
 func (t *transformer) buildFieldFromString(name, fieldValue string, parent *extv1.JSONSchemaProps) (*extv1.JSONSchemaProps, error) {

--- a/pkg/testutil/k8s/crdschema.go
+++ b/pkg/testutil/k8s/crdschema.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/generated/openapi"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/client-go/discovery/fake"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// RealCustomResourceDefinitionSchema returns the CustomResourceDefinition
+// schema in the shape kro's schema resolver produces for it: built from the
+// apiextensions-apiserver OpenAPI definitions with $refs populated, so
+// spec.versions[].schema.openAPIV3Schema is the full JSONSchemaProps object and
+// its recursive self-references are collapsed into {type: object}
+// placeholders.
+//
+// The hand-written CRD schema in NewFakeResolver is deliberately minimal and
+// has no spec.versions; tests that exercise CEL expressions inside a CRD's
+// versions block should install this schema with FakeResolver.AddSchema so the
+// compiler type-checks against the real shape.
+func RealCustomResourceDefinitionSchema() (*spec.Schema, error) {
+	sch := runtime.NewScheme()
+	if err := extv1.AddToScheme(sch); err != nil {
+		return nil, fmt.Errorf("register apiextensions/v1 types: %w", err)
+	}
+	defs := resolver.NewDefinitionsSchemaResolver(openapi.GetOpenAPIDefinitions, sch)
+	s, err := defs.ResolveSchema(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	if err != nil {
+		return nil, fmt.Errorf("resolve CustomResourceDefinition schema: %w", err)
+	}
+	return s, nil
+}
+
+// NewFakeResolverWithRealCRDSchema is NewFakeResolver with the
+// CustomResourceDefinition entry replaced by RealCustomResourceDefinitionSchema.
+func NewFakeResolverWithRealCRDSchema() (*FakeResolver, *fake.FakeDiscovery, error) {
+	res, disco := NewFakeResolver()
+	crd, err := RealCustomResourceDefinitionSchema()
+	if err != nil {
+		return nil, nil, err
+	}
+	res.AddSchema(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), crd)
+	return res, disco, nil
+}

--- a/test/integration/suites/core/crd_generated_schema_test.go
+++ b/test/integration/suites/core/crd_generated_schema_test.go
@@ -1,0 +1,353 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+	"github.com/kubernetes-sigs/kro/test/integration/environment"
+)
+
+// These specs exercise the graph-native way to define a Kind: a Graph (or an
+// RGD) templates a CustomResourceDefinition whose openAPIV3Schema is produced
+// by CEL with simpleschema.toOpenAPI() from a SimpleSchema block (spec,
+// types, status) — held in a def node for the Graph, carried by the instance
+// for the RGD. Beyond the CRD being created, the real API server must accept
+// the generated schema (structural validation on admission) and enforce it on
+// instances of the new Kind: defaults are applied, required fields and
+// validation markers are enforced.
+var _ = Describe("CRD with CEL-generated schema", func() {
+	// simpleSchemaFields is the SimpleSchema block the CRD schema is built from.
+	simpleSchemaFields := map[string]any{
+		"name":     "string | required=true",
+		"replicas": "integer | default=1 minimum=0",
+		"tags":     "[]string",
+	}
+
+	// expectGeneratedSchema asserts the CRD the controller applied carries the
+	// schema simpleschema.toOpenAPI derived from simpleSchemaFields.
+	expectGeneratedSchema := func(g Gomega, crd *apiextensionsv1.CustomResourceDefinition) {
+		g.Expect(crd.Spec.Versions).To(HaveLen(1))
+		g.Expect(crd.Spec.Versions[0].Schema).ToNot(BeNil())
+		root := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+		g.Expect(root).ToNot(BeNil())
+		g.Expect(root.Type).To(Equal("object"))
+		g.Expect(root.Properties).To(HaveKey("spec"))
+		spec := root.Properties["spec"]
+		g.Expect(spec.Type).To(Equal("object"))
+		g.Expect(spec.Required).To(Equal([]string{"name"}))
+		g.Expect(spec.Properties).To(HaveKey("name"))
+		g.Expect(spec.Properties["name"].Type).To(Equal("string"))
+		g.Expect(spec.Properties).To(HaveKey("replicas"))
+		g.Expect(spec.Properties["replicas"].Type).To(Equal("integer"))
+		g.Expect(spec.Properties["replicas"].Default).ToNot(BeNil())
+		g.Expect(string(spec.Properties["replicas"].Default.Raw)).To(Equal("1"))
+		g.Expect(spec.Properties["replicas"].Minimum).To(HaveValue(Equal(float64(0))))
+		g.Expect(spec.Properties).To(HaveKey("tags"))
+		g.Expect(spec.Properties["tags"].Type).To(Equal("array"))
+	}
+
+	// expectSchemaEnforced creates instances of the generated Kind and checks
+	// the API server applies the generated schema: defaults, required fields
+	// and the minimum marker.
+	expectSchemaEnforced := func(ctx SpecContext, gvk schema.GroupVersionKind, namespace string) {
+		newInstance := func(name string, spec map[string]any) *unstructured.Unstructured {
+			u := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+			u.SetGroupVersionKind(gvk)
+			u.SetName(name)
+			u.SetNamespace(namespace)
+			return u
+		}
+
+		By("creating an instance of the generated Kind and observing server-side defaulting")
+		valid := newInstance("valid", map[string]any{"name": "demo"})
+		Expect(env.Client.Create(ctx, valid)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			// Runs before the CRD-owning Graph/instance is torn down (LIFO), so
+			// the CRD has no custom resources left for the apiserver's
+			// customresourcecleanup finalizer to reap.
+			Expect(client.IgnoreNotFound(env.Client.Delete(ctx, valid))).To(Succeed())
+			Eventually(func(g Gomega, ctx SpecContext) {
+				err := env.Client.Get(ctx, client.ObjectKeyFromObject(valid), valid.DeepCopy())
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+		})
+		replicas, found, err := unstructured.NestedInt64(valid.Object, "spec", "replicas")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue(), "spec.replicas must be defaulted by the API server from the generated schema")
+		Expect(replicas).To(Equal(int64(1)))
+
+		By("rejecting an instance that violates the generated schema")
+		err = env.Client.Create(ctx, newInstance("missing-required", map[string]any{"replicas": int64(2)}))
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected an Invalid error, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("spec.name"))
+
+		err = env.Client.Create(ctx, newInstance("below-minimum", map[string]any{"name": "demo", "replicas": int64(-1)}))
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected an Invalid error, got: %v", err)
+		Expect(err.Error()).To(ContainSubstring("spec.replicas"))
+	}
+
+	It("Graph: templates a CRD whose openAPIV3Schema comes from simpleschema.toOpenAPI", func(ctx SpecContext) {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+
+		suffix := rand.String(5)
+		group := fmt.Sprintf("gen-%s.kro.run", suffix)
+		kind := "Widget" + strings.ToUpper(suffix[:1]) + suffix[1:]
+		plural := strings.ToLower(kind) + "s"
+		crdName := plural + "." + group
+
+		// A Graph deletion prunes the CRD it owns; the fallback keeps the shared
+		// envtest API server clean if that ever fails.
+		DeferCleanup(func(ctx SpecContext) {
+			crd := &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}}
+			_ = client.IgnoreNotFound(env.Client.Delete(ctx, crd))
+		})
+
+		g := &krov1alpha1.Graph{
+			ObjectMeta: metav1.ObjectMeta{Name: "kind-from-schema", Namespace: ns},
+			Spec: krov1alpha1.GraphSpec{
+				Nodes: []krov1alpha1.Node{
+					{
+						// The Kind's definition in SimpleSchema, the way an RGD author
+						// would write spec.schema: spec and status field maps plus the
+						// custom types they share. The remaining keys describe the CRD
+						// and are ignored by simpleschema.toOpenAPI(kindSpec).
+						ID: "kindSpec",
+						Def: environment.RawExt(t, map[string]any{
+							"group":   group,
+							"kind":    kind,
+							"plural":  plural,
+							"version": "v1alpha1",
+							"spec":    simpleSchemaFields,
+							"types": map[string]any{
+								"Condition": map[string]any{
+									"type":    "string | required=true",
+									"status":  "string | required=true",
+									"reason":  "string",
+									"message": "string",
+								},
+							},
+							"status": map[string]any{
+								"items":      "integer",
+								"conditions": "[]Condition",
+							},
+						}),
+					},
+					{
+						ID: "crd",
+						Template: environment.RawExt(t, map[string]any{
+							"apiVersion": "apiextensions.k8s.io/v1",
+							"kind":       "CustomResourceDefinition",
+							"metadata":   map[string]any{"name": "${kindSpec.plural + '.' + kindSpec.group}"},
+							"spec": map[string]any{
+								"group": "${kindSpec.group}",
+								"names": map[string]any{
+									"kind":   "${kindSpec.kind}",
+									"plural": "${kindSpec.plural}",
+								},
+								"scope": "Namespaced",
+								"versions": []any{map[string]any{
+									"name":    "${kindSpec.version}",
+									"served":  true,
+									"storage": true,
+									"subresources": map[string]any{
+										"status": map[string]any{},
+									},
+									"schema": map[string]any{
+										// Root, spec and status are all derived from the block.
+										"openAPIV3Schema": "${simpleschema.toOpenAPI(kindSpec)}",
+									},
+								}},
+							},
+						}),
+						ReadyWhen: []string{
+							`${crd.?status.?conditions.orValue([]).exists(c, c.type == 'Established' && c.status == 'True')}`,
+						},
+					},
+				},
+			},
+		}
+		env.CreateGraph(t, g)
+
+		By("waiting for the Graph to be accepted and ready")
+		key := types.NamespacedName{Namespace: ns, Name: g.Name}
+		env.AwaitCondition(t, key, krov1alpha1.GraphConditionTypeAccepted, metav1.ConditionTrue, 30*time.Second)
+		env.AwaitCondition(t, key, krov1alpha1.GraphConditionTypeReady, metav1.ConditionTrue, 60*time.Second)
+
+		By("checking the applied CRD carries the generated schema")
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: crdName}, crd)).To(Succeed())
+			g.Expect(crd.Spec.Group).To(Equal(group))
+			g.Expect(crd.Spec.Names.Kind).To(Equal(kind))
+			g.Expect(crd.Spec.Names.Plural).To(Equal(plural))
+			g.Expect(crd.Spec.Versions[0].Name).To(Equal("v1alpha1"))
+			expectGeneratedSchema(g, crd)
+
+			// The status block is converted with the same custom types as spec.
+			root := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+			g.Expect(root.Properties).To(HaveKey("status"))
+			status := root.Properties["status"]
+			g.Expect(status.Type).To(Equal("object"))
+			g.Expect(status.Properties).To(HaveKey("items"))
+			g.Expect(status.Properties["items"].Type).To(Equal("integer"))
+			g.Expect(status.Properties).To(HaveKey("conditions"))
+			g.Expect(status.Properties["conditions"].Type).To(Equal("array"))
+			g.Expect(status.Properties["conditions"].Items).ToNot(BeNil())
+			g.Expect(status.Properties["conditions"].Items.Schema.Required).To(Equal([]string{"status", "type"}))
+		}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		expectSchemaEnforced(ctx, schema.GroupVersionKind{Group: group, Version: "v1alpha1", Kind: kind}, ns)
+	})
+
+	It("RGD: an instance's SimpleSchema fields become the openAPIV3Schema of a templated CRD", func(ctx SpecContext) {
+		namespace := env.CreateNamespace(GinkgoT())
+
+		suffix := rand.String(5)
+		factoryKind := "KindFactory" + strings.ToUpper(suffix[:1]) + suffix[1:]
+		group := fmt.Sprintf("gen-%s.kro.run", suffix)
+		kind := "Gadget" + strings.ToUpper(suffix[:1]) + suffix[1:]
+		plural := strings.ToLower(kind) + "s"
+		crdName := plural + "." + group
+
+		DeferCleanup(func(ctx SpecContext) {
+			crd := &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}}
+			_ = client.IgnoreNotFound(env.Client.Delete(ctx, crd))
+		})
+
+		By("creating an RGD whose CRD resource has CEL outside metadata")
+		// The instance carries the Kind's SimpleSchema block as an opaque
+		// object; the CRD template converts it at reconcile time.
+		rgd := generator.NewResourceGraphDefinition("kind-factory-"+suffix,
+			generator.WithSchema(
+				factoryKind, "v1alpha1",
+				map[string]any{
+					"group":      "string | required=true",
+					"kind":       "string | required=true",
+					"plural":     "string | required=true",
+					"version":    "string | default=v1alpha1",
+					"definition": "object",
+				},
+				nil,
+			),
+			generator.WithResource("crd", map[string]any{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata":   map[string]any{"name": "${schema.spec.plural + '.' + schema.spec.group}"},
+				"spec": map[string]any{
+					"group": "${schema.spec.group}",
+					"names": map[string]any{
+						"kind":   "${schema.spec.kind}",
+						"plural": "${schema.spec.plural}",
+					},
+					"scope": "Namespaced",
+					"versions": []any{map[string]any{
+						"name":    "${schema.spec.version}",
+						"served":  true,
+						"storage": true,
+						"schema": map[string]any{
+							"openAPIV3Schema": "${simpleschema.toOpenAPI(schema.spec.definition)}",
+						},
+					}},
+				},
+			}, []string{
+				`${crd.?status.?conditions.orValue([]).exists(c, c.type == 'Established' && c.status == 'True')}`,
+			}, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(client.IgnoreNotFound(env.Client.Delete(ctx, rgd))).To(Succeed())
+		})
+
+		By("waiting for the RGD to become active")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			got := &krov1alpha1.ResourceGraphDefinition{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, got)).To(Succeed())
+			g.Expect(got.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("creating a factory instance that describes the new Kind in SimpleSchema")
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1",
+			"kind":       factoryKind,
+			"metadata":   map[string]any{"name": "gadget-kind", "namespace": namespace},
+			"spec": map[string]any{
+				"group":      group,
+				"kind":       kind,
+				"plural":     plural,
+				"version":    "v1alpha1",
+				"definition": map[string]any{"spec": simpleSchemaFields},
+			},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(client.IgnoreNotFound(env.Client.Delete(ctx, instance))).To(Succeed())
+			// kro finalizes the instance only once the CRD it manages is gone.
+			// Under parallel CRD churn the apiserver's customresourcecleanup
+			// finalizer can lag for tens of seconds (see unstickTerminatingCRD);
+			// the generated Kind has no instances left at this point, so clear it
+			// while waiting, then let kro drop the instance finalizer before the
+			// RGD is removed.
+			Eventually(func(g Gomega, ctx SpecContext) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				if err := env.Client.Get(ctx, types.NamespacedName{Name: crdName}, crd); err == nil &&
+					crd.DeletionTimestamp != nil && len(crd.Finalizers) == 1 &&
+					crd.Finalizers[0] == apiextensionsv1.CustomResourceCleanupFinalizer {
+					crd.Finalizers = nil
+					_ = env.Client.Update(ctx, crd) // best effort; the apiserver may win the race
+				}
+				err := env.Client.Get(ctx, types.NamespacedName{Name: instance.GetName(), Namespace: namespace}, instance.DeepCopy())
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "factory instance still present")
+			}, 60*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+		})
+
+		By("checking the CRD the instance produced carries the generated schema")
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: crdName}, crd)).To(Succeed())
+			g.Expect(crd.Spec.Group).To(Equal(group))
+			g.Expect(crd.Spec.Names.Kind).To(Equal(kind))
+			g.Expect(crd.Spec.Versions[0].Name).To(Equal("v1alpha1"))
+			expectGeneratedSchema(g, crd)
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("waiting for the instance to report the established CRD as ready")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: instance.GetName(), Namespace: namespace}, instance)).To(Succeed())
+			g.Expect(instance.Object["status"]).To(HaveKeyWithValue("state", "ACTIVE"))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		expectSchemaEnforced(ctx, schema.GroupVersionKind{Group: group, Version: "v1alpha1", Kind: kind}, namespace)
+	})
+})

--- a/website/docs/docs/concepts/rgd/04-cel-libraries.md
+++ b/website/docs/docs/concepts/rgd/04-cel-libraries.md
@@ -16,6 +16,7 @@ kro includes a rich set of CEL function libraries from three sources: kro's own 
 | Maps                        | kro        | [kro](#maps), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Maps) |
 | Index Mutation              | kro        | [kro](#index-mutation), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Lists) |
 | Omit                        | kro        | [kro](#omit), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#Omit) |
+| SimpleSchema                | kro        | [kro](#simpleschema), [Go doc](https://pkg.go.dev/github.com/kubernetes-sigs/kro/pkg/cel/library#SimpleSchema) |
 | Strings                     | cel-go     | [kro](#strings), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#Strings) |
 | Lists (cel-go)              | cel-go     | [kro](#lists-cel-go), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#Lists) |
 | Encoders                    | cel-go     | [kro](#encoders), [Go doc](https://pkg.go.dev/github.com/google/cel-go/ext#Encoders) |
@@ -160,6 +161,133 @@ nodeSelector: ${schema.spec.pinToNode ? {"kubernetes.io/hostname": schema.spec.n
 
 :::note
 `omit()` is only allowed in resource template fields. It is rejected in `includeWhen`, `readyWhen`, and `forEach` expressions.
+:::
+
+### SimpleSchema
+
+Convert kro's [SimpleSchema](../../../api/specifications/simple-schema.md) format into OpenAPI v3 JSON schema. This is the same conversion kro applies to an RGD's `spec.schema` when it generates the instance CRD, exposed so an RGD or a Graph can define a Kind itself: template a `CustomResourceDefinition` whose `openAPIV3Schema` is derived from a SimpleSchema block. CEL expressions are accepted anywhere in a CRD template, not only under `metadata`.
+
+| Function | Returns | Description |
+| --- | --- | --- |
+| `simpleschema.toOpenAPI(schema)` | `dyn` (map) | Convert an RGD-style schema block (a map with the optional keys `spec`, `types` and `status`) into the root `openAPIV3Schema` of a CRD: `{type: object, properties: {apiVersion, kind, metadata, spec: <converted spec>, status: <converted status>}}`. |
+
+`spec` and `status` are SimpleSchema field maps (field name → type expression such as `string | required=true`, or a nested map for an inline object), both resolved against the custom types in `types`; an absent block yields `{type: object}`. Other keys in the block (`apiVersion`, `kind`, `group`, `scope`, `additionalPrinterColumns`, ...) describe the CRD rather than its schema and are ignored, so an RGD's `spec.schema` can be passed as-is. A status field whose value is a CEL expression — a string with `${` in its type position, or a list of such strings like kro's `status.conditions` block — cannot be typed by the function (its type depends on the resources it references, which only kro's RGD controller can resolve against the cluster) and is emitted as `{x-kubernetes-preserve-unknown-fields: true}`, which accepts whatever the expression evaluates to. kro's default instance status fields (`state`, `conditions`) are not injected: declare them in the status block when you need them.
+
+The result is a regular CEL map: each converted block has `type: "object"`, a `properties` map with one entry per field, and a sorted `required` list; markers become their OpenAPI counterparts (`default`, `enum`, `x-kubernetes-validations`, ...). Integral numbers (`default=3`, `minimum=1`, ...) come back as `int`, so the value can be placed directly into a resource template or serialized with `json.marshal()`. Conversion errors (unknown types, unknown markers, cyclic custom types, non-string map keys) fail the expression with a message naming the function and the block (`spec:`, `types:` or `status:`).
+
+**Examples:**
+
+```kro
+# {"type": "object", "properties": {"apiVersion": {"type": "string"}, "kind": {"type": "string"}, "metadata": {"type": "object"},
+#   "spec": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+#   "status": {"type": "object"}}}
+openAPIV3Schema: ${simpleschema.toOpenAPI({"spec": {"name": "string | required=true"}})}
+
+# Whole CRD schema from an RGD-style block held in a def: node (see below)
+openAPIV3Schema: ${simpleschema.toOpenAPI(kindSpec)}
+
+# Whole CRD schema from an RGD read into the Graph via ref:, adding kro's
+# default status fields the RGD controller would inject. deepMerge replaces the
+# RGD's expression-valued conditions list with a typed declaration.
+openAPIV3Schema: ${simpleschema.toOpenAPI(rgd.spec.schema.deepMerge({"status": {"state": "string", "conditions": "[]KroCondition"}, "types": {"KroCondition": {"type": "string", "status": "string", "reason": "string", "message": "string", "lastTransitionTime": "string", "observedGeneration": "integer"}}}))}
+
+# Only the spec sub-schema, to compose a root by hand
+spec: ${simpleschema.toOpenAPI(kindSpec).properties.spec}
+
+# Store a generated schema as JSON
+data:
+  openapi: ${json.marshal(simpleschema.toOpenAPI(rgd.spec.schema))}
+```
+
+A Graph (the alpha `kro.run/v1alpha1` `Graph` kind, behind the `GraphKind` feature gate) that defines a Kind — the block is written the way an RGD author writes `spec.schema`, and the CRD's names and versions come from the same `def:`:
+
+```yaml
+- id: kindSpec
+  def:
+    group: example.com
+    kind: Widget
+    plural: widgets
+    types:
+      Condition:
+        type: string | required=true
+        status: string | required=true
+        reason: string
+        message: string
+    spec:
+      name: string | required=true
+      replicas: integer | default=1 minimum=0
+    status:
+      items: integer
+      conditions: "[]Condition"
+- id: crd
+  template:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ${kindSpec.plural + '.' + kindSpec.group}
+    spec:
+      group: ${kindSpec.group}
+      names:
+        kind: ${kindSpec.kind}
+        plural: ${kindSpec.plural}
+      scope: Namespaced
+      versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+          subresources:
+            status: {}
+          schema:
+            openAPIV3Schema: ${simpleschema.toOpenAPI(kindSpec)}
+  readyWhen:
+    - ${crd.?status.?conditions.orValue([]).exists(c, c.type == 'Established' && c.status == 'True')}
+```
+
+Instances of `Widget` get `replicas` defaulted and `name` enforced by the API server. The same works in an RGD whose instances each describe a new Kind and carry its schema block as an opaque `object`:
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: kind-factory
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: KindFactory
+    spec:
+      group: string | required=true
+      kind: string | required=true
+      plural: string | required=true
+      definition: object   # {spec: {...}, types: {...}, status: {...}}
+  resources:
+    - id: crd
+      readyWhen:
+        - ${crd.?status.?conditions.orValue([]).exists(c, c.type == 'Established' && c.status == 'True')}
+      template:
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        metadata:
+          name: ${schema.spec.plural + '.' + schema.spec.group}
+        spec:
+          group: ${schema.spec.group}
+          names:
+            kind: ${schema.spec.kind}
+            plural: ${schema.spec.plural}
+          scope: Namespaced
+          versions:
+            - name: v1alpha1
+              served: true
+              storage: true
+              subresources:
+                status: {}
+              schema:
+                openAPIV3Schema: ${simpleschema.toOpenAPI(schema.spec.definition)}
+```
+
+Expressions in CRD templates are type-checked against the CRD schema where their path resolves (`spec.group` must be a string, ...). The `openAPIV3Schema` field is typed as `JSONSchemaProps`; the function result is `dyn` and always assignable, but a schema composed by hand must be dyn-valued too — a map literal whose values are all strings (`${{"type": "object"}}`) has type `map(string, string)` and is rejected, and so is an OpenAPI schema held as a typed `def:` value; wrap either in `dyn(...)`.
+
+:::note
+A non-empty block must contain at least one of `spec`, `types` or `status`, or one of the CRD-describing keys above. A bare field map (`toOpenAPI({"name": "string"})`) is rejected rather than silently converting to an empty spec — wrap it as `{"spec": {...}}`.
 :::
 
 ### Runtime


### PR DESCRIPTION
## Summary

Lets a Graph (or an RGD) define a Kubernetes Kind graph-natively: template a `CustomResourceDefinition` whose `openAPIV3Schema` is synthesized from a kro SimpleSchema block. Two commits:

1. **`feat(graph): allow CEL anywhere in CustomResourceDefinition templates`** — removes the incidental `metadata.*`-only restriction on CEL expressions in `CustomResourceDefinition` templates in both engines.
2. **`feat(cel): add simpleschema.toOpenAPI CEL function`** — `simpleschema.toOpenAPI(schema) -> dyn`, which converts an RGD-style schema block (`spec`, `types`, `status`) into the complete root `openAPIV3Schema` of a CRD, using the same SimpleSchema → OpenAPI conversion the RGD controller applies to instance CRDs.

This is the first of the pieces the KREP-024 north-star example (`examples/graph/rgd.yaml`) lists as missing for implementing the RGD controller as a Graph; the example's L1 CRD now uses the function and its header lists only `plural()` as the remaining missing CEL function.

## Motivation

KREP-024 aims to implement the RGD controller itself as a Graph (L0 → per-RGD L1 → per-instance L2). At L1 the Graph has to create the user Kind's CRD, which requires translating SimpleSchema into OpenAPI. The Go code existed (`pkg/simpleschema.ToOpenAPISpec`, used by `pkg/graph/builder.go`) but was not reachable from CEL, and even once it was, CRD templates rejected any expression outside `metadata.*`.

## `simpleschema.toOpenAPI(schema)`

Takes an RGD-style schema block — a map with the optional keys `spec`, `types` and `status` (the shape of `ResourceGraphDefinition.spec.schema`, or of a Kind definition held in a `def:` node) — and returns the root `openAPIV3Schema` of a CRD: `apiVersion`/`kind`/`metadata` plus `spec` and `status` converted from SimpleSchema against the shared custom `types`. Other keys in the block (`group`, `kind`, `scope`, ...) are ignored, so `rgd.spec.schema` can be passed as-is (including the schema of an RGD that declares no `spec`/`types`/`status`); a non-empty block with none of those keys is rejected as a bare field map. A status field whose value is a CEL expression (`${` in the type position — a marker such as `default="${x}"` does not count — or a list of expressions like kro's `status.conditions`) cannot be typed by the function and is emitted as `x-kubernetes-preserve-unknown-fields: true`; kro's default `state`/`conditions` status fields are not injected. Status is handled this way because an expression's type depends on the referenced resources' schemas, which only the RGD controller can resolve against the cluster, so a Kind defined this way gets a weaker status schema than the RGD controller produces. Errors name the function and the block (`types:`/`spec:`/`status:`).

A Graph that defines a `Widget` Kind:

```yaml
apiVersion: kro.run/v1alpha1
kind: Graph
metadata:
  name: widget-kind
spec:
  nodes:
    - id: kindSpec
      def:
        group: example.com
        kind: Widget
        plural: widgets
        types:
          Condition:
            type: string | required=true
            status: string | required=true
            reason: string
        spec:
          name: string | required=true
          replicas: integer | default=1 minimum=0
          tags: "[]string"
        status:
          items: integer
          conditions: "[]Condition"
    - id: crd
      template:
        apiVersion: apiextensions.k8s.io/v1
        kind: CustomResourceDefinition
        metadata:
          name: ${kindSpec.plural + '.' + kindSpec.group}
        spec:
          group: ${kindSpec.group}
          names:
            kind: ${kindSpec.kind}
            plural: ${kindSpec.plural}
          scope: Namespaced
          versions:
            - name: v1alpha1
              served: true
              storage: true
              subresources:
                status: {}
              schema:
                openAPIV3Schema: ${simpleschema.toOpenAPI(kindSpec)}
      readyWhen:
        - ${crd.?status.?conditions.orValue([]).exists(c, c.type == 'Established' && c.status == 'True')}
```

renders this `openAPIV3Schema` (verified output; the API server establishes the CRD, defaults `spec.replicas` and enforces `spec.name` on `Widget` instances):

```yaml
type: object
properties:
  apiVersion:
    type: string
  kind:
    type: string
  metadata:
    type: object
  spec:
    type: object
    required:
      - name
    properties:
      name:
        type: string
      replicas:
        type: integer
        default: 1
        minimum: 0
      tags:
        type: array
        items:
          type: string
  status:
    type: object
    properties:
      items:
        type: integer
      conditions:
        type: array
        items:
          type: object
          required:
            - status
            - type
          properties:
            type:
              type: string
            status:
              type: string
            reason:
              type: string
```

## CEL anywhere in CRD templates

**Why the restriction existed.** CRDs have always been parsed schemalessly; before #840 any CEL in a CRD template was rejected outright. #840 needed a dynamic `metadata.name` and relaxed that to `metadata.*` only; no technical reason for the `metadata.` limit is recorded. CRDs genuinely need the schemaless parser: the apiextensions OpenAPI document models `openAPIV3Schema` as the recursive `JSONSchemaProps` type and the resolver's `PopulateRefs` collapses each self-reference into a bare `{type: object}` placeholder, so the typed parser cannot walk a user's nested `properties`/`items` and would reject any CRD carrying a real schema. But the schemaless parser already extracts expressions from every path; the `metadata.` filter was conservative scoping on top.

**Why dropping it is safe.** The expected type of each expression comes from the node's OpenAPI schema (`expectedTypeForField`), not from the parser. Verified against the *real* apiextensions CRD schema (the test fake had no `spec.versions`): `spec.group: ${1 + 1}` is still rejected as int-vs-string; the `openAPIV3Schema` field is typed as `JSONSchemaProps`, so a map placed there must be dyn-valued — the function result is, while a hand-written homogeneous literal `${{"type": "object"}}` (`map(string, string)`) or an OpenAPI schema held as a typed `def:` value is rejected and `dyn({...})` accepted (documented and pinned). Expressions nested inside a static schema resolve to the resolver's collapsed `{type: object}` placeholder and are effectively `dyn`.

## Behaviour changes and compatibility

- The function is purely additive (one new global function). `pkg/simpleschema.ToOpenAPISpec` gains a variadic options parameter (`AllowExpressionFields()`, used for the status walk only), source-compatible for callers.
- The CRD change is strictly backwards compatible: every CRD template that compiled before (static CRDs, CEL under `metadata.*`) compiles unchanged on both engines and renders identically on the graph-engine runtime — pinned by explicit tests. The only observable change is that templates previously rejected at RGD accept / Graph compile time with "CEL expressions in CRDs are only supported for metadata fields" are now accepted, subject to the same type-checking every other resource gets. That error message no longer exists.
- The two existing tests that pinned the old guard (both in `pkg/graph/builder_test.go`) were flipped to assert the new behaviour: `TestGraphBuilder_Validation/"crds aren't allowed to have variables in their spec fields"` → `"crds may use CEL expressions in spec fields"` and `TestBuildRGResourceErrorPaths/"crd only allows metadata expressions"` → `"crd extracts expressions outside metadata"`. The graph-engine compiler had no test pinning the guard; `TestCompile_CRDTemplateExpressions` adds that coverage.
- No `go.mod` changes; `cmd/kro` (pins kro v0.9.3) unaffected.
