### PR TITLE
fix(graphengine): retry transient collection update failures instead of tolerating them

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -177,15 +177,14 @@ func NewController(
 		})
 	}
 	// Surface a tolerated collection-update rejection (an already-existing item
-	// whose SSA update was rejected — e.g. an immutable field — that we keep-live
-	// and converge on) as a Warning Event on the affected CHILD object, so the
-	// dropped desired change is visible in `kubectl describe` and not just the
-	// controller log. Observational only: this hook never influences readiness or
-	// requeue (the node still converges), so it cannot reintroduce the wedge an
-	// unfixable update would otherwise cause. Set at construction (not per
-	// reconcile) because the executor is shared across concurrent reconcile
-	// workers; the event subject is derived from the rejection's own target
-	// identity rather than any per-reconcile instance state.
+	// whose SSA update was permanently rejected — e.g. an immutable field — that
+	// we keep-live and converge on) as a Warning Event on the affected CHILD
+	// object, so the dropped desired change is visible in `kubectl describe`.
+	// Observational only: the hook never influences readiness or requeue.
+	// Transient failures never reach it (they hold the node not-ready and their
+	// cause is on the ResourcesReady condition). Set at construction because the
+	// executor is shared across concurrent reconcile workers; the event subject
+	// is derived from the rejection's own target identity.
 	if eventRecorder != nil {
 		exec.OnToleratedRejection = func(r executor.ToleratedRejection) {
 			ref := &corev1.ObjectReference{

--- a/pkg/graphengine/executor/apply_template_test.go
+++ b/pkg/graphengine/executor/apply_template_test.go
@@ -207,12 +207,11 @@ func TestSimple_ApplyTemplate_WatchRegistrationFailureIsSoftFail(t *testing.T) {
 func TestSimple_ApplyTemplate_CollectionApplyTolerance(t *testing.T) {
 	t.Parallel()
 
-	t.Run("a rejected update conflict on an existing object records the live identity", func(t *testing.T) {
+	t.Run("a transiently rejected update on an existing object keeps the live identity but holds the node not-ready", func(t *testing.T) {
 		t.Parallel()
-		// Both members already exist, so every SSA is an update. A rejected
-		// update due to field-manager conflict must not block the node forever:
-		// the objects are in the cluster, so their identities are recorded and
-		// the node converges.
+		// Both members already exist, so every SSA is an update. A 409 is not
+		// proven permanent: the identities stay tracked but the node is held soft
+		// not-ready and retried rather than reported converged.
 		base := fake.NewClientBuilder().WithScheme(newScheme(t)).
 			WithObjects(liveCM("cm-alpha"), liveCM("cm-beta")).Build()
 		cl := &patchFailClient{Client: base, err: apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "cm-alpha", errors.New("field manager conflict"))}
@@ -220,20 +219,19 @@ func TestSimple_ApplyTemplate_CollectionApplyTolerance(t *testing.T) {
 		res, err := NewSimple(cl).Apply(context.Background(),
 			compileAndBuild(t, collectionCMGraph()), watchrouter.NoopWatcher{})
 
-		require.NoError(t, err,
-			"a tolerated update conflict on objects that exist must not hold the node not-ready")
-		// The per-item error is dropped by design (see recordUpdateRejected): a
-		// tolerated update-rejection is silent — the object is present, so the
-		// node converges and the underlying conflict is NOT surfaced as any
-		// returned error. (This pins the corrected comment: the rejection is not
-		// escalated to a hard error, and — the RGD path having no per-node
-		// condition message for a converged node — it is not surfaced at all.)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotReady),
+			"a transient update rejection must hold the node soft not-ready so it is retried, got %v", err)
+		assert.Contains(t, err.Error(), "field manager conflict",
+			"the underlying cause must reach the condition message")
+		assert.Contains(t, res.Unresolved, "cm",
+			"a not-ready node must be reported Unresolved so prune is withheld")
 		names := make([]string, 0, len(res.Applied))
 		for _, a := range res.Applied {
 			names = append(names, a.Name)
 		}
 		assert.ElementsMatch(t, []string{"cm-alpha", "cm-beta"}, names,
-			"existing objects keep their tracked identities")
+			"existing objects keep their tracked identities so they are never pruned")
 	})
 
 	t.Run("a permanent update rejection on an existing object is tolerated", func(t *testing.T) {
@@ -302,14 +300,10 @@ func TestSimple_ApplyTemplate_CollectionApplyTolerance(t *testing.T) {
 	})
 }
 
-// TestCollectionApplyState_UpdateRejectedIsSilent pins the corrected contract
-// behind the FINDING-1 comment fix: recordUpdateRejected records the live
-// identity (so the item lands in Applied) but records NO item failure and NO
-// hard error — the tolerated update-rejection is intentionally silent and is
-// NOT surfaced as any returned error. The old comment claimed the per-item
-// error was "surfaced in the node's condition message", which was false; this
-// test guards against that false claim creeping back in as behavior (e.g. a
-// well-meaning change that starts returning the dropped error).
+// TestCollectionApplyState_UpdateRejectedIsSilent pins the permanent tolerate
+// path: recordUpdateRejected tracks the live identity but records neither an
+// item failure nor a hard error, so the node converges silently (the hook / log
+// line is the only signal).
 func TestCollectionApplyState_UpdateRejectedIsSilent(t *testing.T) {
 	t.Parallel()
 
@@ -502,8 +496,8 @@ func TestSimple_ApplyTemplate_LargeCollectionTolerance(t *testing.T) {
 	t.Parallel()
 
 	const count = 60
-	// 00..09: pre-existing, fail on update (tolerated, live recorded)
-	// 10..19: absent, fail on create (tolerated, recorded in itemFailures, soft ErrNotReady)
+	// 00..09: pre-existing, fail on update with a 409 (live identity recorded, node held soft ErrNotReady)
+	// 10..19: absent, fail on create (recorded in itemFailures, soft ErrNotReady)
 	// 20..59: absent, succeed on create (applied)
 
 	seeded := make([]client.Object, 0, 10)
@@ -531,11 +525,14 @@ func TestSimple_ApplyTemplate_LargeCollectionTolerance(t *testing.T) {
 		compileAndBuild(t, largeCollectionGraph(count)), watchrouter.NoopWatcher{})
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrNotReady), "failing creates must produce soft ErrNotReady")
-	assert.Contains(t, err.Error(), "10 item(s) failed to apply")
+	assert.True(t, errors.Is(err, ErrNotReady), "failing creates and transient update failures must produce soft ErrNotReady")
+	assert.Contains(t, err.Error(), "20 item(s) failed to apply",
+		"both the 10 transient update failures and the 10 failed creates are reported")
 	assert.Contains(t, err.Error(), "quota exceeded")
+	assert.Contains(t, err.Error(), "field manager conflict",
+		"a transient update failure's cause must reach the condition message")
 
-	// 10 existing + 40 newly created = 50 items tracked in Applied
+	// 10 existing (rejected update, still tracked) + 40 newly created = 50 items tracked in Applied
 	assert.Len(t, res.Applied, 50)
 
 	appliedNames := make(map[string]bool, len(res.Applied))
@@ -545,7 +542,7 @@ func TestSimple_ApplyTemplate_LargeCollectionTolerance(t *testing.T) {
 
 	for i := range 10 {
 		name := fmt.Sprintf("cm-item-%02d", i)
-		assert.True(t, appliedNames[name], "pre-existing item with rejected update must be in Applied: %s", name)
+		assert.True(t, appliedNames[name], "pre-existing item with transiently rejected update must stay in Applied (never pruned): %s", name)
 	}
 	for i := 10; i < 20; i++ {
 		name := fmt.Sprintf("cm-item-%02d", i)
@@ -628,9 +625,9 @@ func TestSimple_ApplyTemplate_CollectionHardErrors(t *testing.T) {
 		)
 
 		// All three items already exist; two of their updates are permanently
-		// rejected (Invalid / Forbidden immutable-field updates). By design these
-		// are tolerated on existing objects: the live identities are recorded and
-		// the collection converges rather than aborting the walk.
+		// rejected (Invalid and BadRequest). By design these are tolerated on
+		// existing objects: the live identities are recorded and the collection
+		// converges rather than aborting the walk.
 		base := fake.NewClientBuilder().WithScheme(newScheme(t)).
 			WithObjects(liveCM("cm-0"), liveCM("cm-1"), liveCM("cm-2")).Build()
 		cl := &concurrencyTrackingClient{
@@ -641,7 +638,7 @@ func TestSimple_ApplyTemplate_CollectionHardErrors(t *testing.T) {
 					return apierrors.NewInvalid(schema.GroupKind{Kind: "ConfigMap"}, "cm-0", nil)
 				}
 				if name == "cm-2" {
-					return apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "cm-2", errors.New("forbidden mutation"))
+					return apierrors.NewBadRequest("malformed update for cm-2")
 				}
 				return nil
 			},

--- a/pkg/graphengine/executor/executor.go
+++ b/pkg/graphengine/executor/executor.go
@@ -128,12 +128,12 @@ type Contribution struct {
 }
 
 // ToleratedRejection describes a collection item whose server-side-apply UPDATE
-// was rejected on an ALREADY-EXISTING object and tolerated: the live object is
-// kept and the node still converges (so an unfixable update — e.g. an immutable
-// field — does not wedge the instance forever). The desired change did NOT land,
-// so this is surfaced as an observational signal (log + optional Warning event
-// via Simple.OnToleratedRejection) WITHOUT affecting readiness gating or
-// requeue — flipping those would reintroduce the wedge.
+// was permanently rejected (Invalid/BadRequest, e.g. an immutable field) on an
+// ALREADY-EXISTING object and tolerated: the live object is kept and the node
+// still converges so an unfixable update does not wedge the instance. It is an
+// observational signal (log + optional Warning event via
+// Simple.OnToleratedRejection) and must not affect readiness or requeue.
+// Transient failures are retried, not tolerated, and never produce it.
 type ToleratedRejection struct {
 	NodeID     string // fully-qualified node path
 	APIVersion string // target apiVersion ("apps/v1", "v1", ...)
@@ -141,15 +141,8 @@ type ToleratedRejection struct {
 	Namespace  string
 	Name       string
 	// Reason is a short operator-facing classification of WHY the update was
-	// rejected (e.g. "field immutable", "invalid request", or a transient cause
-	// that will be retried on a later reconcile). Derived from the typed API
-	// error, since a permanent immutable-field rejection and a transient one are
-	// not distinguishable by outcome here (both keep the live object).
+	// rejected (e.g. "field immutable", "invalid request").
 	Reason string
-	// Permanent is true when the rejection cannot succeed by retrying the same
-	// payload (Invalid/BadRequest); false for transient causes that a later
-	// reconcile may resolve.
-	Permanent bool
 	// Cause is the raw API error string, for the log/event detail.
 	Cause string
 }

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -112,13 +112,12 @@ type Simple struct {
 	// remains as a backstop.
 	identityClaims *identityClaimSet
 	// OnToleratedRejection, when non-nil, is invoked for each collection item
-	// whose UPDATE was rejected on an already-existing object and tolerated
-	// (the live object is kept and the node still converges). It is a purely
-	// OBSERVATIONAL hook — it must not influence readiness or requeue, or the
-	// anti-wedge tolerance would be lost. The instance controller wires it to an
-	// event recorder (Warning event); the Graph controller leaves it nil
-	// (log-only, it has no recorder). Called from parallel apply goroutines, so
-	// the implementation must be safe for concurrent use (an EventRecorder is).
+	// whose UPDATE was permanently rejected (Invalid/BadRequest) on an
+	// already-existing object and tolerated (live object kept, node converges).
+	// Transient failures are retried, not tolerated, and never reach it. Purely
+	// OBSERVATIONAL — it must not influence readiness or requeue. The instance
+	// controller wires it to an event recorder; the Graph controller leaves it
+	// nil. Called from parallel apply goroutines, so it must be concurrency-safe.
 	OnToleratedRejection func(ToleratedRejection)
 }
 
@@ -605,13 +604,11 @@ var errSchemaNotReady = errors.New("executor: target GVK not yet known to the cl
 // read-only and handled by applyRef/applyRefCollection, not here).
 //
 // Collection nodes apply each item INDEPENDENTLY and tolerate per-item SSA
-// failures: a failure to
-// UPDATE an already-present item (e.g. an immutable field) does not abort
-// the node — the live object is recorded as applied so tracking/prune stay
-// correct and the node can still converge. A failure to CREATE an item that
-// is not yet present marks the node soft not-ready so downstream gates and
-// the reconcile requeues. A scalar node still returns an SSA error as a hard
-// error, unchanged.
+// failures: a permanent (Invalid/BadRequest) rejection of an UPDATE to an
+// already-present item records the live object as applied and the node still
+// converges; a transient one keeps the live object tracked but holds the node
+// soft not-ready so it is retried; a failed CREATE holds the node soft
+// not-ready. A scalar node still returns an SSA error as a hard error.
 func (s *Simple) applyTemplate(ctx context.Context, rt *runtime.Runtime, w watchrouter.Watcher, n *runtime.Node, desired []*unstructured.Unstructured) ([]expv1alpha1.ManagedResource, error) {
 	mappings, err := s.buildMappings(n, desired)
 	if err != nil {
@@ -785,16 +782,13 @@ func (st *collectionApplyState) recordApplied(i int, mr expv1alpha1.ManagedResou
 	st.mu.Unlock()
 }
 
-// classifyRejection turns a tolerated collection-update rejection into a short
-// operator-facing reason and a permanent/transient flag. A permanent rejection
-// (Invalid/BadRequest) cannot succeed by retrying the same payload; an Invalid
-// whose status causes name an immutable field is reported specifically so the
-// operator sees WHY the desired change never landed. Transient causes
-// (Conflict, timeouts, throttling, unavailability) are retried on a later
-// reconcile, so they are flagged non-permanent. This is best-effort: a webhook
-// Forbidden or a CEL-validation Invalid that depends on other mutable cluster
-// state cannot be perfectly classified by error code, which is exactly why the
-// node converges and merely SURFACES the rejection rather than gating on it.
+// classifyRejection maps a rejected UPDATE of an already-existing collection
+// item to an operator-facing reason and whether retrying the same payload can
+// never succeed. "Permanent" is kept narrow (Invalid/BadRequest): misreading a
+// transient cause as permanent tolerates a stale member as converged, while the
+// reverse only costs a visible retry. Hence a 400-coded webhook denial (the
+// apiserver default when the webhook sets no code) or a 422
+// ValidatingAdmissionPolicy Invalid is tolerated; a 403-coded denial is retried.
 func classifyRejection(err error) (reason string, permanent bool) {
 	switch {
 	case apierrors.IsInvalid(err):
@@ -838,9 +832,9 @@ func isImmutableFieldError(err error) bool {
 	return false
 }
 
-// recordUpdateRejected records a tolerated per-item UPDATE failure on an
-// already-present object: the live identity is tracked and the desired slot is
-// replaced with the live object so downstream scope sees what actually landed.
+// recordUpdateRejected records a tolerated permanent per-item UPDATE rejection
+// on an already-present object: the live identity is tracked and the desired
+// slot is replaced with the live object so downstream scope sees what landed.
 func (st *collectionApplyState) recordUpdateRejected(i int, mr expv1alpha1.ManagedResource, desired []*unstructured.Unstructured, current *unstructured.Unstructured) {
 	st.mu.Lock()
 	st.results[i] = &mr
@@ -910,9 +904,11 @@ func (st *collectionApplyState) softError(nodeID string) error {
 // parallelism. It registers ONE selector watch for the whole node up front,
 // then applies each item independently, tolerating per-item failures: a
 // rejected UPDATE on an already-present item records the live identity and
-// converges; a failed CREATE holds the node soft not-ready; a terminating item
-// gates the node. Hard errors (bad GET, namespace, applyset conflict, permanent
-// validation rejection) abort and are deterministically joined by item index.
+// converges only when the rejection is permanent; a failed CREATE (or a
+// transiently rejected UPDATE) holds the node soft not-ready; a terminating
+// item gates the node. Hard errors (bad GET, namespace, applyset conflict,
+// permanent validation rejection of a CREATE) abort and are deterministically
+// joined by item index.
 func (s *Simple) applyCollectionTemplate(ctx context.Context, w watchrouter.Watcher, rt *runtime.Runtime, n *runtime.Node, desired []*unstructured.Unstructured, mappings []applyMapping) ([]expv1alpha1.ManagedResource, error) {
 	if len(desired) == 0 {
 		return []expv1alpha1.ManagedResource{}, nil
@@ -982,8 +978,8 @@ func (s *Simple) applyCollectionTemplate(ctx context.Context, w watchrouter.Watc
 	if deletingErr := st.deletingError(); deletingErr != nil {
 		return st.appliedResources(), deletingErr
 	}
-	// Any create failure holds the collection soft not-ready so downstream
-	// gates and the reconcile requeues (never a hard abort).
+	// Item failures (failed creates, transiently rejected updates) hold the
+	// collection soft not-ready so downstream gates and the reconcile requeues.
 	if softErr := st.softError(n.ID()); softErr != nil {
 		return st.appliedResources(), softErr
 	}
@@ -1049,30 +1045,33 @@ func (s *Simple) applyCollectionItem(ctx context.Context, rt *runtime.Runtime, n
 			return nil
 		}
 		if current != nil {
-			// The object already exists; only the UPDATE was rejected. This is
-			// tolerated BY DESIGN, including permanent rejections such as a
-			// Kubernetes immutable-field update (`Forbidden: pod updates may not
-			// change fields ...`): the object is present in the cluster, so record
-			// the live identity and let the collection converge rather than block
-			// the node forever on an unfixable update. (Integration coverage:
-			// collection_test.go deep-chaining scale up/down relies on this.)
-			//
-			// The rejection is NOT escalated to a hard error or a soft not-ready
-			// (that would wedge the node on an unfixable update), but it must not
-			// be fully SILENT either: a desired change did not land while the node
-			// still converges. Emit a warning to the controller log AND, when the
-			// caller wired OnToleratedRejection, an observational signal (the
-			// instance controller records a Warning event) classifying WHY — so a
-			// stale live object is diagnosable in `kubectl describe`, not just in
-			// logs. The signal is observational ONLY: it never touches readiness
-			// gating or requeue, or the anti-wedge tolerance would be lost.
+			// The object exists; only the UPDATE was rejected. A permanent
+			// rejection (Invalid/BadRequest, e.g. an immutable field) is tolerated
+			// so one unfixable member cannot wedge the node: record the live
+			// identity, converge, and surface the dropped change via the log and
+			// OnToleratedRejection (observational only). Anything else keeps the
+			// live identity tracked but is an ordinary item failure, so the node is
+			// held not-ready and the update retried — treating it as converged
+			// would leave the member stale with nothing requeued.
 			reason, permanent := classifyRejection(err)
-			log.FromContext(ctx).Info("collection item update rejected; keeping live object and converging (desired change did not land)",
+			if !permanent {
+				log.FromContext(ctx).Info("collection item update rejected; keeping live object tracked and holding the node not-ready, will retry",
+					"node", s.qualifiedPath(n.ID()),
+					"object", obj.GetNamespace()+"/"+obj.GetName(),
+					"gvk", obj.GroupVersionKind().String(),
+					"reason", reason,
+					"cause", err.Error())
+				// desired[i] is left alone: a not-ready node never publishes scope,
+				// so there is no downstream reader to show the live object to.
+				st.recordApplied(i, managedResourceFrom(n, current))
+				st.recordFailure(i, fmt.Errorf("item %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
+				return nil
+			}
+			log.FromContext(ctx).Info("collection item update rejected permanently; keeping live object and converging (desired change did not land)",
 				"node", s.qualifiedPath(n.ID()),
 				"object", obj.GetNamespace()+"/"+obj.GetName(),
 				"gvk", obj.GroupVersionKind().String(),
 				"reason", reason,
-				"permanent", permanent,
 				"cause", err.Error())
 			if s.OnToleratedRejection != nil {
 				gvk := obj.GroupVersionKind()
@@ -1083,7 +1082,6 @@ func (s *Simple) applyCollectionItem(ctx context.Context, rt *runtime.Runtime, n
 					Namespace:  obj.GetNamespace(),
 					Name:       obj.GetName(),
 					Reason:     reason,
-					Permanent:  permanent,
 					Cause:      err.Error(),
 				})
 			}

--- a/pkg/graphengine/executor/tolerated_rejection_test.go
+++ b/pkg/graphengine/executor/tolerated_rejection_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,8 +26,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/watchrouter"
 )
 
@@ -110,7 +114,6 @@ func TestApply_OnToleratedRejectionHookFires(t *testing.T) {
 		assert.Equal(t, "ConfigMap", r.Kind)
 		assert.Equal(t, "default", r.Namespace)
 		assert.Equal(t, "field immutable", r.Reason)
-		assert.True(t, r.Permanent, "an immutable-field rejection is permanent")
 		assert.Contains(t, r.Cause, "immutable")
 	}
 }
@@ -127,4 +130,194 @@ func TestApply_NoHookWhenNil(t *testing.T) {
 	_, err := s.Apply(context.Background(),
 		compileAndBuild(t, collectionCMGraph()), watchrouter.NoopWatcher{})
 	require.NoError(t, err, "a nil hook must be a safe no-op")
+}
+
+// collectionCMGraphWithDependent is collectionCMGraph plus a scalar node "dep"
+// that reads the collection, so a test can observe whether the collection node
+// reached ready (dep applied) or was held not-ready (dep gated).
+func collectionCMGraphWithDependent() *expv1alpha1.Graph {
+	return generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithDef("src", map[string]any{"names": []any{"alpha", "beta"}}),
+		generator.WithTemplate("cm", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "${'cm-' + n}"},
+			"data":     map[string]any{"k": "new"},
+		}, generator.ForEachDim("n", "${src.names}")),
+		generator.WithTemplate("dep", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "dep"},
+			"data":     map[string]any{"count": "${string(size(cm))}"},
+		}),
+	)
+}
+
+// failOnlyClient fails SSA for the named object only and delegates every other
+// patch.
+type failOnlyClient struct {
+	client.Client
+	name string
+	err  error
+}
+
+func (f *failOnlyClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if obj.GetName() == f.name {
+		return f.err
+	}
+	return f.Client.Patch(ctx, obj, patch, opts...)
+}
+
+// appliedNames projects the names in an ApplyResult.Applied inventory.
+func appliedNames(res ApplyResult) []string {
+	names := make([]string, 0, len(res.Applied))
+	for _, a := range res.Applied {
+		names = append(names, a.Name)
+	}
+	return names
+}
+
+// TestApply_TransientUpdateRejectionHoldsNodeNotReady: a rejection of an UPDATE
+// to an already-existing member that classifyRejection cannot prove permanent
+// keeps the live identity tracked but is not converged — Apply returns
+// ErrNotReady with the cause, the node is Unresolved, dependents gate, and the
+// observational hook does not fire. One row per transient class.
+func TestApply_TransientUpdateRejectionHoldsNodeNotReady(t *testing.T) {
+	t.Parallel()
+
+	webhookDown := apierrors.NewInternalError(errors.New(
+		`failed calling webhook "block.example.com": failed to call webhook: service "does-not-exist" not found`))
+
+	tests := []struct {
+		name  string
+		err   error
+		cause string // must reach the returned error (and so the condition message)
+	}{
+		{"internal error (webhook backend unreachable)", webhookDown, "failed calling webhook"},
+		{"throttled", apierrors.NewTooManyRequestsError("slow down"), "slow down"},
+		{"conflict", apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "cm-alpha", errors.New("resource version mismatch")), "resource version mismatch"},
+		{"forbidden (a denial is not proven permanent)", apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "cm-alpha", errors.New("denied by policy")), "denied by policy"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Both members exist, so every SSA is an UPDATE; only cm-alpha's fails.
+			base := fake.NewClientBuilder().WithScheme(newScheme(t)).
+				WithObjects(liveCM("cm-alpha"), liveCM("cm-beta")).Build()
+			cl := &failOnlyClient{Client: base, name: "cm-alpha", err: tc.err}
+
+			var hookCalls atomic.Int32
+			s := NewSimple(cl)
+			s.GateReadiness = true
+			s.OnToleratedRejection = func(ToleratedRejection) { hookCalls.Add(1) }
+
+			res, err := s.Apply(context.Background(),
+				compileAndBuild(t, collectionCMGraphWithDependent()), watchrouter.NoopWatcher{})
+
+			require.Error(t, err, "a transient update rejection must not be reported as converged")
+			assert.True(t, errors.Is(err, ErrNotReady),
+				"the failure must be a soft not-ready so the reconcile requeues, got %v", err)
+			assert.False(t, errors.Is(err, ErrResourceDeleting))
+			assert.Contains(t, err.Error(), "collection \"cm\": 1 item(s) failed to apply")
+			assert.Contains(t, err.Error(), "item default/cm-alpha")
+			assert.Contains(t, err.Error(), tc.cause, "the rejection cause must reach the condition message")
+
+			assert.ElementsMatch(t, []string{"cm-alpha", "cm-beta"}, appliedNames(res),
+				"the rejected member's live identity must stay in Applied")
+			assert.Contains(t, res.Unresolved, "cm",
+				"the collection node must be Unresolved so prune is withheld")
+
+			assert.Contains(t, res.Unresolved, "dep",
+				"a dependent of the not-ready collection must be gated (Unresolved)")
+			assert.False(t, cmExists(t, base, "dep"),
+				"a dependent must not be created while the collection is not ready")
+
+			assert.Zero(t, hookCalls.Load(),
+				"a transient failure is retried, not tolerated: OnToleratedRejection must not fire")
+		})
+	}
+}
+
+// TestApply_PermanentUpdateRejectionStillTolerated: a permanent rejection
+// (Invalid/BadRequest) of an UPDATE to an already-existing member is tolerated —
+// live object recorded as applied, hook fired once, Apply nil, dependents
+// released — so one unfixable member does not wedge the node.
+func TestApply_PermanentUpdateRejectionStillTolerated(t *testing.T) {
+	t.Parallel()
+
+	immutable := apierrors.NewInvalid(
+		schema.GroupKind{Kind: "ConfigMap"}, "cm-alpha",
+		field.ErrorList{field.Invalid(field.NewPath("data"), "x", "field is immutable")},
+	)
+	tests := []struct {
+		name       string
+		err        error
+		wantReason string
+	}{
+		{"immutable field (Invalid)", immutable, "field immutable"},
+		{"other Invalid", apierrors.NewInvalid(schema.GroupKind{Kind: "ConfigMap"}, "cm-alpha", nil), "invalid request"},
+		{"BadRequest", apierrors.NewBadRequest("malformed"), "invalid request"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			base := fake.NewClientBuilder().WithScheme(newScheme(t)).
+				WithObjects(liveCM("cm-alpha"), liveCM("cm-beta")).Build()
+			cl := &failOnlyClient{Client: base, name: "cm-alpha", err: tc.err}
+
+			var mu sync.Mutex
+			var got []ToleratedRejection
+			s := NewSimple(cl)
+			s.GateReadiness = true
+			s.OnToleratedRejection = func(r ToleratedRejection) {
+				mu.Lock()
+				got = append(got, r)
+				mu.Unlock()
+			}
+
+			res, err := s.Apply(context.Background(),
+				compileAndBuild(t, collectionCMGraphWithDependent()), watchrouter.NoopWatcher{})
+
+			require.NoError(t, err, "a permanent update rejection on an existing member must still be tolerated")
+			assert.ElementsMatch(t, []string{"cm-alpha", "cm-beta", "dep"}, appliedNames(res),
+				"the live member, its sibling and the released dependent are all tracked")
+			assert.Empty(t, res.Unresolved, "a converged node has nothing unresolved")
+			assert.True(t, cmExists(t, base, "dep"),
+				"the node converged, so its dependent must have been applied")
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.Len(t, got, 1, "the hook must fire exactly once, for the rejected member only")
+			assert.Equal(t, "cm-alpha", got[0].Name)
+			assert.Equal(t, "cm", got[0].NodeID)
+			assert.Equal(t, tc.wantReason, got[0].Reason)
+		})
+	}
+}
+
+// TestApply_TransientCreateFailureUnchanged: when the member does not exist and
+// CREATE fails transiently, the node is held soft not-ready, nothing is
+// advertised as applied, and the hook (about rejected UPDATES) does not fire.
+func TestApply_TransientCreateFailureUnchanged(t *testing.T) {
+	t.Parallel()
+
+	base := fake.NewClientBuilder().WithScheme(newScheme(t)).Build() // no members exist
+	cl := &failOnlyClient{Client: base, name: "cm-alpha", err: apierrors.NewInternalError(errors.New("failed calling webhook"))}
+
+	var hookCalls atomic.Int32
+	s := NewSimple(cl)
+	s.GateReadiness = true
+	s.OnToleratedRejection = func(ToleratedRejection) { hookCalls.Add(1) }
+
+	res, err := s.Apply(context.Background(),
+		compileAndBuild(t, collectionCMGraphWithDependent()), watchrouter.NoopWatcher{})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotReady), "a transient create failure stays a soft requeue, got %v", err)
+	assert.Contains(t, err.Error(), "failed calling webhook")
+	assert.ElementsMatch(t, []string{"cm-beta"}, appliedNames(res),
+		"only the member that actually landed may be advertised as applied")
+	assert.Contains(t, res.Unresolved, "cm")
+	assert.Contains(t, res.Unresolved, "dep")
+	assert.False(t, cmExists(t, base, "dep"))
+	assert.Zero(t, hookCalls.Load(), "a failed create is not a tolerated update rejection")
 }

--- a/test/integration/suites/core/collection_transient_rejection_test.go
+++ b/test/integration/suites/core/collection_transient_rejection_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// A collection member whose UPDATE fails transiently (here: a failurePolicy=Fail
+// admission webhook with an unreachable backend, so the apiserver answers 500
+// "failed calling webhook") must hold the instance not-ready and be retried, not
+// be tolerated as converged. envtest's kube-apiserver runs the
+// ValidatingAdmissionWebhook plugin, so a ValidatingWebhookConfiguration pointing
+// at an unreachable loopback URL reproduces this end to end.
+var _ = Describe("Collection transient update rejection", func() {
+	var namespace string
+	// nsLabelKey/value scope the (cluster-wide) webhook configuration to this
+	// spec's namespace, so parallel specs on the shared apiserver are unaffected.
+	const nsLabelKey = "kro-test-transient-webhook"
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   namespace,
+				Labels: map[string]string{nsLabelKey: namespace},
+			},
+		}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("holds the instance not-ready while one member's update fails transiently and converges once the failure clears", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-transient-rejection",
+			generator.WithSchema(
+				"TransientRejectionCollection", "v1alpha1",
+				map[string]any{
+					"name":  "string",
+					"slots": "[]string",
+					"value": "string",
+				},
+				nil,
+			),
+			generator.WithResourceCollection("configmaps", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name": "${schema.spec.name}-${slot}",
+					"labels": map[string]any{
+						"slot": "${slot}",
+					},
+				},
+				"data": map[string]any{
+					"value": "${schema.spec.value}",
+				},
+			},
+				[]krov1alpha1.ForEachDimension{
+					{"slot": "${schema.spec.slots}"},
+				},
+				nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		defer func() { _ = env.Client.Delete(ctx, rgd) }()
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			createdRGD := &krov1alpha1.ResourceGraphDefinition{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, createdRGD)).To(Succeed())
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		name := "coll"
+		instance := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TransientRejectionCollection",
+				"metadata":   map[string]any{"name": name, "namespace": namespace},
+				"spec": map[string]any{
+					"name":  name,
+					"slots": []any{"a", "b"},
+					"value": "v1",
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		By("converging both members at v1")
+		waitForInstanceActive(ctx, namespace, name, instance)
+		for _, slot := range []string{"a", "b"} {
+			Eventually(func(g Gomega, ctx SpecContext) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name + "-" + slot, Namespace: namespace}, cm)).To(Succeed())
+				g.Expect(cm.Data["value"]).To(Equal("v1"))
+			}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+		}
+
+		By("installing a failurePolicy=Fail webhook with an unreachable backend that intercepts UPDATEs of the slot=a member only")
+		webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("block-slot-a-%s", namespace)},
+			Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+				Name:                    "block-slot-a.kro-test.invalid",
+				AdmissionReviewVersions: []string{"v1"},
+				SideEffects:             new(admissionregistrationv1.SideEffectClassNone),
+				FailurePolicy:           new(admissionregistrationv1.Fail),
+				TimeoutSeconds:          new(int32(1)),
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Update},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"configmaps"},
+					},
+				}},
+				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{nsLabelKey: namespace}},
+				ObjectSelector:    &metav1.LabelSelector{MatchLabels: map[string]string{"slot": "a"}},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					// Nothing listens on port 1; under failurePolicy=Fail the apiserver
+					// rejects the UPDATE with 500 InternalError "failed calling webhook".
+					URL: new("https://127.0.0.1:1/validate"),
+				},
+			}},
+		}
+		Expect(env.Client.Create(ctx, webhook)).To(Succeed())
+		defer func() { _ = env.Client.Delete(ctx, webhook) }()
+
+		// The apiserver picks the configuration up asynchronously: probe with a
+		// throwaway ConfigMap until an UPDATE is rejected, so the change below
+		// cannot race ahead of the webhook becoming active.
+		probe := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "webhook-probe", Namespace: namespace, Labels: map[string]string{"slot": "a"}},
+			Data:       map[string]string{"n": "0"},
+		}
+		Expect(env.Client.Create(ctx, probe)).To(Succeed())
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: probe.Name, Namespace: namespace}, probe)).To(Succeed())
+			probe.Data["n"] = rand.String(4)
+			err := env.Client.Update(ctx, probe)
+			g.Expect(err).To(HaveOccurred(), "the webhook must intercept UPDATEs of slot=a ConfigMaps")
+			g.Expect(apierrors.IsInternalError(err)).To(BeTrue(), "expected 500 InternalError, got %v", err)
+			g.Expect(err.Error()).To(ContainSubstring("failed calling webhook"))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("changing the desired value so every member needs an UPDATE")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, instance)).To(Succeed())
+			g.Expect(unstructured.SetNestedField(instance.Object, "v2", "spec", "value")).To(Succeed())
+			g.Expect(env.Client.Update(ctx, instance)).To(Succeed())
+		}, 10*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("reporting the instance not-ready with the webhook failure while the unaffected member converges")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, instance)).To(Succeed())
+
+			state, _, _ := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(state).To(Equal("IN_PROGRESS"),
+				"a transient update failure is a soft not-ready, not converged (ACTIVE) and not degraded (ERROR)")
+
+			cond := instanceConditionByType(instance, "ResourcesReady")
+			g.Expect(cond).ToNot(BeNil())
+			g.Expect(cond["status"]).To(Equal("False"))
+			g.Expect(cond["message"]).To(ContainSubstring("failed calling webhook"))
+			g.Expect(cond["message"]).To(ContainSubstring(name + "-a"))
+
+			cmB := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name + "-b", Namespace: namespace}, cmB)).To(Succeed())
+			g.Expect(cmB.Data["value"]).To(Equal("v2"), "the sibling not covered by the webhook must still be updated")
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		// The blocked member is still present (never pruned) and still stale.
+		cmA := &corev1.ConfigMap{}
+		Expect(env.Client.Get(ctx, types.NamespacedName{Name: name + "-a", Namespace: namespace}, cmA)).To(Succeed())
+		Expect(cmA.Data["value"]).To(Equal("v1"), "the webhook must have blocked the update of the slot=a member")
+
+		By("removing the webhook and letting the requeue retry the update — without touching the instance")
+		Expect(env.Client.Delete(ctx, webhook)).To(Succeed())
+
+		// Nothing on the instance or its children changes when the webhook is
+		// removed, so only the not-ready requeue can drive this convergence.
+		Eventually(func(g Gomega, ctx SpecContext) {
+			cmA := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name + "-a", Namespace: namespace}, cmA)).To(Succeed())
+			g.Expect(cmA.Data["value"]).To(Equal("v2"), "the retried update must land once the webhook is gone")
+
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, instance)).To(Succeed())
+			state, _, _ := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(state).To(Equal("ACTIVE"))
+			cond := instanceConditionByType(instance, "ResourcesReady")
+			g.Expect(cond).ToNot(BeNil())
+			g.Expect(cond["status"]).To(Equal("True"))
+		}, 2*time.Minute, 500*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, instance)
+			g.Expect(err).To(MatchError(apierrors.IsNotFound, "instance should be deleted"))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+	})
+})
+
+// instanceConditionByType returns the status.conditions entry of the given type
+// from an unstructured instance, or nil when absent.
+func instanceConditionByType(instance *unstructured.Unstructured, condType string) map[string]any {
+	conditions, found, err := unstructured.NestedSlice(instance.Object, "status", "conditions")
+	if err != nil || !found {
+		return nil
+	}
+	for _, cond := range conditions {
+		if c, ok := cond.(map[string]any); ok && c["type"] == condType {
+			return c
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem

When the server-side-apply UPDATE of an already-existing `forEach` collection member is rejected, `applyCollectionItem` tolerates it: the live object is recorded as applied and the node converges. That is right for a permanent rejection (Invalid/BadRequest, e.g. an immutable field), where retrying can never help and one bad member must not wedge the node. But the same path swallowed transient failures — 5xx, timeouts, throttling, 409, a `failurePolicy: Fail` admission webhook whose backend is unreachable — because `classifyRejection`'s permanent/transient flag only fed the log line and the `OnToleratedRejection` hook.

A user sees the instance `ACTIVE` with `ResourcesReady=True "all resources are created and ready"` while one member still holds the old value; a `Warning UpdateRejected` event on the child is the only trace. Nothing is requeued, so the member stays stale until an unrelated event or the multi-hour resync, even after the outage clears. The pre-rewrite engine reported such an update error as `ResourcesReady=False` and converged as soon as the webhook went away.

## Fix

- `pkg/graphengine/executor/simple.go` `applyCollectionItem`: branch on `classifyRejection`'s flag. A permanent rejection takes the existing tolerate path (`recordUpdateRejected`, hook fires, node converges). Anything else keeps the live identity in `Applied` (`recordApplied`, so the object stays in inventory and is never pruned) but is also recorded as an item failure (`recordFailure`), so the node is held not-ready with the cause, dependents gate, the instance stays `IN_PROGRESS`, and the reconcile requeues with the existing capped backoff until the update lands; the hook does not fire. A new envtest spec blocks UPDATEs of one member with a `ValidatingWebhookConfiguration` pointing at an unreachable loopback URL, asserts `IN_PROGRESS` with the webhook error on `ResourcesReady`, then deletes the webhook and asserts convergence without touching the instance.
- `pkg/graphengine/executor/executor.go` `ToleratedRejection`: the `Permanent` field is removed — only permanent rejections reach the hook now, so it would be a constant, and its only consumer (the instance controller's `Warning UpdateRejected` event) never read it.
- `classifyRejection` is unchanged in behaviour; its comment now states why "permanent" is kept narrow (Invalid/BadRequest): misreading a transient cause as permanent tolerates a stale member as converged, while the reverse only costs a visible retry.

## Behaviour changes

- An UPDATE of an existing collection member that fails with anything other than Invalid/BadRequest now holds the instance `IN_PROGRESS` (`ResourcesReady=False`, reason `NotReady`, message naming the item and cause), gates dependents, and is retried with backoff (3 s doubling to a 5 min cap) instead of reporting `ACTIVE` with a stale member. No `Warning UpdateRejected` event is emitted for these anymore; the cause is on the condition.
- A no-change re-apply is an admission-checked UPDATE too: while such a webhook keeps failing, an instance whose members are already at the desired state also flips from `ACTIVE` to `IN_PROGRESS` on its next reconcile, and returns to `ACTIVE` on the first successful re-apply. A scalar template behind the same webhook is already reported this way (hard error, `ERROR`).
- 403 `Forbidden` is on the retried side: a 403-coded admission denial (controller-runtime `admission.Denied`, Gatekeeper, a `ValidatingAdmissionPolicy` validation with `reason: Forbidden`) or missing RBAC now surfaces as not-ready + retry rather than silent convergence, matching the create path and the pre-rewrite engine. A denial that can never pass keeps the instance visibly `IN_PROGRESS` with the denial message rather than falsely `ACTIVE`.
- Unchanged, now documented: a denial the apiserver codes 400 (its default when a webhook returns `allowed: false` without a status code, e.g. Kyverno's default deny) or 422 (a `ValidatingAdmissionPolicy` with the default reason `Invalid`) is classified permanent and still tolerated with the instance `ACTIVE`. The same policy engine's denial therefore lands on either side depending on the status code it sets.
- Permanent rejections of an UPDATE to an existing member are tolerated exactly as before; create failures, scalar templates, terminating objects and field-manager conflicts are unchanged.
- Existing tests that pinned the old behaviour were updated: `TestSimple_ApplyTemplate_CollectionApplyTolerance`'s Conflict subtest now expects `ErrNotReady` instead of success; `TestSimple_ApplyTemplate_LargeCollectionTolerance` expects `20 item(s) failed to apply` (the 10 conflicting updates now count) with `Applied` still 50; `TestSimple_ApplyTemplate_CollectionHardErrors` uses `BadRequest` instead of `Forbidden` for its second permanently-rejected member.
