### PR TITLE
fix(graphengine): fail closed on malformed external-collection selectors

### DIFF
--- a/pkg/graphengine/compiler/context.go
+++ b/pkg/graphengine/compiler/context.go
@@ -220,7 +220,7 @@ func (ctx *CompilationContext) buildDefNode(n *expv1alpha1.Node, order int, payl
 }
 
 func (ctx *CompilationContext) buildNode(p *parser.Parser, n *expv1alpha1.Node, order int) (*Node, *spec.Schema, error) {
-	kind, payload, err := projectPayload(n)
+	kind, payload, err := projectPayload(p, n)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -589,8 +589,9 @@ func validateRefMetadata(payload map[string]any) error {
 }
 
 // projectPayload converts the discriminated-union API node into a single
-// unstructured map suitable for CEL extraction.
-func projectPayload(n *expv1alpha1.Node) (NodeKind, map[string]any, error) {
+// unstructured map suitable for CEL extraction. Ref metadata contracts are
+// checked here so they cover both the static and dynamic-GVK ref paths.
+func projectPayload(p *parser.Parser, n *expv1alpha1.Node) (NodeKind, map[string]any, error) {
 	switch {
 	case n.Template != nil:
 		obj, err := unmarshalRaw(n.Template.Raw)
@@ -608,6 +609,11 @@ func projectPayload(n *expv1alpha1.Node) (NodeKind, map[string]any, error) {
 		// (bypassing the CRD XValidation on ExternalRefMetadata) as well as to
 		// both the static and dynamic ref compile paths.
 		if err := validateRefMetadata(obj); err != nil {
+			return 0, nil, fmt.Errorf("ref: %w", err)
+		}
+		// metadata.selector is schemaless; reject a malformed literal here as a
+		// compile error rather than per instance at apply time.
+		if err := validateRefSelector(p, obj); err != nil {
 			return 0, nil, fmt.Errorf("ref: %w", err)
 		}
 		return NodeKindRef, obj, nil

--- a/pkg/graphengine/compiler/selector.go
+++ b/pkg/graphengine/compiler/selector.go
@@ -1,0 +1,81 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/kubernetes-sigs/kro/pkg/graph/parser"
+	"github.com/kubernetes-sigs/kro/pkg/graph/schema"
+)
+
+var selectorFieldPath = field.NewPath("metadata", "selector")
+
+var errRefSelectorShape = fmt.Errorf("%s must be a Kubernetes LabelSelector object (matchLabels and/or matchExpressions) or a single CEL expression that resolves to one", selectorFieldPath)
+
+// DecodeLabelSelector strictly decodes a rendered metadata.selector into a
+// metav1.LabelSelector and validates it. Unknown keys are errors: dropping them
+// would leave an empty selector that matches every object of the kind.
+func DecodeLabelSelector(raw map[string]any) (*metav1.LabelSelector, error) {
+	ls := &metav1.LabelSelector{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(raw, ls, true); err != nil {
+		return nil, fmt.Errorf("%s is not a valid LabelSelector object (matchLabels: map of string to string, matchExpressions: list of {key, operator, values}): %w", selectorFieldPath, err)
+	}
+	if errs := metav1validation.ValidateLabelSelector(ls, metav1validation.LabelSelectorValidationOptions{}, selectorFieldPath); len(errs) != 0 {
+		return nil, fmt.Errorf("invalid label selector: %w", errs.ToAggregate())
+	}
+	return ls, nil
+}
+
+// validateRefSelector checks a ref node's schemaless metadata.selector at
+// compile time: a standalone ${...} expression is accepted (decoded at apply
+// time); an object must fit the LabelSelector schema and, when it holds no CEL,
+// decode strictly. An absent or null selector is not a collection ref.
+func validateRefSelector(p *parser.Parser, payload map[string]any) error {
+	md, _ := payload["metadata"].(map[string]any)
+	sel, ok := md["selector"]
+	if !ok || sel == nil {
+		return nil
+	}
+	switch s := sel.(type) {
+	case string:
+		standalone, err := parser.IsStandaloneExpression(s)
+		if err != nil {
+			return fmt.Errorf("%s: invalid expression: %w", selectorFieldPath, err)
+		}
+		if !standalone {
+			return errRefSelectorShape
+		}
+		return nil
+	case map[string]any:
+		expressions, err := p.ParseResourceAtPath(s, &schema.LabelSelectorSchema, selectorFieldPath.String())
+		if err != nil {
+			return err
+		}
+		if len(expressions) > 0 {
+			// CEL values are only known at apply time; the executor decodes them.
+			return nil
+		}
+		_, err = DecodeLabelSelector(s)
+		return err
+	default:
+		return errRefSelectorShape
+	}
+}

--- a/pkg/graphengine/compiler/selector_test.go
+++ b/pkg/graphengine/compiler/selector_test.go
@@ -1,0 +1,208 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/graph/parser"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
+)
+
+// TestValidateRefSelector pins the compile-time shape check on a ref node's
+// schemaless metadata.selector.
+func TestValidateRefSelector(t *testing.T) {
+	t.Parallel()
+
+	refPayload := func(selector any) map[string]any {
+		md := map[string]any{"namespace": "default"}
+		if selector != nil {
+			md["selector"] = selector
+		}
+		return map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": md}
+	}
+
+	cases := []struct {
+		name    string
+		payload map[string]any
+		wantErr string
+	}{
+		// --- accepted ---
+		{name: "no selector (single-object ref)", payload: refPayload(nil)},
+		{
+			name:    "explicit null selector is treated as absent",
+			payload: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"selector": nil}},
+		},
+		{name: "empty selector object matches everything by contract", payload: refPayload(map[string]any{})},
+		{name: "literal matchLabels", payload: refPayload(map[string]any{"matchLabels": map[string]any{"tier": "db"}})},
+		{
+			name: "literal matchExpressions",
+			payload: refPayload(map[string]any{"matchExpressions": []any{
+				map[string]any{"key": "tier", "operator": "In", "values": []any{"db", "cache"}},
+			}}),
+		},
+		{name: "whole selector is a standalone CEL expression", payload: refPayload("${schema.spec.sel}")},
+		{name: "matchLabels is a CEL expression", payload: refPayload(map[string]any{"matchLabels": "${schema.spec.labels}"})},
+		{name: "matchLabels value is a CEL expression", payload: refPayload(map[string]any{"matchLabels": map[string]any{"tier": "${schema.spec.tier}"}})},
+		{
+			name: "matchExpressions values carry CEL",
+			payload: refPayload(map[string]any{"matchExpressions": []any{
+				map[string]any{"key": "tier", "operator": "In", "values": []any{"${schema.spec.tier}"}},
+			}}),
+		},
+		{
+			// Only known at apply time; left to the executor's decode.
+			name: "CEL-bearing selector with a bad operator is deferred to apply time",
+			payload: refPayload(map[string]any{"matchExpressions": []any{
+				map[string]any{"key": "${schema.spec.key}", "operator": "Bogus"},
+			}}),
+		},
+
+		// --- rejected ---
+		{
+			name:    "misspelled matchLabels key",
+			payload: refPayload(map[string]any{"matchLabel": map[string]any{"tier": "db"}}),
+			wantErr: "matchLabel",
+		},
+		{
+			name:    "bare label map without matchLabels",
+			payload: refPayload(map[string]any{"tier": "db"}),
+			wantErr: "schema not found for field tier",
+		},
+		{
+			name:    "unknown key next to a CEL matchLabels",
+			payload: refPayload(map[string]any{"matchLabels": "${schema.spec.labels}", "bogus": "x"}),
+			wantErr: "schema not found for field bogus",
+		},
+		{
+			name:    "matchLabels is a plain string",
+			payload: refPayload(map[string]any{"matchLabels": "tier=db"}),
+			wantErr: "expected object type for path metadata.selector.matchLabels, got string",
+		},
+		{
+			name:    "matchLabels value is not a string",
+			payload: refPayload(map[string]any{"matchLabels": map[string]any{"tier": int64(3)}}),
+			wantErr: "expected string type for path metadata.selector.matchLabels.tier",
+		},
+		{
+			name:    "matchExpressions item is a scalar",
+			payload: refPayload(map[string]any{"matchExpressions": []any{"tier"}}),
+			wantErr: "expected object type for path metadata.selector.matchExpressions[0]",
+		},
+		{
+			name: "unknown field in a matchExpressions item",
+			payload: refPayload(map[string]any{"matchExpressions": []any{
+				map[string]any{"key": "tier", "operator": "Exists", "bogus": true},
+			}}),
+			wantErr: "schema not found for field bogus",
+		},
+		{
+			name: "literal bad operator",
+			payload: refPayload(map[string]any{"matchExpressions": []any{
+				map[string]any{"key": "tier", "operator": "Bogus"},
+			}}),
+			wantErr: "not a valid selector operator",
+		},
+		{
+			name: "literal In operator without values",
+			payload: refPayload(map[string]any{"matchExpressions": []any{
+				map[string]any{"key": "tier", "operator": "In"},
+			}}),
+			wantErr: "invalid label selector",
+		},
+		{
+			name:    "literal malformed label key",
+			payload: refPayload(map[string]any{"matchLabels": map[string]any{"bad key!": "db"}}),
+			wantErr: "invalid label selector",
+		},
+		{name: "plain string selector", payload: refPayload("tier=db"), wantErr: "must be a Kubernetes LabelSelector object"},
+		{name: "templated string selector", payload: refPayload("prefix-${schema.spec.sel}"), wantErr: "must be a Kubernetes LabelSelector object"},
+		{name: "unterminated CEL selector", payload: refPayload("${schema.spec.sel"), wantErr: "invalid expression"},
+		{name: "list selector", payload: refPayload([]any{"tier"}), wantErr: "must be a Kubernetes LabelSelector object"},
+		{name: "numeric selector", payload: refPayload(int64(42)), wantErr: "must be a Kubernetes LabelSelector object"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := newTestRootContext(t)
+			err := validateRefSelector(parser.New(ctx.fieldCache), tc.payload)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestCompile_RefSelectorShape pins that the shape check runs on both the
+// static- and dynamic-GVK ref compile paths and names the node.
+func TestCompile_RefSelectorShape(t *testing.T) {
+	t.Parallel()
+
+	typo := runtime.RawExtension{Raw: []byte(`{"matchLabel":{"tier":"db"}}`)}
+
+	t.Run("static ref with a misspelled matchLabels key is a compile error", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithRef("coll", &expv1alpha1.ExternalRef{
+				APIVersion: "v1", Kind: "ConfigMap",
+				Metadata: expv1alpha1.ExternalRefMetadata{Selector: typo},
+			}),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `build node "coll"`)
+		assert.Contains(t, err.Error(), "matchLabel")
+	})
+
+	t.Run("dynamic-GVK ref with a misspelled matchLabels key is a compile error", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("crd", map[string]any{"kind": "Widget"}),
+			generator.WithRef("coll", &expv1alpha1.ExternalRef{
+				APIVersion: "example.com/v1", Kind: "${crd.kind}",
+				Metadata: expv1alpha1.ExternalRefMetadata{Selector: typo},
+			}),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `build node "coll"`)
+		assert.Contains(t, err.Error(), "matchLabel")
+	})
+
+	t.Run("a whole-selector CEL expression compiles and marks a collection", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("input", map[string]any{"sel": map[string]any{"matchLabels": map[string]any{"tier": "db"}}}),
+			generator.WithRef("coll", &expv1alpha1.ExternalRef{
+				APIVersion: "v1", Kind: "ConfigMap",
+				Metadata: expv1alpha1.ExternalRefMetadata{
+					Selector: runtime.RawExtension{Raw: []byte(`"${input.sel}"`)},
+				},
+			}),
+		)
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+		assert.True(t, prog.Nodes["coll"].IsCollection())
+		assert.Equal(t, []string{"input"}, prog.Nodes["coll"].HardDepIDs())
+	})
+}

