### PR TITLE
fix(graphengine): restore RGD validator / compiler / runtime parity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,15 +39,15 @@ linters:
           - unparam
           - gocyclo
         path: (_test\.go|^test/integration/.*\.go|^pkg/testutil/.*\.go)$
-      # Pre-existing staticcheck findings deferred to a dedicated cleanup PR
-      # (tracked in docs/pr-1355-open-todos.md). SA1019 deprecated-API
-      # migrations (scheme.Builder, client.Apply→SSA ApplyConfiguration,
-      # GetEventRecorderFor, sets.String, FieldsV1.Raw) change behavior/ripple
-      # through generated scaffolding, and two exported-symbol renames (ST1003:
-      # V1ApplySetIdFormat, ApiExtensionsClient) ripple across consumers — both
-      # are out of scope here. staticcheck is otherwise fully enabled (it was
-      # previously disabled entirely via checks: [-QF1008]); the follow-up PR
-      # does the SA1019 migration and drops these exclusions.
+      # Pre-existing staticcheck findings deferred to a dedicated cleanup PR.
+      # SA1019 deprecated-API migrations (scheme.Builder, client.Apply→SSA
+      # ApplyConfiguration, GetEventRecorderFor, sets.String, FieldsV1.Raw)
+      # change behavior/ripple through generated scaffolding, and two
+      # exported-symbol renames (ST1003: V1ApplySetIdFormat,
+      # ApiExtensionsClient) ripple across consumers — both are out of scope
+      # here. staticcheck is otherwise fully enabled (it was previously
+      # disabled entirely via checks: [-QF1008]); the follow-up PR does the
+      # SA1019 migration and drops these exclusions.
       - linters:
           - staticcheck
         text: "SA1019"
@@ -57,8 +57,8 @@ linters:
         path: (pkg/controller/instance/applyset/const\.go|pkg/client/fake/fake\.go)
       # ST1000 (missing package comment) is pervasive pre-existing doc debt
       # across ~36 packages repo-wide, unrelated to this PR. Deferred to the
-      # same follow-up cleanup PR (tracked in docs/pr-1355-open-todos.md);
-      # excluding it as a class avoids touching 36 unrelated packages here.
+      # same follow-up cleanup PR; excluding it as a class avoids touching 36
+      # unrelated packages here.
       - linters:
           - staticcheck
         text: "ST1000"

--- a/cmd/controller/graphengine.go
+++ b/cmd/controller/graphengine.go
@@ -50,6 +50,7 @@ func setupGraphController(
 	logger logr.Logger,
 	concurrentReconciles int,
 	maxCollectionSize int,
+	maxCollectionDimensionSize int,
 	applyConcurrency int,
 	controllerServiceAccount string,
 ) error {
@@ -103,17 +104,18 @@ func setupGraphController(
 	})
 
 	reconciler := &ctrlgraph.Reconciler{
-		Client:                   mgr.GetClient(),
-		Compiler:                 cmp,
-		Registry:                 reg,
-		Executor:                 exec,
-		Router:                   router,
-		SchemaWatcher:            sw,
-		MaxConcurrentReconciles:  concurrentReconciles,
-		MaxCollectionSize:        maxCollectionSize,
-		Impersonation:            impersonation,
-		RequireImpersonation:     true,
-		ControllerServiceAccount: controllerServiceAccount,
+		Client:                     mgr.GetClient(),
+		Compiler:                   cmp,
+		Registry:                   reg,
+		Executor:                   exec,
+		Router:                     router,
+		SchemaWatcher:              sw,
+		MaxConcurrentReconciles:    concurrentReconciles,
+		MaxCollectionSize:          maxCollectionSize,
+		MaxCollectionDimensionSize: maxCollectionDimensionSize,
+		Impersonation:              impersonation,
+		RequireImpersonation:       true,
+		ControllerServiceAccount:   controllerServiceAccount,
 	}
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup graph reconciler: %w", err)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -369,6 +369,7 @@ func main() {
 			rootLogger,
 			graphConcurrentReconciles,
 			rgdMaxCollectionSize,
+			rgdMaxCollectionDimensionSize,
 			applyConcurrency,
 			controllerSA,
 		); err != nil {

--- a/pkg/controller/graph/controller.go
+++ b/pkg/controller/graph/controller.go
@@ -72,6 +72,9 @@ type Reconciler struct {
 	SchemaWatcher           *schemawatcher.SchemaWatcher
 	MaxConcurrentReconciles int
 	MaxCollectionSize       int
+	// MaxCollectionDimensionSize caps the forEach axes per collection node
+	// (0 = runtime default); wired from --rgd-max-collection-dimension-size.
+	MaxCollectionDimensionSize int
 
 	// Impersonation, when set, resolves a per-Graph executor that applies the
 	// Graph's resources while impersonating a ServiceAccount in the Graph's
@@ -325,6 +328,7 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 	if r.MaxCollectionSize > 0 {
 		rtOpts = append(rtOpts, krotruntime.WithMaxCollectionSize(r.MaxCollectionSize))
 	}
+	rtOpts = append(rtOpts, krotruntime.WithMaxCollectionDimensions(r.MaxCollectionDimensionSize))
 	rt := krotruntime.New(prog, g, rtOpts...)
 	watcher := r.watcherFor(key)
 	previous := g.Status.ManagedResources

--- a/pkg/controller/graph/tracking.go
+++ b/pkg/controller/graph/tracking.go
@@ -228,10 +228,11 @@ func seedDefNodes(rt *krotruntime.Runtime) {
 
 // childRuntime builds the child runtime for a subgraph (NodeKindGraph) node the
 // SAME way the executor's applySubgraph does: seed the child scope from the
-// parent runtime's scope and carry MaxCollectionSize. Returns nil when the node
-// carries no compiled child program (a malformed subgraph the executor would
-// itself reject), so callers simply skip it — its identities are uncertain and
-// its post-apply entries, if any, record it.
+// parent runtime's scope and carry both collection caps (MaxCollectionSize and
+// MaxCollectionDimensions). Returns nil when the node carries no compiled child
+// program (a malformed subgraph the executor would itself reject), so callers
+// simply skip it — its identities are uncertain and its post-apply entries, if
+// any, record it.
 func childRuntime(rt *krotruntime.Runtime, n *krotruntime.Node) *krotruntime.Runtime {
 	sub := n.Spec().SubProgram
 	if sub == nil {
@@ -240,6 +241,7 @@ func childRuntime(rt *krotruntime.Runtime, n *krotruntime.Node) *krotruntime.Run
 	return krotruntime.New(sub, rt.Graph(),
 		krotruntime.WithSeedScope(rt.Scope()),
 		krotruntime.WithMaxCollectionSize(rt.MaxCollectionSize()),
+		krotruntime.WithMaxCollectionDimensions(rt.MaxCollectionDimensions()),
 	)
 }
 

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -65,6 +65,10 @@ type ReconcileConfig struct {
 	// MaxCollectionSize is the maximum number of instances a single
 	// forEach collection expansion may generate.
 	MaxCollectionSize int
+	// MaxCollectionDimensionSize caps the forEach axes per collection; wired
+	// from --rgd-max-collection-dimension-size so the runtime admits what RGD
+	// validation admitted. 0 keeps the runtime default.
+	MaxCollectionDimensionSize int
 	// ApplyConcurrency bounds the number of concurrent SSA apply operations
 	// executed in parallel for collection nodes. 0 means use default (20).
 	ApplyConcurrency int

--- a/pkg/controller/instance/controller_graph_engine.go
+++ b/pkg/controller/instance/controller_graph_engine.go
@@ -33,12 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
-	celunstructured "github.com/kubernetes-sigs/kro/pkg/cel/unstructured"
 	controllergraph "github.com/kubernetes-sigs/kro/pkg/controller/graph"
 	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/dynamiccontroller"
@@ -160,6 +158,7 @@ func (c *Controller) reconcileViaGraphEngine(
 	if c.reconcileConfig.MaxCollectionSize > 0 {
 		rtOpts = append(rtOpts, geruntime.WithMaxCollectionSize(c.reconcileConfig.MaxCollectionSize))
 	}
+	rtOpts = append(rtOpts, geruntime.WithMaxCollectionDimensions(c.reconcileConfig.MaxCollectionDimensionSize))
 	rt, _, err := rgdadapter.BuildRuntimeForInstanceCached(rgd, inst, c.graphEngineCompiler, c.programCache, rtOpts...)
 	if err != nil {
 		metrics.InstanceGraphResolutionFailuresTotal.WithLabelValues(gvrStr, "build_failed").Inc()
@@ -383,10 +382,12 @@ func (c *Controller) requeueUntilRGDSpecPopulated(ctx context.Context, inst *uns
 //
 // The inventory is written as the UNION of the newly-applied group-kinds/
 // namespaces and the prior parent "memory" (the values already recorded in the
-// instance's ApplySet annotations).  Mirroring applyset.Project, this union
-// guarantees the inventory never shrinks on a not-ready/degraded cycle — which
-// is what keeps the deletion path from finding zero managed resources and
-// orphaning children when a dependent is transiently withheld.
+// instance's ApplySet annotations), the same grow-only union the pre-apply
+// projection performs (candidateMetadata + applyset.Union; applyset.Project is
+// deletion-only). Growing rather than replacing guarantees the inventory never
+// shrinks on a not-ready/degraded cycle — which is what keeps the deletion path
+// from finding zero managed resources and orphaning children when a dependent
+// is transiently withheld.
 //
 // Pruning is gated on fullyResolved (!hardErr && no Unresolved nodes):
 // we must never prune while anything is unresolved, or we would delete
@@ -558,11 +559,6 @@ func (c *Controller) candidateMetadata(rt *geruntime.Runtime, inst *unstructured
 					rt.Set(n.ID(), list)
 				} else {
 					rt.Set(n.ID(), desired[0].Object)
-				}
-				if rt.Program() != nil {
-					if sc, ok := rt.Program().NodeSchemas[n.ID()]; ok && sc != nil {
-						rt.Scope()[n.ID()] = celunstructured.UnstructuredToVal(desired[0].Object, &openapi.Schema{Schema: sc})
-					}
 				}
 			}
 		}

--- a/pkg/controller/instance/controller_graph_engine_test.go
+++ b/pkg/controller/instance/controller_graph_engine_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
@@ -856,6 +857,59 @@ func TestReconcileViaGraphEngine_Success(t *testing.T) {
 
 		stored := getStoredParentObject(t, raw)
 		assert.Equal(t, metav1.ConditionTrue, conditionByType(t, stored, ResourcesReady).Status)
+	})
+
+	// ReconcileConfig.MaxCollectionDimensionSize must reach the per-reconcile
+	// runtime: a 3-axis collection is rejected under a cap of 2 and applied under 3.
+	t.Run("MaxCollectionDimensionSize is enforced by the instance runtime", func(t *testing.T) {
+		threeAxisSpec := func() *v1alpha1.ResourceGraphDefinitionSpec {
+			return &v1alpha1.ResourceGraphDefinitionSpec{
+				Schema: &v1alpha1.Schema{
+					Kind:       "WebApp",
+					Group:      "kro.run",
+					APIVersion: "v1alpha1",
+				},
+				Resources: []*v1alpha1.Resource{{
+					ID: "cms",
+					ForEach: []v1alpha1.ForEachDimension{
+						{"x": `${["a"]}`},
+						{"y": `${["b"]}`},
+						{"z": `${["c"]}`},
+					},
+					Template: apimachineryruntime.RawExtension{
+						Raw: []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"${x + '-' + y + '-' + z}","namespace":"default"},"data":{"key":"val"}}`),
+					},
+				}},
+			}
+		}
+
+		t.Run("cap below the declared axes fails the instance", func(t *testing.T) {
+			inst := newInstanceObject("demo", "default")
+			raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+			fakeRuntimeCl := newFakeRuntimeClient(t)
+			c, _ := newGraphEngineControllerUnderTest(t, raw, threeAxisSpec(), revisions.RevisionStateActive, comp, fakeRuntimeCl)
+			c.reconcileConfig.MaxCollectionDimensionSize = 2
+
+			err := c.reconcileViaGraphEngine(context.Background(), inst, &fakeInstanceWatcher{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "collection has 3 forEach dimensions, exceeds the maximum of 2")
+		})
+
+		t.Run("cap at the declared axes applies the collection", func(t *testing.T) {
+			inst := newInstanceObject("demo", "default")
+			raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+			fakeRuntimeCl := newFakeRuntimeClient(t)
+			c, _ := newGraphEngineControllerUnderTest(t, raw, threeAxisSpec(), revisions.RevisionStateActive, comp, fakeRuntimeCl)
+			c.reconcileConfig.MaxCollectionDimensionSize = 3
+
+			err := c.reconcileViaGraphEngine(context.Background(), inst, &fakeInstanceWatcher{})
+			require.NoError(t, err)
+
+			stored := getStoredParentObject(t, raw)
+			assert.Equal(t, metav1.ConditionTrue, conditionByType(t, stored, ResourcesReady).Status)
+			var cm corev1.ConfigMap
+			require.NoError(t, fakeRuntimeCl.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "a-b-c"}, &cm))
+		})
 	})
 
 	t.Run("NewController sets ApplyConcurrency on executor", func(t *testing.T) {

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -194,11 +194,12 @@ func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 	instCtrl := instancectrl.NewController(
 		instanceLogger,
 		instancectrl.ReconcileConfig{
-			DefaultRequeueDuration: r.cfg.InstanceRequeueInterval,
-			HasAuthorConditions:    len(processedRGD.Instance.Conditions) > 0,
-			MaxCollectionSize:      r.cfg.RGDConfig.MaxCollectionSize,
-			ApplyConcurrency:       r.cfg.ApplyConcurrency,
-			CELCostLimit:           r.cfg.CELCostLimit,
+			DefaultRequeueDuration:     r.cfg.InstanceRequeueInterval,
+			HasAuthorConditions:        len(processedRGD.Instance.Conditions) > 0,
+			MaxCollectionSize:          r.cfg.RGDConfig.MaxCollectionSize,
+			MaxCollectionDimensionSize: r.cfg.RGDConfig.MaxCollectionDimensionSize,
+			ApplyConcurrency:           r.cfg.ApplyConcurrency,
+			CELCostLimit:               r.cfg.CELCostLimit,
 		},
 		gvr,
 		r.revisionsRegistry.ResolverFor(rgd.Name),

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -69,7 +69,6 @@ var (
 		"externalRefs",
 		"externalReferences",
 		"graph",
-		"graphengine",
 		"instance",
 		"item",
 		"items",

--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -107,7 +107,7 @@ func TestIsKROReservedWord(t *testing.T) {
 	}{
 		{"resourcegraphdefinition", true},
 		{"instance", true},
-		{"graphengine", true},
+		{"graphengine", false},
 		{"each", true}, // Reserved for per-item readiness in collections
 		{"notReserved", false},
 		{"RESOURCEGRAPHDEFINITION", false}, // Case-sensitive check

--- a/pkg/graphengine/compiler/compiler.go
+++ b/pkg/graphengine/compiler/compiler.go
@@ -198,8 +198,8 @@ func WithSoftDependencies(nodeID string) CompileOption {
 // WithDataPendingTolerant marks a node so that a field whose expression is
 // data-pending is omitted from the rendered object rather than failing the
 // whole node. The node still applies its remaining resolved fields. Used with
-// WithSoftDependencies for the author-status writeback node so status fields
-// appear progressively, mirroring ProjectInstanceStatus's per-field skip.
+// WithSoftDependencies for the RGD adapter's synthesized author-status patch
+// node (rgdadapter.StatusPatchNodeID) so status fields appear progressively.
 func WithDataPendingTolerant(nodeID string) CompileOption {
 	return func(o *compileOptions) {
 		if o.dataPendingTolerant == nil {

--- a/pkg/graphengine/compiler/compiler_test.go
+++ b/pkg/graphengine/compiler/compiler_test.go
@@ -417,30 +417,31 @@ func TestCompile(t *testing.T) {
 			wantErr: "references its own id",
 		},
 		{
-			// Finding 4: an optional<bool> condition becomes a runtime error
-			// when empty (optional.none()); reject it at compile time with a
-			// hint to collapse it to a concrete bool.
-			name: "readyWhen returning optional<bool> is rejected",
+			// optional<bool> is accepted (the runtime reads an empty optional as
+			// false); `${cm.?immutable}` is optional_type(bool) because
+			// ConfigMap.immutable is a typed bool field.
+			name: "readyWhen returning optional<bool> is accepted",
 			graph: generator.NewGraph("g",
 				generator.WithTemplate("cm", configMap("source")),
-				// optional.of(true) is optional_type(bool) with no collapse.
-				generator.WithReadyWhen("${optional.of(true)}"),
+				generator.WithReadyWhen("${cm.?immutable}"),
 			),
-			wantErr: "optional<bool>",
+			after: func(t *testing.T, prog *Program, _ *expv1alpha1.Graph) {
+				require.Len(t, prog.Nodes["cm"].ReadyWhen, 1)
+			},
 		},
 		{
-			// Finding 4: same rejection for includeWhen.
-			name: "includeWhen returning optional<bool> is rejected",
+			name: "includeWhen returning optional<bool> is accepted",
 			graph: generator.NewGraph("g",
 				generator.WithTemplate("cm", configMap("source")),
 				generator.WithDef("guarded", map[string]any{"k": "v"}),
 				generator.WithIncludeWhen("${optional.of(true)}"),
 			),
-			wantErr: "orValue(false)",
+			after: func(t *testing.T, prog *Program, _ *expv1alpha1.Graph) {
+				require.Len(t, prog.Nodes["guarded"].IncludeWhen, 1)
+			},
 		},
 		{
-			// Finding 4: the .orValue(false) escape hatch collapses to a
-			// concrete bool and still compiles.
+			// The .orValue(false) collapse to a concrete bool still compiles.
 			name: "readyWhen optional collapsed with orValue is accepted",
 			graph: generator.NewGraph("g",
 				generator.WithTemplate("cm", configMap("source")),
@@ -451,16 +452,13 @@ func TestCompile(t *testing.T) {
 			},
 		},
 		{
-			name: "readyWhen returning optional<bool> is accepted (via ?-accessor or optional macros)",
+			// optional<non-bool> is still a type error.
+			name: "readyWhen returning optional<string> is rejected",
 			graph: generator.NewGraph("g",
 				generator.WithTemplate("cm", configMap("source")),
-				// optional.of(true) returns optional_type(bool), exercising
-				// the IsBoolOrOptionalBool branch.
-				generator.WithReadyWhen("${optional.of(true).orValue(true)}"),
+				generator.WithReadyWhen("${cm.metadata.?name}"),
 			),
-			after: func(t *testing.T, prog *Program, _ *expv1alpha1.Graph) {
-				require.Len(t, prog.Nodes["cm"].ReadyWhen, 1)
-			},
+			wantErr: "must return bool",
 		},
 		{
 			name: "readyWhen that references another node is rejected",

--- a/pkg/graphengine/compiler/typecheck.go
+++ b/pkg/graphengine/compiler/typecheck.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	krocel "github.com/kubernetes-sigs/kro/pkg/cel"
+	"github.com/kubernetes-sigs/kro/pkg/cel/conversion"
 	"github.com/kubernetes-sigs/kro/pkg/graph/fieldpath"
 	"github.com/kubernetes-sigs/kro/pkg/graph/schema"
 	"github.com/kubernetes-sigs/kro/pkg/graph/variable"
@@ -324,9 +325,10 @@ func validateAndCompileNode(bc *buildContext, n *Node, payloadSchema *spec.Schem
 
 // validateAndCompileConditions compiles each bool-returning condition
 // expression against bc.env. Verifies the output is assignable to bool —
-// concretely-typed bools pass; dyn passes (def-sourced expressions can't
-// be statically narrowed to bool); anything else (string, int, list, etc.)
-// is almost always a user mistake.
+// concretely-typed bools pass; optional<bool> passes (the runtime treats an
+// empty optional as false, see runtime.conditionResult); dyn passes
+// (def-sourced expressions can't be statically narrowed to bool); anything
+// else (string, int, list, etc.) is almost always a user mistake.
 func validateAndCompileConditions(bc *buildContext, env *cel.Env, exprs []*krocel.Expression, nodeID, kind string) error {
 	for i, expr := range exprs {
 		checked, err := bc.compile(env, expr)
@@ -334,33 +336,17 @@ func validateAndCompileConditions(bc *buildContext, env *cel.Env, exprs []*kroce
 			return fmt.Errorf("node %q: %s[%d] (%q): %w", nodeID, kind, i, expr.UserExpression(), err)
 		}
 		out := checked.OutputType()
-		// Accept bool or dyn. dyn covers def-sourced expressions (the static
-		// type can't be narrowed). An optional<bool> is rejected: an empty
-		// optional (optional.none()) has no boolean value, which becomes a
-		// runtime error where a condition must decide include/ready. Reject it
-		// at compile time and tell the author to collapse it to a concrete
-		// bool. Anything else (string, int, list, struct) is a user mistake.
-		if isOptionalBool(out) {
-			return fmt.Errorf("node %q: %s[%d] (%q) returns optional<bool>, which becomes a runtime error when empty; "+
-				"make it a concrete bool (e.g. append .orValue(false))",
-				nodeID, kind, i, expr.UserExpression())
+		// Accept bool, optional<bool> (the same check the RGD-level validator
+		// applies; the runtime reads an empty optional as false) or dyn
+		// (def-sourced expressions can't be narrowed). Anything else (string,
+		// int, list, struct) is a user mistake.
+		if conversion.IsBoolOrOptionalBool(out) || out == cel.DynType {
+			continue
 		}
-		if !cel.BoolType.IsAssignableType(out) && out != cel.DynType {
-			return fmt.Errorf("node %q: %s[%d] (%q) must return bool, got %s",
-				nodeID, kind, i, expr.UserExpression(), out.String())
-		}
+		return fmt.Errorf("node %q: %s[%d] (%q) must return bool, got %s",
+			nodeID, kind, i, expr.UserExpression(), out.String())
 	}
 	return nil
-}
-
-// isOptionalBool reports whether t is optional<bool> (as opposed to a plain
-// bool or dyn). Used to reject optional-typed condition expressions, whose
-// empty case has no boolean value.
-func isOptionalBool(t *cel.Type) bool {
-	if cel.BoolType.IsAssignableType(t) {
-		return false // a plain bool, not an optional
-	}
-	return cel.OptionalType(cel.BoolType).IsAssignableType(t)
 }
 
 // validateAndCompileForEach compiles each forEach axis, requires it to

--- a/pkg/graphengine/compiler/validation.go
+++ b/pkg/graphengine/compiler/validation.go
@@ -40,12 +40,14 @@ var (
 	// for itself — graph-level vocabulary that must not collide with user
 	// node IDs. Keep this list to names we actually reference (or plan to
 	// reference imminently); over-reservation breaks user graphs without
-	// telling them why.
+	// telling them why. It must stay a subset of graph.kroReservedKeyWords
+	// (TestReservedNodeIDsSynchronizedWithGraph), so a name added here alone
+	// ends up reserved for every existing RGD too.
 	reservedNodeIDs = sets.New(
 		// Kubernetes manifest top-level fields and common subsections.
 		"apiVersion", "kind", "metadata", "namespace", "spec", "status",
-		// Project namespace.
-		"graph", "graphengine", "kro",
+		// Project namespace ("graphengine" is a legitimate user id, not reserved).
+		"graph", "kro",
 		// CEL / runtime identifiers we wire in.
 		"each", "item", "items", "object", "self", "this", "context",
 	).Union(celReservedSymbols)

--- a/pkg/graphengine/compiler/validation_test.go
+++ b/pkg/graphengine/compiler/validation_test.go
@@ -36,6 +36,7 @@ func TestValidateNodeID(t *testing.T) {
 		{name: "camelCase", id: "myConfig"},
 		{name: "upper", id: "Pod"},
 		{name: "with digits", id: "vpc1"},
+		{name: "graphengine not reserved", id: "graphengine"},
 		{name: "empty", id: "", wantErr: "required"},
 		{name: "starts with digit", id: "1vpc", wantErr: "must match"},
 		{name: "hyphen rejected", id: "vpc-1", wantErr: "must match"},

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -1385,6 +1385,7 @@ func (s *Simple) applySubgraph(ctx context.Context, rt *runtime.Runtime, w watch
 	childRT := runtime.New(sub, rt.Graph(),
 		runtime.WithSeedScope(rt.Scope()),
 		runtime.WithMaxCollectionSize(rt.MaxCollectionSize()),
+		runtime.WithMaxCollectionDimensions(rt.MaxCollectionDimensions()),
 	)
 
 	prefix := n.ID() + "/"
@@ -1853,6 +1854,11 @@ const patchFieldManagerPrefix = "kro-graphengine.patch."
 // subgraphs that reuse a local id distinct; embedding graphSeg lets the
 // conflict classifier recognize two managers of the same Graph as our own
 // (vs a peer). nodeID is the node's fully-qualified path (e.g. "subA/res").
+//
+// graphSeg distinguishes Graphs only on the standalone Graph path. On the
+// RGD/instance path the adapter's Graph has no UID (rgdadapter.stampGraphMeta
+// sets only name/namespace), so graphSeg is the constant sha256("")[:12] for
+// every instance and must not be read as an instance identity.
 //
 // Exported as PatchFieldManager so the graph controller's contribution
 // write-ahead projects the SAME field-manager identity the executor will apply

--- a/pkg/graphengine/rgdadapter/graph_translate.go
+++ b/pkg/graphengine/rgdadapter/graph_translate.go
@@ -105,8 +105,7 @@ const StatusPatchNodeID = "instance"
 // status so their ${...} CEL is compiled and type-checked like any patch
 // manifest. BuildRuntimeForInstance marks this node soft-deps +
 // per-field-tolerant so it never gates on the resources it reads and omits
-// unresolved fields (mirroring ProjectInstanceStatus's per-field progressive
-// projection).
+// unresolved fields, so author status projects progressively.
 func authorStatusPatchNode(rgd *v1alpha1.ResourceGraphDefinition) (v1alpha1.Node, bool, error) {
 	if rgd.Spec.Schema == nil {
 		return v1alpha1.Node{}, false, nil

--- a/pkg/graphengine/rgdadapter/runtime.go
+++ b/pkg/graphengine/rgdadapter/runtime.go
@@ -102,14 +102,17 @@ func BuildRuntimeForInstance(
 		return nil, nil, fmt.Errorf("rgdadapter: compile: %w", err)
 	}
 
-	// Step 5: construct the runtime.
+	// Step 5: construct the runtime. As in BuildRuntimeForInstanceCached, the
+	// objectOverride keeps the typed `schema` seed through runtime.New and
+	// makes Runtime.Set republish it wrapped in the declared schema.
 	schemaData, err := instanceSchemaValue(instance)
 	if err != nil {
 		return nil, nil, fmt.Errorf("rgdadapter: schema value: %w", err)
 	}
 	var rtOpts []runtime.Option
 	if seedOpt := instanceSeedScopeOption(rgd, schemaData); seedOpt != nil {
-		rtOpts = append(rtOpts, seedOpt)
+		rtOpts = append(rtOpts, seedOpt,
+			runtime.WithNodeObjectOverride(SchemaNodeID, &unstructured.Unstructured{Object: schemaData}))
 	}
 	rtOpts = append(rtOpts, opts...)
 	rt := runtime.New(prog, g, rtOpts...)
@@ -268,10 +271,10 @@ func instanceSeedScopeOption(rgd *v1alpha1.ResourceGraphDefinition, schemaData m
 //   - its type is taken from the RGD's declared SimpleSchema (override), not
 //     inferred from the current instance value, so a fresh instance missing
 //     fields must still compile;
-//   - a synthesized author-status writeback node is marked soft-deps (never
-//     gates on the resources it reads) and per-field data-pending-tolerant so
-//     status projects progressively and non-gating, mirroring
-//     ProjectInstanceStatus.
+//   - the synthesized author-status patch node (authorStatusPatchNode,
+//     StatusPatchNodeID) is marked soft-deps (never gates on the resources it
+//     reads) and per-field data-pending-tolerant so author status projects
+//     progressively and non-gating.
 func schemaCompileOpts(rgd *v1alpha1.ResourceGraphDefinition, g *v1alpha1.Graph) ([]compiler.CompileOption, error) {
 	opts := []compiler.CompileOption{compiler.WithLiteralNode(SchemaNodeID)}
 	if rgd.Spec.Schema != nil {

--- a/pkg/graphengine/rgdadapter/runtime_cache_test.go
+++ b/pkg/graphengine/rgdadapter/runtime_cache_test.go
@@ -328,3 +328,57 @@ func TestBuildRuntimeForInstanceCached_FallsBack(t *testing.T) {
 		require.NotNil(t, rt)
 	})
 }
+
+// TestBuildRuntimeForInstanceCached_SchemaKeepsDeclaredTypingAfterPublish
+// pins that `schema` keeps its declared-schema CEL typing after the executor
+// republishes it through Runtime.Set: metadata.creationTimestamp is
+// format: date-time, so getFullYear() only resolves while the value is typed.
+func TestBuildRuntimeForInstanceCached_SchemaKeepsDeclaredTypingAfterPublish(t *testing.T) {
+	rgd := &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "yearapp"},
+		Spec: v1alpha1.ResourceGraphDefinitionSpec{
+			Schema: &v1alpha1.Schema{
+				APIVersion: "v1alpha1",
+				Kind:       "YearApp",
+				Spec:       runtime.RawExtension{Raw: []byte(`{"value":"string"}`)},
+			},
+			Resources: []*v1alpha1.Resource{{
+				ID: "cm",
+				Template: rawResource(map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]any{"name": "cm", "namespace": "default"},
+					"data":       map[string]any{"year": "${string(schema.metadata.creationTimestamp.getFullYear())}"},
+				}),
+			}},
+		},
+	}
+	inst := webInstance("a", "default", "x")
+	inst.Object["kind"] = "YearApp"
+	inst.Object["metadata"].(map[string]any)["creationTimestamp"] = "2024-05-06T07:08:09Z"
+
+	rt, _, err := BuildRuntimeForInstanceCached(rgd, inst, newTestCompiler(t), registry.New())
+	require.NoError(t, err)
+
+	resolveYear := func() string {
+		t.Helper()
+		cmObjs, err := rt.Node("cm").Resolve()
+		require.NoError(t, err)
+		require.Len(t, cmObjs, 1)
+		return nestedString(t, cmObjs[0].Object, "data", "year")
+	}
+
+	assert.Equal(t, "2024", resolveYear(), "seeded schema value must carry declared-schema typing")
+
+	// Publish the schema node as the executor does (SetObserved + publishScope).
+	schemaNode := rt.Node(SchemaNodeID)
+	schemaObjs, err := schemaNode.Resolve()
+	require.NoError(t, err)
+	require.Len(t, schemaObjs, 1)
+	schemaNode.SetObserved(schemaObjs, schemaObjs)
+	rt.Set(SchemaNodeID, schemaObjs[0].Object)
+
+	_, isRawMap := rt.Scope()[SchemaNodeID].(map[string]any)
+	assert.False(t, isRawMap, "publishing the overridden schema node must not downgrade it to a raw map")
+	assert.Equal(t, "2024", resolveYear(), "published schema value must keep declared-schema typing")
+}

--- a/pkg/graphengine/rgdadapter/status.go
+++ b/pkg/graphengine/rgdadapter/status.go
@@ -96,7 +96,7 @@ func ProjectInstanceConditions(
 	}
 
 	// Build a CEL env WITH library.Runtime() so runtime.newCondition compiles.
-	// All node IDs are declared (see ProjectInstanceStatus) so a condition
+	// All node IDs are declared (see buildStatusEnvForNodes) so a condition
 	// referencing an unpublished node is a skippable data-pending error.
 	env, err := buildStatusEnvForNodes(rt, true)
 	if err != nil {
@@ -320,9 +320,6 @@ func buildStatusEnvForNodes(rt *runtime.Runtime, includeRuntime bool) (*cel.Env,
 	}
 	return krocel.DefaultEnvironment(opts...)
 }
-
-// getAtPath removed with ProjectInstanceStatus (author status is now written
-// by the synthesized status-patch node); see git history.
 
 // compileCEL parses, type-checks, and programs a plain CEL expression (no
 // ${…} wrapper) against env, wrapping each stage's error with expr context.

--- a/pkg/graphengine/runtime/collection.go
+++ b/pkg/graphengine/runtime/collection.go
@@ -27,8 +27,8 @@ import (
 // objects per reconcile — a runaway. This cap keeps the expansion bounded.
 const DefaultMaxCollectionSize = 1000
 
-// DefaultMaxCollectionDimensions is the maximum number of forEach axes
-// a collection node may declare.
+// DefaultMaxCollectionDimensions is the default maximum number of forEach
+// axes a collection node may declare (see WithMaxCollectionDimensions).
 const DefaultMaxCollectionDimensions = 10
 
 // identityKey returns the GVK + namespace + name string used to dedup
@@ -125,16 +125,16 @@ type evaluatedDimension struct {
 }
 
 // cartesianProduct computes the cartesian product of multiple axes and
-// caps the total combination count at maxSize. Each output row maps
-// every iterator name to one value from its source list. Any zero-length
-// source short-circuits the whole expansion to empty (the SQL outer-join
-// semantics).
-func cartesianProduct(dims []evaluatedDimension, maxSize int) ([]map[string]any, error) {
+// caps the total combination count at maxSize and the number of axes at
+// maxDims. Each output row maps every iterator name to one value from its
+// source list. Any zero-length source short-circuits the whole expansion to
+// empty (the SQL outer-join semantics).
+func cartesianProduct(dims []evaluatedDimension, maxSize, maxDims int) ([]map[string]any, error) {
 	if len(dims) == 0 {
 		return []map[string]any{{}}, nil
 	}
-	if len(dims) > DefaultMaxCollectionDimensions {
-		return nil, fmt.Errorf("collection has %d forEach dimensions, exceeds the maximum of %d", len(dims), DefaultMaxCollectionDimensions)
+	if len(dims) > maxDims {
+		return nil, fmt.Errorf("collection has %d forEach dimensions, exceeds the maximum of %d", len(dims), maxDims)
 	}
 	total := 1
 	for _, d := range dims {

--- a/pkg/graphengine/runtime/coverage_test.go
+++ b/pkg/graphengine/runtime/coverage_test.go
@@ -66,7 +66,7 @@ func TestCartesianProductOverflowRejected(t *testing.T) {
 	for i := range dims {
 		dims[i] = evaluatedDimension{name: "a", values: axis}
 	}
-	rows, err := cartesianProduct(dims, 0)
+	rows, err := cartesianProduct(dims, 0, DefaultMaxCollectionDimensions)
 	require.Error(t, err, "overflow must be rejected even when cap disabled")
 	assert.Contains(t, err.Error(), "overflows")
 	assert.Nil(t, rows)
@@ -84,7 +84,7 @@ func TestCartesianProductDimensionCap(t *testing.T) {
 	for i := range dims10 {
 		dims10[i] = evaluatedDimension{name: fmt.Sprintf("d%d", i), values: []any{1}}
 	}
-	rows, err := cartesianProduct(dims10, 0)
+	rows, err := cartesianProduct(dims10, 0, DefaultMaxCollectionDimensions)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 
@@ -93,9 +93,67 @@ func TestCartesianProductDimensionCap(t *testing.T) {
 	for i := range dims11 {
 		dims11[i] = evaluatedDimension{name: fmt.Sprintf("d%d", i), values: []any{1}}
 	}
-	_, err = cartesianProduct(dims11, 0)
+	_, err = cartesianProduct(dims11, 0, DefaultMaxCollectionDimensions)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("collection has %d forEach dimensions, exceeds the maximum of %d", len(dims11), DefaultMaxCollectionDimensions))
+}
+
+// TestRuntimeMaxCollectionDimensionsOption pins WithMaxCollectionDimensions:
+// custom values apply, <= 0 keeps the default.
+func TestRuntimeMaxCollectionDimensionsOption(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []Option
+		want int
+	}{
+		{name: "default-cap", opts: nil, want: DefaultMaxCollectionDimensions},
+		{name: "custom-cap", opts: []Option{WithMaxCollectionDimensions(12)}, want: 12},
+		{name: "zero-keeps-default", opts: []Option{WithMaxCollectionDimensions(0)}, want: DefaultMaxCollectionDimensions},
+		{name: "negative-keeps-default", opts: []Option{WithMaxCollectionDimensions(-1)}, want: DefaultMaxCollectionDimensions},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := generator.NewGraph("g",
+				generator.WithNamespace("default"),
+				generator.WithDef("seed", map[string]any{"k": "v"}),
+			)
+			prog := compileGraph(t, g)
+			rt := New(prog, g, tc.opts...)
+			assert.Equal(t, tc.want, rt.MaxCollectionDimensions())
+		})
+	}
+}
+
+// TestNodeExpandHonoursConfiguredDimensionCap pins that expansion uses the
+// Runtime's configured axis cap, not the package default.
+func TestNodeExpandHonoursConfiguredDimensionCap(t *testing.T) {
+	g := generator.NewGraph("g",
+		generator.WithDef("src", map[string]any{
+			"a": []any{"1"}, "b": []any{"2"}, "c": []any{"3"},
+		}),
+		generator.WithTemplate("cm", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "${x + y + z}"},
+			"data":     map[string]any{"k": "v"},
+		},
+			generator.ForEachDim("x", "${src.a}"),
+			generator.ForEachDim("y", "${src.b}"),
+			generator.ForEachDim("z", "${src.c}"),
+		),
+	)
+	prog := compileGraph(t, g)
+
+	tooLow := New(prog, g, WithMaxCollectionDimensions(2))
+	setFirst(tooLow, "src")
+	_, err := tooLow.Node("cm").Resolve()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collection has 3 forEach dimensions, exceeds the maximum of 2")
+
+	ok := New(prog, g, WithMaxCollectionDimensions(3))
+	setFirst(ok, "src")
+	out, err := ok.Node("cm").Resolve()
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
 }
 
 // TestCartesianProductHonoursCap regression-pins the post-multiply cap
@@ -105,7 +163,7 @@ func TestCartesianProductHonoursCap(t *testing.T) {
 		{name: "a", values: []any{1, 2, 3}},
 		{name: "b", values: []any{1, 2, 3}},
 	}
-	_, err := cartesianProduct(dims, 5)
+	_, err := cartesianProduct(dims, 5, DefaultMaxCollectionDimensions)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds")
 }

--- a/pkg/graphengine/runtime/helpers_test.go
+++ b/pkg/graphengine/runtime/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/kubernetes-sigs/kro/pkg/cel/sentinels"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/compiler"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
 )
@@ -268,7 +269,7 @@ func TestCartesianProduct_EmptyDimensions(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := cartesianProduct(tc.dims, DefaultMaxCollectionSize)
+			got, err := cartesianProduct(tc.dims, DefaultMaxCollectionSize, DefaultMaxCollectionDimensions)
 			assert.NoError(t, err)
 			if tc.wantNil {
 				assert.Nil(t, got)
@@ -469,4 +470,31 @@ func TestWithSeedScope(t *testing.T) {
 	rt.Set("captured", "overwritten")
 	assert.Equal(t, map[string]any{"name": "from-parent"}, parentScope["captured"],
 		"seed is copied; child mutation must not leak back to the source")
+}
+
+// TestConditionResult pins that both shapes of an empty optional — nil
+// (CELOmitFunction off) and sentinels.Omit (on) — read as false, and that any
+// other non-bool is still rejected.
+func TestConditionResult(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		in     any
+		want   bool
+		wantOK bool
+	}{
+		{name: "true", in: true, want: true, wantOK: true},
+		{name: "false", in: false, want: false, wantOK: true},
+		{name: "nil (empty optional, gate off)", in: nil, want: false, wantOK: true},
+		{name: "omit sentinel (empty optional, gate on)", in: sentinels.Omit{}, want: false, wantOK: true},
+		{name: "string is not a bool", in: "true", wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := conditionResult(tc.in)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/pkg/graphengine/runtime/node.go
+++ b/pkg/graphengine/runtime/node.go
@@ -166,7 +166,7 @@ func (n *Node) computeIgnored() (bool, error) {
 			}
 			return false, fmt.Errorf("node %q: includeWhen %q: %w", n.spec.ID, expr.UserExpression(), err)
 		}
-		b, ok := v.(bool)
+		b, ok := conditionResult(v)
 		if !ok {
 			return false, fmt.Errorf("node %q: includeWhen %q returned %T, want bool", n.spec.ID, expr.UserExpression(), v)
 		}
@@ -176,6 +176,22 @@ func (n *Node) computeIgnored() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// conditionResult coerces an evaluated includeWhen/readyWhen value to a bool.
+// nil (a CEL null or an empty optional) and sentinels.Omit (an empty optional
+// under CELOmitFunction) read as false, so `${cm.?immutable}` on an absent
+// field means not-included / not-ready rather than a hard error; ok is false
+// for any other non-bool value.
+func conditionResult(v any) (result bool, ok bool) {
+	switch b := v.(type) {
+	case bool:
+		return b, true
+	case nil, sentinels.Omit:
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 // CheckReadiness evaluates readyWhen against the node's observed state.
@@ -227,7 +243,7 @@ func (n *Node) CheckReadiness() error {
 			}
 			return fmt.Errorf("node %q: readyWhen %q: %w", n.spec.ID, expr.UserExpression(), err)
 		}
-		b, ok := v.(bool)
+		b, ok := conditionResult(v)
 		if !ok {
 			return fmt.Errorf("node %q: readyWhen %q returned %T, want bool", n.spec.ID, expr.UserExpression(), v)
 		}
@@ -276,7 +292,7 @@ func (n *Node) checkCollectionReadiness() error {
 				}
 				return fmt.Errorf("node %q: readyWhen %q (item %d): %w", n.spec.ID, expr.UserExpression(), i, err)
 			}
-			b, ok := v.(bool)
+			b, ok := conditionResult(v)
 			if !ok {
 				return fmt.Errorf("node %q: readyWhen %q (item %d) returned %T, want bool", n.spec.ID, expr.UserExpression(), i, v)
 			}
@@ -433,7 +449,7 @@ func (n *Node) expand() ([]map[string]any, error) {
 		}
 		dims = append(dims, evaluatedDimension{name: axis.Name, values: items})
 	}
-	rows, err := cartesianProduct(dims, n.rt.maxCollectionSize)
+	rows, err := cartesianProduct(dims, n.rt.maxCollectionSize, n.rt.maxCollectionDimensions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graphengine/runtime/node_test.go
+++ b/pkg/graphengine/runtime/node_test.go
@@ -138,6 +138,39 @@ func TestNode_IsIgnored(t *testing.T) {
 			assertID: "guarded",
 			wantErr:  ErrDataPending.Error(),
 		},
+		{
+			// An empty optional (`cm.?immutable` with no immutable field) reads
+			// as false: the node is ignored rather than hard-erroring on nil.
+			name: "includeWhen optional<bool> that is empty → ignored",
+			graph: generator.NewGraph("g",
+				generator.WithTemplate("cm", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "cm"},
+					"data":     map[string]any{"k": "v"},
+				}),
+				generator.WithDef("guarded", map[string]any{"x": "y"}),
+				generator.WithIncludeWhen("${cm.?immutable}"),
+			),
+			populate: func(rt *Runtime) { setFirst(rt, "cm") },
+			assertID: "guarded",
+			want:     true,
+		},
+		{
+			name: "includeWhen optional<bool> that is present → honoured",
+			graph: generator.NewGraph("g",
+				generator.WithTemplate("cm", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata":  map[string]any{"name": "cm"},
+					"immutable": true,
+					"data":      map[string]any{"k": "v"},
+				}),
+				generator.WithDef("guarded", map[string]any{"x": "y"}),
+				generator.WithIncludeWhen("${cm.?immutable}"),
+			),
+			populate: func(rt *Runtime) { setFirst(rt, "cm") },
+			assertID: "guarded",
+			want:     false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -269,6 +302,66 @@ func TestNode_CheckReadiness(t *testing.T) {
 			},
 			assertID: "svc",
 			wantErr:  "want bool",
+		},
+		{
+			// An empty optional (`cm.?immutable` with no immutable field) means
+			// not ready, not a hard error.
+			name: "readyWhen optional<bool> that is empty → waiting",
+			graph: generator.NewGraph("g",
+				generator.WithTemplate("cm", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "cm"},
+					"data":     map[string]any{"k": "v"},
+				}),
+				generator.WithReadyWhen("${cm.?immutable}"),
+			),
+			populate: func(rt *Runtime) {
+				objs, _ := rt.Node("cm").Resolve()
+				rt.Set("cm", objs[0].Object)
+				rt.Node("cm").SetObserved(objs, objs)
+			},
+			assertID:    "cm",
+			wantWaiting: true,
+		},
+		{
+			name: "readyWhen optional<bool> that is present → ready",
+			graph: generator.NewGraph("g",
+				generator.WithTemplate("cm", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata":  map[string]any{"name": "cm"},
+					"immutable": true,
+					"data":      map[string]any{"k": "v"},
+				}),
+				generator.WithReadyWhen("${cm.?immutable}"),
+			),
+			populate: func(rt *Runtime) {
+				objs, _ := rt.Node("cm").Resolve()
+				rt.Set("cm", objs[0].Object)
+				rt.Node("cm").SetObserved(objs, objs)
+			},
+			assertID: "cm",
+			wantNil:  true,
+		},
+		{
+			// Per-item evaluation with `each`: an empty optional on any item
+			// means the collection is not ready.
+			name: "collection readyWhen optional<bool> that is empty → waiting",
+			graph: generator.NewGraph("g",
+				generator.WithDef("src", map[string]any{"names": []any{"a", "b"}}),
+				generator.WithTemplate("cms", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "${'cm-' + n}"},
+					"data":     map[string]any{"k": "v"},
+				}, generator.ForEachDim("n", "${src.names}")),
+				generator.WithReadyWhen("${each.?immutable}"),
+			),
+			populate: func(rt *Runtime) {
+				setFirst(rt, "src")
+				objs, _ := rt.Node("cms").Resolve()
+				rt.Node("cms").SetObserved(objs, objs)
+			},
+			assertID:    "cms",
+			wantWaiting: true,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/graphengine/runtime/runtime.go
+++ b/pkg/graphengine/runtime/runtime.go
@@ -61,6 +61,11 @@ type Runtime struct {
 	// the overflow safeguard in cartesianProduct still active).
 	maxCollectionSize int
 
+	// maxCollectionDimensions caps the number of forEach axes a collection
+	// node may expand. Per Runtime so it can follow the RGD-level
+	// --rgd-max-collection-dimension-size; always > 0.
+	maxCollectionDimensions int
+
 	// nodeObjectOverrides replaces a literal Def node's compiled payload with
 	// a per-Runtime value at render time. This is what lets one compiled
 	// Program be shared across every instance of a revision: the `schema`
@@ -79,6 +84,17 @@ type Option func(*Runtime)
 // Use 0 to disable the cap entirely.
 func WithMaxCollectionSize(n int) Option {
 	return func(r *Runtime) { r.maxCollectionSize = n }
+}
+
+// WithMaxCollectionDimensions overrides the default cap on forEach axes per
+// collection node (DefaultMaxCollectionDimensions). n <= 0 keeps the default;
+// unlike the size cap there is no unlimited mode.
+func WithMaxCollectionDimensions(n int) Option {
+	return func(r *Runtime) {
+		if n > 0 {
+			r.maxCollectionDimensions = n
+		}
+	}
 }
 
 // WithNodeObjectOverride replaces the literal payload of the named Def node
@@ -112,6 +128,10 @@ func WithSeedScope(seed map[string]any) Option {
 // MaxCollectionSize returns this Runtime's forEach expansion cap.
 func (r *Runtime) MaxCollectionSize() int { return r.maxCollectionSize }
 
+// MaxCollectionDimensions returns this Runtime's cap on forEach axes per
+// collection node.
+func (r *Runtime) MaxCollectionDimensions() int { return r.maxCollectionDimensions }
+
 // New constructs a Runtime around the supplied Program and source Graph.
 // Dependency pointers are wired so each Node can walk its transitive
 // upstream set without touching the Program directly.
@@ -128,11 +148,12 @@ func New(prog *compiler.Program, g *expv1alpha1.Graph, opts ...Option) *Runtime 
 	}
 
 	rt := &Runtime{
-		program:           prog,
-		graph:             g,
-		scope:             make(map[string]any, nodeCount),
-		byID:              make(map[string]*Node, nodeCount),
-		maxCollectionSize: DefaultMaxCollectionSize,
+		program:                 prog,
+		graph:                   g,
+		scope:                   make(map[string]any, nodeCount),
+		byID:                    make(map[string]*Node, nodeCount),
+		maxCollectionSize:       DefaultMaxCollectionSize,
+		maxCollectionDimensions: DefaultMaxCollectionDimensions,
 	}
 	for _, opt := range opts {
 		opt(rt)
@@ -283,20 +304,30 @@ func (r *Runtime) Scope() map[string]any { return r.scope }
 // it via CEL expressions like ${id.field}. Values with known OpenAPI schemas
 // on Template and Ref nodes are wrapped via UnstructuredToVal so CEL format
 // annotations (such as format: "byte") are respected at runtime.
+//
+// Def nodes are not wrapped: their schema is inferred (compiler.inferDefSchema)
+// and marks CEL-fragment fields x-kubernetes-int-or-string, which
+// UnstructuredToVal rejects for bool/map/list values. A Def carrying an
+// objectOverride is wrapped anyway: its schema is declared by the caller
+// (compiler.WithNodeSchemaOverride) and the RGD adapter seeds it already
+// wrapped in that schema, so republishing must keep the typing (e.g.
+// schema.metadata.creationTimestamp stays a timestamp).
 func (r *Runtime) Set(id string, value any) {
 	var sc *spec.Schema
-	isTemplateOrRef := false
+	wrap := false
 	if r.program != nil {
 		sc = r.program.NodeSchemas[id]
 	}
 	if node, ok := r.byID[id]; ok {
-		isTemplateOrRef = node.Kind() == compiler.NodeKindTemplate || node.Kind() == compiler.NodeKindRef
+		wrap = node.Kind() == compiler.NodeKindTemplate ||
+			node.Kind() == compiler.NodeKindRef ||
+			node.objectOverride != nil
 	}
-	r.scope[id] = wrapValueForScope(value, sc, isTemplateOrRef)
+	r.scope[id] = wrapValueForScope(value, sc, wrap)
 }
 
-func wrapValueForScope(val any, sc *spec.Schema, isTemplateOrRef bool) any {
-	if !isTemplateOrRef || sc == nil || val == nil {
+func wrapValueForScope(val any, sc *spec.Schema, wrap bool) any {
+	if !wrap || sc == nil || val == nil {
 		return val
 	}
 	switch v := val.(type) {

--- a/pkg/testutil/k8s/discovery.go
+++ b/pkg/testutil/k8s/discovery.go
@@ -466,6 +466,8 @@ func NewFakeResolver() (*FakeResolver, *fake.FakeDiscovery) {
 							},
 						},
 					},
+					// Typed bool so tests can write optional<bool> conditions (`${cm.?immutable}`).
+					"immutable": {SchemaProps: spec.SchemaProps{Type: []string{"boolean"}}},
 				},
 			},
 		},

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -299,8 +299,10 @@ func (e *Environment) grantImpersonatedServiceAccounts() error {
 func (e *Environment) setupController() error {
 	var err error
 	rgdConfig := graph.Config{
-		MaxCollectionSize:          1000,
-		MaxCollectionDimensionSize: 10,
+		MaxCollectionSize: 1000,
+		// One above the runtime default so an 11-axis spec proves the RGD-level
+		// cap reaches the instance runtime.
+		MaxCollectionDimensionSize: 11,
 	}
 	maxGraphRevisions := e.ControllerConfig.MaxGraphRevisions
 	if maxGraphRevisions <= 0 {
@@ -437,16 +439,17 @@ func (e *Environment) setupController() error {
 		})
 
 		graphReconciler := &ctrlgraph.Reconciler{
-			Client:                  e.CtrlManager.GetClient(),
-			Compiler:                geCmp,
-			Registry:                reg,
-			Executor:                exec,
-			Router:                  router,
-			SchemaWatcher:           sw,
-			MaxConcurrentReconciles: 40,
-			MaxCollectionSize:       1000,
-			Impersonation:           impersonation,
-			RequireImpersonation:    true,
+			Client:                     e.CtrlManager.GetClient(),
+			Compiler:                   geCmp,
+			Registry:                   reg,
+			Executor:                   exec,
+			Router:                     router,
+			SchemaWatcher:              sw,
+			MaxConcurrentReconciles:    40,
+			MaxCollectionSize:          rgdConfig.MaxCollectionSize,
+			MaxCollectionDimensionSize: rgdConfig.MaxCollectionDimensionSize,
+			Impersonation:              impersonation,
+			RequireImpersonation:       true,
 		}
 		if err := graphReconciler.SetupWithManager(e.CtrlManager); err != nil {
 			return fmt.Errorf("setting up graph reconciler: %w", err)

--- a/test/integration/suites/core/rgd_runtime_parity_test.go
+++ b/test/integration/suites/core/rgd_runtime_parity_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+// describeConditions renders RGD conditions with reason and message so a
+// failed wait shows why the RGD is not Active.
+func describeConditions(conds []krov1alpha1.Condition) string {
+	out := make([]string, 0, len(conds))
+	for _, c := range conds {
+		reason, message := "", ""
+		if c.Reason != nil {
+			reason = *c.Reason
+		}
+		if c.Message != nil {
+			message = *c.Message
+		}
+		out = append(out, fmt.Sprintf("%s=%s (%s: %s)", c.Type, c.Status, reason, message))
+	}
+	return strings.Join(out, "; ")
+}
+
+// Every RGD here is accepted by the RGD-level validator; its instances must
+// then compile and converge on the graphengine runtime as well.
+var _ = Describe("RGD validator / graphengine runtime parity", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	// waitForRGDActive blocks until the RGD reports Active.
+	waitForRGDActive := func(ctx SpecContext, name string) {
+		Eventually(func(g Gomega, ctx SpecContext) {
+			rgd := &krov1alpha1.ResourceGraphDefinition{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name}, rgd)).To(Succeed())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive),
+				"RGD %s should be Active: %s", name, describeConditions(rgd.Status.Conditions))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+	}
+
+	// waitForInstanceActive blocks until the instance reports status.state
+	// ACTIVE and returns the instance as last observed.
+	waitForInstanceActive := func(ctx SpecContext, kind, name string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		Eventually(func(g Gomega, ctx SpecContext) {
+			obj.SetAPIVersion("kro.run/v1alpha1")
+			obj.SetKind(kind)
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)).To(Succeed())
+			state, _, _ := unstructured.NestedString(obj.Object, "status", "state")
+			g.Expect(state).To(Equal("ACTIVE"), "instance status: %v", obj.Object["status"])
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+		return obj
+	}
+
+	// "graphengine" is an ordinary resource id, not a reserved word.
+	It("accepts an RGD whose resource id is 'graphengine' and reconciles its instance", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-parity-graphengine-id",
+			generator.WithSchema("ParityGraphEngineID", "v1alpha1",
+				map[string]any{"name": "string"},
+				nil,
+			),
+			generator.WithResource("graphengine", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}"},
+				"data":       map[string]any{"id": "graphengine"},
+			}, nil, nil),
+			// References the `graphengine` node so the id is exercised as a CEL variable too.
+			generator.WithResource("dependent", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}-dep"},
+				"data":       map[string]any{"upstream": "${graphengine.metadata.name}"},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1",
+			"kind":       "ParityGraphEngineID",
+			"metadata":   map[string]any{"name": "ge", "namespace": namespace},
+			"spec":       map[string]any{"name": "ge-cm"},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			cm := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "ge-cm", Namespace: namespace}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("id", "graphengine"))
+			dep := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "ge-cm-dep", Namespace: namespace}, dep)).To(Succeed())
+			g.Expect(dep.Data).To(HaveKeyWithValue("upstream", "ge-cm"))
+		}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+		waitForInstanceActive(ctx, "ParityGraphEngineID", "ge")
+	})
+
+	// optional<bool> conditions compile; an empty optional reads as false
+	// (includeWhen → node skipped; readyWhen → not ready).
+	It("accepts optional<bool> readyWhen/includeWhen conditions and treats an empty optional as false", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-parity-optional-bool",
+			generator.WithSchema("ParityOptionalBool", "v1alpha1",
+				map[string]any{
+					"name": "string",
+					// No default, so ${schema.spec.?enabled} is empty when unset.
+					"enabled": "boolean",
+				},
+				nil,
+			),
+			// `${cm.?immutable}` is optional<bool>; the template sets it, so the node becomes ready.
+			generator.WithResource("cm", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}"},
+				"immutable":  true,
+				"data":       map[string]any{"k": "v"},
+			}, []string{"${cm.?immutable}"}, nil),
+			generator.WithResource("guarded", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}-guarded"},
+				"data":       map[string]any{"k": "v"},
+			}, nil, []string{"${schema.spec.?enabled}"}),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1",
+			"kind":       "ParityOptionalBool",
+			"metadata":   map[string]any{"name": "opt", "namespace": namespace},
+			// spec.enabled unset.
+			"spec": map[string]any{"name": "opt-cm"},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		})
+
+		By("the readyWhen ${cm.?immutable} node is created and becomes ready (instance ACTIVE)")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			cm := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "opt-cm", Namespace: namespace}, cm)).To(Succeed())
+		}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+		waitForInstanceActive(ctx, "ParityOptionalBool", "opt")
+
+		By("the includeWhen ${schema.spec.?enabled} node is skipped while spec.enabled is unset")
+		Consistently(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: "opt-cm-guarded", Namespace: namespace}, &corev1.ConfigMap{})
+			g.Expect(errors.IsNotFound(err)).To(BeTrue(), "guarded ConfigMap must not exist while the optional is empty")
+		}, 3*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("setting spec.enabled=true includes the guarded node")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			current := &unstructured.Unstructured{}
+			current.SetAPIVersion("kro.run/v1alpha1")
+			current.SetKind("ParityOptionalBool")
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "opt", Namespace: namespace}, current)).To(Succeed())
+			g.Expect(unstructured.SetNestedField(current.Object, true, "spec", "enabled")).To(Succeed())
+			g.Expect(env.Client.Update(ctx, current)).To(Succeed())
+		}, 10*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			cm := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "opt-cm-guarded", Namespace: namespace}, cm)).To(Succeed())
+		}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+		waitForInstanceActive(ctx, "ParityOptionalBool", "opt")
+	})
+
+	// metadata.creationTimestamp is format: date-time, so getFullYear() only
+	// resolves while the published `schema` value keeps its declared typing.
+	It("keeps the schema node typed so schema.metadata.creationTimestamp is a timestamp", func(ctx SpecContext) {
+		rgd := generator.NewResourceGraphDefinition("test-parity-schema-typing",
+			generator.WithSchema("ParitySchemaTyping", "v1alpha1",
+				map[string]any{"name": "string"},
+				nil,
+			),
+			generator.WithResource("cm", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}"},
+				"data": map[string]any{
+					"year": "${string(schema.metadata.creationTimestamp.getFullYear())}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1",
+			"kind":       "ParitySchemaTyping",
+			"metadata":   map[string]any{"name": "typed", "namespace": namespace},
+			"spec":       map[string]any{"name": "typed-cm"},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		})
+
+		created := waitForInstanceActive(ctx, "ParitySchemaTyping", "typed")
+		wantYear := strconv.Itoa(created.GetCreationTimestamp().UTC().Year())
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			cm := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "typed-cm", Namespace: namespace}, cm)).To(Succeed())
+			g.Expect(cm.Data).To(HaveKeyWithValue("year", wantYear))
+		}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+	})
+
+	// The environment sets the RGD-level axis cap to 11 (environment/setup.go),
+	// one above the runtime default, so this instance converges only if that
+	// value reaches the instance runtime through the RGD reconciler.
+	It("expands a forEach collection with as many axes as --rgd-max-collection-dimension-size admits", func(ctx SpecContext) {
+		const axes = 11
+		forEach := make([]krov1alpha1.ForEachDimension, 0, axes)
+		nameParts := make([]string, 0, axes)
+		for i := 0; i < axes; i++ {
+			iter := fmt.Sprintf("d%d", i)
+			forEach = append(forEach, krov1alpha1.ForEachDimension{iter: `${["x"]}`})
+			nameParts = append(nameParts, "${"+iter+"}")
+		}
+		rgd := generator.NewResourceGraphDefinition("test-parity-dimension-cap",
+			generator.WithSchema("ParityDimensionCap", "v1alpha1",
+				map[string]any{"name": "string"},
+				nil,
+			),
+			generator.WithResourceCollection("cms", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}-" + strings.Join(nameParts, "-")},
+				"data":       map[string]any{"k": "v"},
+			}, forEach, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1",
+			"kind":       "ParityDimensionCap",
+			"metadata":   map[string]any{"name": "dims", "namespace": namespace},
+			"spec":       map[string]any{"name": "dims"},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		})
+
+		waitForInstanceActive(ctx, "ParityDimensionCap", "dims")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			cm := &corev1.ConfigMap{}
+			name := "dims-" + strings.TrimSuffix(strings.Repeat("x-", axes), "-")
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cm)).To(Succeed())
+		}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## Problem

On the RGD path the RGD reconciler still validates with `pkg/graph`, while instances are compiled and executed by the graphengine compiler/runtime. Wherever the two disagree, the RGD becomes `Active` and every instance goes `ERROR`, with nothing on the RGD hinting at the cause. Four such divergences exist, all regressions against the pre-rewrite engine (`7458023`):

- `graphengine` is reserved as a node id by the compiler and, to keep the two lists in sync, by the RGD validator; an existing RGD with `id: graphengine` flips to `Inactive` on upgrade and its instances freeze.
- The RGD validator accepts `optional<bool>` conditions such as `readyWhen: ["${cm.?immutable}"]` or `includeWhen: ["${schema.spec.?enabled}"]`, but the compiler rejects them and the runtime hard-errors on the `nil` an empty optional evaluates to (the old runtime read it as `false`).
- The runtime caps forEach axes at the package constant (10) regardless of `--rgd-max-collection-dimension-size`: with the flag at 12 an 11-axis RGD is `Active` while every instance fails with `exceeds the maximum of 10`.
- The adapter seeds the `schema` node as a schema-typed CEL value, but the executor republishes it through `Runtime.Set`, which only wrapped Template/Ref nodes, so `schema` becomes a raw map and `${schema.metadata.creationTimestamp.getFullYear()}` fails with `no such overload getFullYear(string)`.

## Fix

- `pkg/graph/validation.go`, `pkg/graphengine/compiler/validation.go`: `graphengine` is removed from both reserved-id lists; nothing references such an identifier.
- `pkg/graphengine/compiler/typecheck.go` `validateAndCompileConditions`: accepts `bool`, `optional<bool>` (the same `conversion.IsBoolOrOptionalBool` check the RGD validator uses) or `dyn`; other types are still rejected. `pkg/graphengine/runtime/node.go` `conditionResult`: an empty optional (`nil`, or `sentinels.Omit` under `CELOmitFunction`) reads as `false` for includeWhen and readyWhen, singleton and collection.
- `pkg/graphengine/runtime`: per-Runtime `maxCollectionDimensions` (`WithMaxCollectionDimensions`, `<= 0` keeps the default) enforced by `cartesianProduct`, wired from `--rgd-max-collection-dimension-size` through the instance controller, the RGD reconciler, the Graph controller and subgraph child runtimes. An envtest spec with 11 axes (the integration environment's RGD-level cap is 11) pins the RGD reconciler → runtime plumbing.
- `pkg/graphengine/runtime/runtime.go` `Set`: also wraps a Def node carrying an `objectOverride` — the adapter's `schema` node, whose schema is declared rather than inferred — so the published value keeps the seed's typing. `rgdadapter.BuildRuntimeForInstance` registers the same override as the cached path, and the instance controller's pre-apply `candidateMetadata` drops its now-redundant re-wrap.
- Comment corrections: references to the removed `ProjectInstanceStatus` point at the synthesized author-status patch node; `patchFieldManager` notes that `graphSeg` is a constant on the RGD/instance path; `reconcileApplySetInventory` no longer claims to mirror the deletion-only `applyset.Project`; `.golangci.yml` no longer points at a nonexistent file.

## Behaviour changes

- `graphengine` is usable as a resource/node id again; an RGD that was `Inactive` because of it returns to `Active` on its next reconcile.
- `optional<bool>` includeWhen/readyWhen expressions compile on the instance path; an empty optional means "not included" / "not ready". A CEL `null` result (reachable only from `dyn`-typed conditions) reads as `false` the same way — the old engine did too; on `main` it was a hard `want bool` error.
- The runtime's forEach axis cap follows `--rgd-max-collection-dimension-size` (default 10, so unchanged unless the flag is set); standalone Graphs get the same cap from the same flag.
- `${schema.*}` stays typed by the RGD's declared schema plus ObjectMeta for the whole reconcile, as on the old engine; fields without a declared schema still resolve to native values as before.
- Flipped assertions: `TestIsKROReservedWord` now expects `graphengine` → unreserved; the two compiler cases that pinned the `optional<bool>` rejection now assert acceptance. The integration environment's RGD-level dimension cap is 11 instead of 10; no existing spec asserted a cap rejection.