--- a/pkg/graphengine/executor/refcollection_test.go
+++ b/pkg/graphengine/executor/refcollection_test.go
@@ -17,6 +17,7 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -94,6 +95,197 @@ func TestRefCollectionSelector(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "coll", "the error must name the offending node")
 	})
+}
+
+// TestRefCollectionSelector_FailsClosed pins the strict decode of a rendered
+// metadata.selector: malformed shapes are errors, not labels.Everything(). The
+// objects are raw maps because a typed metav1.LabelSelector cannot express them.
+func TestRefCollectionSelector_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	// withSelector sets metadata.selector even when nil (present-but-null).
+	withSelector := func(selector any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{
+				"namespace": "default",
+				"selector":  selector,
+			},
+		}}
+	}
+
+	t.Run("malformed selectors are errors naming the node and the fault", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name     string
+			selector any
+			wantErr  string
+		}{
+			{
+				name:     "misspelled matchLabels key",
+				selector: map[string]any{"matchLabel": map[string]any{"tier": "db"}},
+				wantErr:  `unknown field "matchLabel"`,
+			},
+			{
+				name:     "bare label map without matchLabels",
+				selector: map[string]any{"tier": "db"},
+				wantErr:  `unknown field "tier"`,
+			},
+			{
+				name: "unknown field in a matchExpressions item",
+				selector: map[string]any{"matchExpressions": []any{
+					map[string]any{"key": "tier", "operator": "In", "values": []any{"db"}, "bogus": true},
+				}},
+				wantErr: `unknown field "matchExpressions[0].bogus"`,
+			},
+			{
+				name:     "matchLabels holding a string instead of a map",
+				selector: map[string]any{"matchLabels": "tier=db"},
+				wantErr:  "not a valid LabelSelector object",
+			},
+			{
+				name:     "matchLabels value that is not a string",
+				selector: map[string]any{"matchLabels": map[string]any{"tier": int64(3)}},
+				wantErr:  "not a valid LabelSelector object",
+			},
+			{
+				name:     "selector that is a string",
+				selector: "tier=db",
+				wantErr:  "must be a LabelSelector object",
+			},
+			{
+				name:     "selector that is a list",
+				selector: []any{map[string]any{"tier": "db"}},
+				wantErr:  "must be a LabelSelector object",
+			},
+			{
+				name:     "selector that is present but null",
+				selector: nil,
+				wantErr:  "must be a LabelSelector object",
+			},
+			{
+				name:     "malformed label key",
+				selector: map[string]any{"matchLabels": map[string]any{"bad key!": "db"}},
+				wantErr:  "invalid label selector",
+			},
+			{
+				name: "In operator without values",
+				selector: map[string]any{"matchExpressions": []any{
+					map[string]any{"key": "tier", "operator": "In"},
+				}},
+				wantErr: "invalid label selector",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				sel, err := refCollectionSelector("coll", withSelector(tc.selector))
+				require.Error(t, err,
+					"selector %#v resolved to %v, which would list every ConfigMap in scope", tc.selector, sel)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Contains(t, err.Error(), `"coll"`, "the error must name the offending node")
+			})
+		}
+	})
+
+	t.Run("empty selectors select everything", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name string
+			ref  *unstructured.Unstructured
+		}{
+			{name: "empty selector object", ref: withSelector(map[string]any{})},
+			{name: "empty matchLabels", ref: withSelector(map[string]any{"matchLabels": map[string]any{}})},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				sel, err := refCollectionSelector("coll", tc.ref)
+				require.NoError(t, err)
+				assert.Equal(t, labels.Everything(), sel)
+			})
+		}
+	})
+
+	t.Run("well-formed raw selectors decode to the expected requirements", func(t *testing.T) {
+		t.Parallel()
+		sel, err := refCollectionSelector("coll", withSelector(map[string]any{
+			"matchLabels": map[string]any{"tier": "db"},
+			"matchExpressions": []any{
+				map[string]any{"key": "env", "operator": "NotIn", "values": []any{"test"}},
+			},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "env notin (test),tier=db", sel.String())
+	})
+}
+
+// TestSimple_ApplyRefCollectionMalformedSelectorFailsClosed drives a CEL-derived
+// malformed selector through Apply: a hard error (not ErrNotReady, since a typo
+// never self-heals), no drift watch, nothing published into scope.
+func TestSimple_ApplyRefCollectionMalformedSelectorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	seed := func(name, tier string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{
+				"name": name, "namespace": "default",
+				"labels": map[string]any{"tier": tier},
+			},
+		}}
+	}
+
+	cases := []struct {
+		name     string
+		selector any
+		wantErr  string
+	}{
+		{
+			name:     "misspelled matchLabels key",
+			selector: map[string]any{"matchLabel": map[string]any{"tier": "db"}},
+			wantErr:  `unknown field "matchLabel"`,
+		},
+		{
+			name:     "selector resolves to a string",
+			selector: "tier=db",
+			wantErr:  "must be a LabelSelector object",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cl := fake.NewClientBuilder().WithScheme(newScheme(t)).
+				WithObjects(seed("db-a", "db"), seed("web", "web")).Build()
+
+			// Route the selector through a def node so its value only exists
+			// at apply time, like ${schema.spec.sel}.
+			rt := compileAndBuild(t, generator.NewGraph("g",
+				generator.WithNamespace("default"),
+				generator.WithDef("input", map[string]any{"selector": tc.selector}),
+				generator.WithRef("coll", &expv1alpha1.ExternalRef{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Metadata: expv1alpha1.ExternalRefMetadata{
+						Namespace: "default",
+						Selector:  apimachineryruntime.RawExtension{Raw: []byte(`"${input.selector}"`)},
+					},
+				}),
+			))
+
+			w := &recordingWatcher{}
+			_, err := NewSimple(cl).Apply(context.Background(), rt, w)
+			require.Error(t, err)
+			assert.False(t, errors.Is(err, ErrNotReady),
+				"a malformed selector is a permanent authoring error, not a soft not-ready")
+			assert.Contains(t, err.Error(), `"coll"`)
+			assert.Contains(t, err.Error(), tc.wantErr)
+
+			assert.Empty(t, w.reqs, "no drift watch may be registered for a selector that failed to decode")
+			_, published := rt.Scope()["coll"]
+			assert.False(t, published, "a failed collection must not publish a match-everything list into scope")
+		})
+	}
 }
 
 // An external collection is read-only: kro lists the matching objects and

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -1274,8 +1273,9 @@ func (s *Simple) applyRef(ctx context.Context, w watchrouter.Watcher, rt *runtim
 // Namespace handling deliberately skips defaultNamespace: an empty
 // metadata.namespace for a namespaced GVR means "list across ALL namespaces",
 // not "the instance's
-// namespace". An empty selector lists everything. A List error is hard; an
-// empty result is valid (an empty collection, treated as ready).
+// namespace". An absent selector lists everything; a malformed one is a hard
+// error (see refCollectionSelector). A List error is hard; an empty result is
+// valid (an empty collection, treated as ready).
 func (s *Simple) applyRefCollection(ctx context.Context, w watchrouter.Watcher, n *runtime.Node, desired []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	// forEach is rejected on ref nodes at translate time, so Resolve produced
 	// exactly one projected {apiVersion, kind, metadata{selector,namespace?}}
@@ -1345,20 +1345,27 @@ func (s *Simple) applyRefCollection(ctx context.Context, w watchrouter.Watcher, 
 }
 
 // refCollectionSelector extracts the label selector from a rendered
-// external-collection ExternalRef. A missing or empty metadata.selector means
-// "select everything" (labels.Everything).
+// external-collection ExternalRef. An absent selector selects everything; a
+// present but malformed one is an error, never a labels.Everything() fallback.
 func refCollectionSelector(id string, ref *unstructured.Unstructured) (labels.Selector, error) {
-	selectorRaw, found, err := unstructured.NestedMap(ref.Object, "metadata", "selector")
-	if err != nil || !found {
+	raw, found, err := unstructured.NestedFieldNoCopy(ref.Object, "metadata", "selector")
+	if err != nil {
+		return nil, fmt.Errorf("external collection %q: read metadata.selector: %w", id, err)
+	}
+	if !found {
 		return labels.Everything(), nil
 	}
-	ls := &metav1.LabelSelector{}
-	if err := apimachineryruntime.DefaultUnstructuredConverter.FromUnstructured(selectorRaw, ls); err != nil {
-		return nil, fmt.Errorf("convert selector for %q: %w", id, err)
+	selectorRaw, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("external collection %q: metadata.selector must be a LabelSelector object (matchLabels and/or matchExpressions), got %T", id, raw)
+	}
+	ls, err := compiler.DecodeLabelSelector(selectorRaw)
+	if err != nil {
+		return nil, fmt.Errorf("external collection %q: %w", id, err)
 	}
 	selector, err := metav1.LabelSelectorAsSelector(ls)
 	if err != nil {
-		return nil, fmt.Errorf("invalid label selector for %q: %w", id, err)
+		return nil, fmt.Errorf("external collection %q: invalid label selector: %w", id, err)
 	}
 	return selector, nil
 }

--- a/test/integration/suites/core/externalref_test.go
+++ b/test/integration/suites/core/externalref_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	ctrlinstance "github.com/kubernetes-sigs/kro/pkg/controller/instance"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
@@ -633,6 +634,160 @@ var _ = Describe("ExternalRef", func() {
 			g.Expect(found).To(BeTrue())
 			g.Expect(configCount).To(Equal("2"))
 		}, 20*time.Second, time.Second).WithContext(ctx).Should(Succeed())
+	})
+
+	It("should fail closed on a malformed instance-supplied selector instead of matching every object", func(ctx SpecContext) {
+		// An instance-supplied selector (selector: ${schema.spec.selector}) is
+		// only seen at reconcile time, so a typo must fail the node hard rather
+		// than decode to an empty selector that matches every ConfigMap.
+		namespace := fmt.Sprintf("test-%s", rand.String(5))
+		uniqueLabel := fmt.Sprintf("strict-selector-%s", rand.String(5))
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, ns)).To(Succeed())
+		})
+
+		By("pre-creating several ConfigMaps, only one of which carries the intended label")
+		for name, tier := range map[string]string{
+			"strict-selector-db":    uniqueLabel,
+			"strict-selector-web":   "web",
+			"strict-selector-cache": "cache",
+		} {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    map[string]string{"tier": tier},
+				},
+				Data: map[string]string{"key": tier},
+			}
+			Expect(env.Client.Create(ctx, cm)).To(Succeed())
+		}
+
+		By("creating an RGD whose external collection selector comes from instance spec")
+		rgd := generator.NewResourceGraphDefinition("test-extcoll-strict-selector",
+			generator.WithSchema(
+				"TestExtCollStrictSelector", "v1alpha1",
+				map[string]any{
+					"selector": "object",
+				},
+				map[string]any{
+					"configCount": "${string(size(allconfigs))}",
+				},
+			),
+			generator.WithExternalRef("allconfigs", &krov1alpha1.ExternalRef{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Metadata: krov1alpha1.ExternalRefMetadata{
+					Selector: toRawExtension("${schema.spec.selector}"),
+				},
+			}, nil, nil),
+		)
+
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		By("waiting for the RGD to become active")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("creating an instance whose selector misspells matchLabels as matchLabel")
+		instance := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "kro.run/v1alpha1",
+				"kind":       "TestExtCollStrictSelector",
+				"metadata": map[string]any{
+					"name":      "test-strict-selector",
+					"namespace": namespace,
+				},
+				"spec": map[string]any{
+					"selector": map[string]any{
+						"matchLabel": map[string]any{"tier": uniqueLabel},
+					},
+				},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		By("asserting the instance fails hard with a condition naming the unknown field")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instance.GetName(),
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			state, found, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(state).To(Equal(string(krov1alpha1.InstanceStateError)),
+				"a malformed selector is a permanent authoring error, not a soft not-ready")
+
+			cond := findInstanceConditionByType(instance, ctrlinstance.ResourcesReady)
+			g.Expect(cond).ToNot(BeNil())
+			g.Expect(cond["status"]).To(Equal("False"))
+			g.Expect(cond["message"]).To(And(
+				ContainSubstring("allconfigs"),
+				ContainSubstring("unknown field"),
+				ContainSubstring("matchLabel"),
+			), "the condition must tell the author what is wrong and where")
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("asserting the instance never goes ACTIVE with a match-everything collection")
+		Consistently(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instance.GetName(),
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(instance.Object["status"]).ToNot(HaveKeyWithValue("state", "ACTIVE"))
+			_, found, err := unstructured.NestedString(instance.Object, "status", "configCount")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse(),
+				"a collection that failed to decode its selector must not publish a count of every ConfigMap in the namespace")
+		}, 6*time.Second, 500*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("correcting the selector to matchLabels on the instance")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instance.GetName(),
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(unstructured.SetNestedField(instance.Object, map[string]any{
+				"matchLabels": map[string]any{"tier": uniqueLabel},
+			}, "spec", "selector")).To(Succeed())
+			g.Expect(env.Client.Update(ctx, instance)).To(Succeed())
+		}, 10*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("asserting the corrected instance converges on exactly the one labelled ConfigMap")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      instance.GetName(),
+				Namespace: namespace,
+			}, instance)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(instance.Object).To(HaveKey("status"))
+			g.Expect(instance.Object["status"]).To(HaveKeyWithValue("state", "ACTIVE"))
+
+			configCount, found, err := unstructured.NestedString(instance.Object, "status", "configCount")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(configCount).To(Equal("1"))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
 	})
 
 	It("should reject a selector label CEL value that references a missing schema field", func(ctx SpecContext) {

--- a/test/integration/suites/core/graph_compilation_test.go
+++ b/test/integration/suites/core/graph_compilation_test.go
@@ -151,6 +151,31 @@ var _ = Describe("Graph Compilation", func() {
 				wantStatus: metav1.ConditionFalse,
 				wantSubstr: "self references are not allowed",
 			},
+			{
+				name: "invalid-ref-selector-misspelled-matchlabels",
+				// metadata.selector is schemaless, so a misspelled key is only
+				// catchable at compile time.
+				nodes: []expv1alpha1.Node{
+					{
+						ID:  "seed",
+						Def: environment.RawExt(t, map[string]any{"v": "x"}),
+					},
+					{
+						ID: "configs",
+						Ref: &expv1alpha1.ExternalRef{
+							APIVersion: "v1",
+							Kind:       "ConfigMap",
+							Metadata: expv1alpha1.ExternalRefMetadata{
+								Selector: *environment.RawExt(t, map[string]any{
+									"matchLabel": map[string]any{"tier": "db"},
+								}),
+							},
+						},
+					},
+				},
+				wantStatus: metav1.ConditionFalse,
+				wantSubstr: "matchLabel",
+			},
 		}
 
 		for _, tc := range tests {

--- a/website/docs/docs/concepts/rgd/02-resource-definitions/05-external-references.md
+++ b/website/docs/docs/concepts/rgd/02-resource-definitions/05-external-references.md
@@ -250,6 +250,10 @@ Each instance of the custom resource resolves the CEL expression with its own sp
 CEL selector values are evaluated on every reconciliation. If the schema field changes, the matched set updates automatically on the next reconcile.
 :::
 
+:::warning
+A selector resolved from instance data must be a valid `LabelSelector` object (`matchLabels` and/or `matchExpressions`). Any other shape — a misspelled key such as `matchLabel`, a bare `{tier: db}` label map, or a non-object value — fails the external ref with `ResourcesReady=False` instead of matching every resource of the kind.
+:::
+
 ### Empty Selectors
 
 An empty selector matches **all** resources of the given kind across all namespaces (or in a specific namespace if `namespace` is set):


### PR DESCRIPTION
## Problem

An external collection's `metadata.selector` is schemaless and, since #1230, may be a whole CEL expression such as `selector: ${schema.spec.sel}`, so its shape is first seen at reconcile time. `refCollectionSelector` decoded the rendered value leniently: unknown keys were dropped and a non-object value was treated as absent, so a misspelled `{matchLabel: {tier: db}}`, a bare `{tier: db}` label map, or a plain string became an empty `LabelSelector`, which `LabelSelectorAsSelector` turns into `labels.Everything()`.

The instance then listed every object of the kind in the namespace — or cluster-wide when `metadata.namespace` is omitted — registered a matching all-objects drift watch, reported `ACTIVE`, and published foreign objects into its status. The pre-rewrite engine (`7458023`) decoded strictly and failed the node; the test pinning that was dropped with the rewrite. Graph `ref:` nodes had no compile-time shape check at all, so a literal typo compiled too.

## Fix

- `pkg/graphengine/compiler/selector.go` (new): `DecodeLabelSelector` strictly decodes a selector map (`FromUnstructuredWithValidation` in strict mode) and runs `metav1validation.ValidateLabelSelector` on it; `validateRefSelector` checks a ref node's literal selector at compile time against the `LabelSelector` OpenAPI schema (a standalone `${...}` expression is accepted and left to the runtime decode), mirroring `pkg/graph`'s RGD-level check.
- `pkg/graphengine/compiler/context.go`: `projectPayload` calls `validateRefSelector` on the shared ref projection path, so a malformed literal selector is a compile error (`Accepted=False`) for both static- and dynamic-GVK Graph `ref:` nodes.
- `pkg/graphengine/executor/simple.go` `refCollectionSelector`: an absent selector still selects everything; a present one must be an object and is decoded through `DecodeLabelSelector`. Any malformed shape is a hard error naming the node, raised before the drift watch is registered and the list runs, so the instance reports `ResourcesReady=False` / `state: ERROR` with an actionable message instead of matching everything. Pinned by unit tests at helper and `Apply` level and by an envtest spec in which an instance-supplied `{matchLabel: ...}` selector fails hard and converges once corrected.
- `website/docs/.../05-external-references.md`: a warning that an instance-supplied selector must be a valid `LabelSelector` object and never falls back to matching everything.

## Behaviour changes

- An external collection whose rendered `metadata.selector` is present but malformed (unknown keys, wrong value types, invalid operator or label syntax) now fails the node hard instead of listing everything. Valid selectors, `{}`, `{matchLabels: {}}` and an absent selector behave as before; `ValidateLabelSelector` enforces the same rules `LabelSelectorAsSelector` already did, so no previously accepted selector is rejected. The hard error is still requeued at the flat default interval, but the instance is no longer reported `InProgress` under a never-ending not-ready backoff.
- Unlike the pre-rewrite decoder, a selector that is present but not an object (including `null`) is an error rather than `labels.Everything()`. A collection node always compiles with a non-null selector, so this only occurs when a CEL expression resolves to a non-object value.
- Unlike the pre-rewrite decoder, key matching is case-sensitive: a wrongly-cased key such as `MatchLabels` is an unknown field (the previous `encoding/json` decoder matched field names case-insensitively).
- A Graph `ref:` node with a malformed literal selector is now rejected at compile time. RGDs were already rejected by the `pkg/graph` builder with the same parser and validation, so nothing an RGD author could publish before is newly rejected.
