### PR TITLE
fix(graphengine): run CRD schema invalidation regardless of the GraphKind gate

### DIFF
--- a/cmd/controller/graphengine.go
+++ b/cmd/controller/graphengine.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes"
@@ -37,15 +38,48 @@ import (
 // api/v1alpha1's SchemeBuilder, which main.go already adds — no separate
 // registration is needed here.
 
-// setupGraphController wires the Graph controller into the
-// manager alongside the ResourceGraphDefinition stack. It builds the compile
-// cache, the resource-drift watch router, and the CRD schema watcher, then
-// registers the reconciler. The router and schema watcher are added as manager
-// Runnables so their event channels feed the same work queue as Graph spec
-// changes.
+// setupGraphEngine builds the graph-engine compiler, the Graph compile cache
+// and the CRD schema watcher (added to the manager) and returns them. It runs
+// regardless of the GraphKind gate: the compiler serves every RGD instance
+// controller, and the watcher is what drives Compiler.InvalidateSchema.
+func setupGraphEngine(
+	mgr ctrl.Manager,
+	restConfig *rest.Config,
+	httpClient *http.Client,
+	logger logr.Logger,
+	celCostLimit uint64,
+) (*compiler.Compiler, *registry.Registry, *schemawatcher.SchemaWatcher, error) {
+	cmp, err := compiler.NewCompiler(restConfig, httpClient)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("build graph-engine compiler: %w", err)
+	}
+	cmp.WithCostLimit(celCostLimit)
+
+	// The registry lives here so the watcher can invalidate it (empty while the
+	// gate is off). The watcher needs full CRD objects, so this adds a structured
+	// CRD informer next to the RGD reconciler's metadata-only one.
+	reg := registry.New()
+	sw := schemawatcher.New(logger.WithName("graph-engine"), schemawatcher.Config{
+		Cache:   mgr.GetCache(),
+		Graphs:  reg,
+		Schemas: cmp,
+	})
+	if err := mgr.Add(sw); err != nil {
+		return nil, nil, nil, fmt.Errorf("add graph-engine schema watcher: %w", err)
+	}
+	return cmp, reg, sw, nil
+}
+
+// setupGraphController wires the Graph controller into the manager alongside
+// the ResourceGraphDefinition stack, reusing the compiler, compile cache and
+// CRD schema watcher from setupGraphEngine. It builds the resource-drift watch
+// router (a manager Runnable feeding the Graph work queue) and the impersonated
+// executor clients, then registers the reconciler.
 func setupGraphController(
 	mgr ctrl.Manager,
 	cmp *compiler.Compiler,
+	reg *registry.Registry,
+	sw *schemawatcher.SchemaWatcher,
 	metaClient metadata.Interface,
 	logger logr.Logger,
 	concurrentReconciles int,
@@ -56,16 +90,6 @@ func setupGraphController(
 	router := watchrouter.NewRouter(logger.WithName("graph-watch-router"), watchrouter.Config{}, metaClient)
 	if err := mgr.Add(router); err != nil {
 		return fmt.Errorf("add graph watch router: %w", err)
-	}
-
-	reg := registry.New()
-	sw := schemawatcher.New(logger.WithName("graph-schema-watcher"), schemawatcher.Config{
-		Cache:   mgr.GetCache(),
-		Graphs:  reg,
-		Schemas: cmp,
-	})
-	if err := mgr.Add(sw); err != nil {
-		return fmt.Errorf("add graph schema watcher: %w", err)
 	}
 
 	exec := executor.NewSimple(mgr.GetClient())
@@ -79,11 +103,12 @@ func setupGraphController(
 	// A namespaced Graph applies its resources while impersonating a
 	// ServiceAccount in the Graph's namespace (default, or spec.serviceAccountName).
 	// Build impersonated controller-runtime clients from the manager's REST
-	// config; they share the manager's REST mapper so discovery is not repeated
-	// per ServiceAccount. The kro controller SA needs the "impersonate" verb on
-	// serviceaccounts for this to take effect.
+	// config; they share the compiler's REST mapper — the one the schema watcher
+	// resets — so discovery is not repeated per ServiceAccount and a recreated
+	// CRD's new plural/scope is picked up. The kro controller SA needs the
+	// "impersonate" verb on serviceaccounts for this to take effect.
 	baseCfg := mgr.GetConfig()
-	mapper := mgr.GetRESTMapper()
+	mapper := cmp.RESTMapper()
 	impersonation := ctrlgraph.NewImpersonation(exec, func(user string) (client.Client, error) {
 		cfg := rest.CopyConfig(baseCfg)
 		cfg.Impersonate = rest.ImpersonationConfig{UserName: user}
@@ -101,6 +126,9 @@ func setupGraphController(
 		}
 		return cs.AuthorizationV1(), nil
 	})
+	// Cached clients memoize each GVK's mapping for their lifetime, so CRD
+	// changes must also purge them (see impersonationCache.InvalidateSchema).
+	sw.AddSchemaInvalidator(impersonation)
 
 	reconciler := &ctrlgraph.Reconciler{
 		Client:                   mgr.GetClient(),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -43,7 +43,6 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/graph"
 	"github.com/kubernetes-sigs/kro/pkg/graph/revisions"
-	"github.com/kubernetes-sigs/kro/pkg/graphengine/compiler"
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 	// +kubebuilder:scaffold:imports
 )
@@ -315,17 +314,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Build a graph-engine compiler and inject it into the RGD reconciler so
-	// micro-controllers route instance reconciliation through the Graph engine.
-	// The compiler is built here (post-SetupWithManager) so it shares restConfig
-	// + httpClient with the rest of the manager process.
+	// Build the graph-engine compiler, compile cache and CRD schema watcher (ungated: the
+	// compiler serves every instance controller) and inject the compiler into the RGD reconciler.
 	setupLog.Info("injecting graph-engine compiler into RGD reconciler")
-	geCmp, err := compiler.NewCompiler(restConfig, set.HTTPClient())
+	geCmp, geReg, geSW, err := setupGraphEngine(mgr, restConfig, set.HTTPClient(), rootLogger, celCostLimit)
 	if err != nil {
-		setupLog.Error(err, "unable to build graph-engine compiler")
+		setupLog.Error(err, "unable to set up graph engine")
 		os.Exit(1)
 	}
-	geCmp.WithCostLimit(celCostLimit)
 	rgd.WithGraphEngineCompiler(geCmp)
 
 	gv := graphrevisionctrl.NewGraphRevisionReconciler(
@@ -365,6 +361,8 @@ func main() {
 		if err := setupGraphController(
 			mgr,
 			geCmp,
+			geReg,
+			geSW,
 			set.Metadata(),
 			rootLogger,
 			graphConcurrentReconciles,

--- a/docs/design/proposals/deferred-schema-resolution.md
+++ b/docs/design/proposals/deferred-schema-resolution.md
@@ -387,17 +387,19 @@ Integration (envtest):
 ### Two facts that shape the work
 
 1. **Recovery is largely free on the RGD path.** The production
-   `ResourceGraphDefinition` path does **not** use the `SchemaWatcher` (that is
-   wired only into the experimental `kro.run/v1alpha1` **Graph** controller,
-   `cmd/controller/graphengine.go`). It does not need it: a `Deferred` node
+   `ResourceGraphDefinition` path does **not** subscribe to the `SchemaWatcher`
+   (per-Graph re-enqueue is wired only into the experimental `kro.run/v1alpha1`
+   **Graph** controller; the watcher itself runs unconditionally and resets the
+   compiler's schema/REST-mapping caches on CRD events). It does not need a
+   subscription: a `Deferred` node
    resolves its GVR *lazily at apply time* (identical to `DynamicGVK`), and the
    instance controller already soft-requeues on `ErrNotReady`
    (`controller_graph_engine.go` → `requeue.NeededAfter`) and re-reconciles on
    child-resource events. In the motivating example the re-trigger is `operator`
    becoming Ready — a child-watch event that re-runs the instance, at which point
    the now-present `InstallAddon` CRD maps successfully. So **no new recovery
-   wiring is required for correctness**; the CRD-add→enqueue bridge and
-   `RESTMapper` reset are latency optimizations only.
+   wiring is required for correctness**; the CRD-add→enqueue bridge is a latency
+   optimization only.
 
 2. **The classic builder is the harder half.** `pkg/graph/builder.go` has no
    `dyn`-identifier path today — every node always carries a resolved schema, so

--- a/pkg/controller/graph/impersonation.go
+++ b/pkg/controller/graph/impersonation.go
@@ -37,6 +37,7 @@ import (
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/executor"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/schemawatcher"
 )
 
 // defaultServiceAccountName is impersonated when a Graph does not set
@@ -75,6 +76,18 @@ type impersonationCache struct {
 	byUser  *lru.Cache[string, executor.Interface]
 	newExec func(user string) (executor.Interface, error)
 }
+
+// InvalidateSchema purges every cached executor: a controller-runtime client
+// memoizes each GVK's REST mapping for life, so a recreated CRD needs fresh clients.
+func (c *impersonationCache) InvalidateSchema(_ schema.GroupKind) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.byUser != nil {
+		c.byUser.Purge()
+	}
+}
+
+var _ schemawatcher.SchemaInvalidator = (*impersonationCache)(nil)
 
 // executorFor returns an executor bound to the impersonated identity for g. It
 // is derived from the base executor via the reconciler's client factory so it

--- a/pkg/controller/graph/impersonation_test.go
+++ b/pkg/controller/graph/impersonation_test.go
@@ -112,6 +112,49 @@ func TestExecutorFor_ImpersonationOverride(t *testing.T) {
 	}, builtFor)
 }
 
+// TestImpersonationCache_InvalidateSchemaRebuildsClients: a schema invalidation
+// drops every cached impersonated executor so the next reconcile rebuilds it.
+func TestImpersonationCache_InvalidateSchemaRebuildsClients(t *testing.T) {
+	base := executor.NewSimple(fake.NewClientBuilder().Build())
+
+	var builtFor []string
+	imp := NewImpersonation(base, func(user string) (client.Client, error) {
+		builtFor = append(builtFor, user)
+		return fake.NewClientBuilder().Build(), nil
+	}, nil)
+	r := &Reconciler{Executor: base, Impersonation: imp}
+
+	exA, err := r.executorFor(graphWithSA("team-a", "deployer"))
+	require.NoError(t, err)
+	exB, err := r.executorFor(graphWithSA("team-b", "deployer"))
+	require.NoError(t, err)
+	require.Len(t, builtFor, 2)
+
+	imp.InvalidateSchema(schema.GroupKind{Group: "spot.example.com", Kind: "Widget"})
+
+	exA2, err := r.executorFor(graphWithSA("team-a", "deployer"))
+	require.NoError(t, err)
+	exB2, err := r.executorFor(graphWithSA("team-b", "deployer"))
+	require.NoError(t, err)
+	assert.NotSame(t, exA, exA2, "team-a executor must be rebuilt after a schema invalidation")
+	assert.NotSame(t, exB, exB2, "team-b executor must be rebuilt after a schema invalidation")
+	assert.Equal(t, []string{
+		"system:serviceaccount:team-a:deployer",
+		"system:serviceaccount:team-b:deployer",
+		"system:serviceaccount:team-a:deployer",
+		"system:serviceaccount:team-b:deployer",
+	}, builtFor, "each identity is rebuilt exactly once after the purge")
+
+	exA3, err := r.executorFor(graphWithSA("team-a", "deployer"))
+	require.NoError(t, err)
+	assert.Same(t, exA2, exA3)
+	require.Len(t, builtFor, 4)
+
+	// An unpopulated cache must not panic.
+	empty := &impersonationCache{newExec: imp.newExec}
+	empty.InvalidateSchema(schema.GroupKind{})
+}
+
 // TestExecutorFor_DefaultServiceAccount verifies that without an override, a
 // Graph impersonates the default ServiceAccount of its namespace.
 func TestExecutorFor_DefaultServiceAccount(t *testing.T) {

--- a/pkg/graphengine/compiler/compiler.go
+++ b/pkg/graphengine/compiler/compiler.go
@@ -108,6 +108,12 @@ func (c *Compiler) WithCostLimit(limit uint64) *Compiler {
 	return c
 }
 
+// RESTMapper returns the compiler's REST mapper so executor clients resolve
+// plural/scope through the mapper InvalidateSchema resets.
+func (c *Compiler) RESTMapper() meta.RESTMapper {
+	return c.restMapper
+}
+
 // rootContext builds a fresh root CompilationContext for a single Compile.
 // It carries the compiler's shared schema resolver and REST mapper plus a
 // per-compile field cache; parent is nil (the root lexical frame).
@@ -117,21 +123,12 @@ func (c *Compiler) rootContext() *CompilationContext {
 	return ctx
 }
 
-// InvalidateSchema drops cached schema entries for the supplied
-// GroupKind from the compiler's resolver cache, so the next compile
-// re-fetches fresh data. The schema watcher calls this when a CRD's
-// content changes. No-op when the compiler was built without a
-// cached resolver (tests).
-//
-// It also resets the REST mapping / discovery caches. The mapper is a
-// DeferredDiscoveryRESTMapper whose delegate caches every GVR->scope/plural
-// mapping; that cache only self-heals on a NoMatch, so recreating a CRD with
-// the same GroupKind+version but a new scope (Namespaced<->Cluster) or plural
-// would otherwise keep routing to the stale endpoint until restart. The mapper
-// has no per-GroupKind eviction, so we do a full Reset() (invalidates the
-// discovery cache and drops the delegate mapper); it re-discovers lazily on the
-// next mapping request. Schema invalidations are rare (CRD content changes), so
-// the cost of a full re-discovery here is acceptable.
+// InvalidateSchema drops the cached schemas for gk and resets the REST mapper's
+// discovery cache; the schema watcher calls it on every CRD add, schema change
+// and delete. The DeferredDiscoveryRESTMapper self-heals a NoMatch only while
+// its discovery cache is unpopulated, so after the first compile it is frozen
+// until Reset() — a same-GVK plural/scope change is never a NoMatch and is only
+// observed here (the RGD path's program cache and executor client still are not).
 func (c *Compiler) InvalidateSchema(gk k8sschema.GroupKind) {
 	if c.resolverCache == nil {
 		return

--- a/pkg/graphengine/compiler/context.go
+++ b/pkg/graphengine/compiler/context.go
@@ -266,7 +266,7 @@ func (ctx *CompilationContext) buildNode(p *parser.Parser, n *expv1alpha1.Node, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve schema for %s: %w", gvk, err)
 	}
-	mapping, err := ctx.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	mapping, err := ctx.restMapping(gvk)
 	if err != nil {
 		return nil, nil, fmt.Errorf("rest mapping for %s: %w", gvk, err)
 	}
@@ -336,6 +336,18 @@ func (ctx *CompilationContext) buildNode(p *parser.Parser, n *expv1alpha1.Node, 
 		// a list into scope like a forEach collection.
 		Collection: kind == NodeKindRef && hasMetadataSelector(payload),
 	}, sch, nil
+}
+
+// restMapping resolves gvk's REST mapping, resetting the mapper and retrying
+// once on a NoMatch: the deferred mapper is a frozen snapshot after its first
+// refresh (see Compiler.InvalidateSchema), so a new Kind is otherwise unmappable.
+func (ctx *CompilationContext) restMapping(gvk k8sschema.GroupVersionKind) (*meta.RESTMapping, error) {
+	mapping, err := ctx.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err == nil || !meta.IsNoMatchError(err) {
+		return mapping, err
+	}
+	meta.MaybeResetRESTMapper(ctx.restMapper)
+	return ctx.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 }
 
 type parsedNodeElements struct {

--- a/pkg/graphengine/compiler/restmapping_test.go
+++ b/pkg/graphengine/compiler/restmapping_test.go
@@ -1,0 +1,216 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	memory "k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
+	testk8s "github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
+)
+
+// scriptedMapper answers RESTMapping from a per-call script and counts calls.
+type scriptedMapper struct {
+	*meta.DefaultRESTMapper
+	script  []error // per-call error; nil means return mapping
+	mapping *meta.RESTMapping
+	calls   int
+}
+
+func (m *scriptedMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	i := m.calls
+	m.calls++
+	if i < len(m.script) && m.script[i] != nil {
+		return nil, m.script[i]
+	}
+	return m.mapping, nil
+}
+
+// resettableScriptedMapper adds Reset() (meta.ResettableRESTMapper) and counts resets.
+type resettableScriptedMapper struct {
+	*scriptedMapper
+	resets int
+}
+
+func (m *resettableScriptedMapper) Reset() { m.resets++ }
+
+var _ meta.ResettableRESTMapper = (*resettableScriptedMapper)(nil)
+
+func noMatchErr(gk schema.GroupKind) error {
+	return &meta.NoKindMatchError{GroupKind: gk, SearchedVersions: []string{"v1"}}
+}
+
+// TestRestMapping_NoMatchResetsAndRetriesOnce pins the retry contract: exactly
+// one Reset and one retry on a NoMatch, none for any other error.
+func TestRestMapping_NoMatchResetsAndRetriesOnce(t *testing.T) {
+	t.Parallel()
+
+	gvk := schema.GroupVersionKind{Group: "spot.example.com", Version: "v1", Kind: "Widget"}
+	want := &meta.RESTMapping{
+		Resource:         schema.GroupVersionResource{Group: "spot.example.com", Version: "v1", Resource: "widgets"},
+		GroupVersionKind: gvk,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	boom := errors.New("discovery: connection refused")
+
+	cases := []struct {
+		name        string
+		script      []error
+		resettable  bool
+		wantErr     error // nil means success
+		wantNoMatch bool
+		wantCalls   int
+		wantResets  int
+	}{
+		{
+			name:       "success first try: no reset",
+			script:     nil,
+			resettable: true,
+			wantCalls:  1,
+			wantResets: 0,
+		},
+		{
+			name:       "nomatch then success: one reset, one retry",
+			script:     []error{noMatchErr(gvk.GroupKind()), nil},
+			resettable: true,
+			wantCalls:  2,
+			wantResets: 1,
+		},
+		{
+			name:        "persistent nomatch: retried exactly once, error surfaces",
+			script:      []error{noMatchErr(gvk.GroupKind()), noMatchErr(gvk.GroupKind()), nil},
+			resettable:  true,
+			wantNoMatch: true,
+			wantCalls:   2,
+			wantResets:  1,
+		},
+		{
+			name:       "non-nomatch error: not retried, no reset",
+			script:     []error{boom, nil},
+			resettable: true,
+			wantErr:    boom,
+			wantCalls:  1,
+			wantResets: 0,
+		},
+		{
+			name:        "nomatch on a mapper without Reset: retried once without a reset, nomatch surfaces",
+			script:      []error{noMatchErr(gvk.GroupKind()), noMatchErr(gvk.GroupKind()), nil},
+			resettable:  false,
+			wantNoMatch: true,
+			wantCalls:   2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			inner := &scriptedMapper{
+				DefaultRESTMapper: meta.NewDefaultRESTMapper(nil),
+				script:            tc.script,
+				mapping:           want,
+			}
+			var rm meta.RESTMapper = inner
+			var resettable *resettableScriptedMapper
+			if tc.resettable {
+				resettable = &resettableScriptedMapper{scriptedMapper: inner}
+				rm = resettable
+			}
+			ctx := newRootContext(nil, rm)
+
+			got, err := ctx.restMapping(gvk)
+
+			switch {
+			case tc.wantNoMatch:
+				require.Error(t, err)
+				assert.True(t, meta.IsNoMatchError(err), "expected a NoMatch error, got %v", err)
+				assert.Nil(t, got)
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+				assert.Nil(t, got)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, want, got)
+			}
+			assert.Equal(t, tc.wantCalls, inner.calls, "RESTMapping call count")
+			if resettable != nil {
+				assert.Equal(t, tc.wantResets, resettable.resets, "Reset call count")
+			}
+		})
+	}
+}
+
+// TestCompile_KindAddedAfterDiscoveryWarmsIsMappable compiles against the real
+// DeferredDiscoveryRESTMapper: a Kind added to discovery after the first
+// compile must be mappable by the next one without an external Reset.
+func TestCompile_KindAddedAfterDiscoveryWarmsIsMappable(t *testing.T) {
+	resolver, disco := testk8s.NewFakeResolver()
+	rm := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disco))
+	c := NewCompilerWithDependencies(resolver, rm)
+
+	// First compile warms the discovery cache.
+	_, err := c.Compile(generator.NewGraph("g", generator.WithTemplate("cm", configMap("cfg"))))
+	require.NoError(t, err)
+
+	// A CRD lands AFTER the cache is warm.
+	widgetGVK := schema.GroupVersionKind{Group: "spot.example.com", Version: "v1", Kind: "Widget"}
+	disco.Resources = append(disco.Resources, &metav1.APIResourceList{
+		GroupVersion: "spot.example.com/v1",
+		APIResources: []metav1.APIResource{{
+			Name: "widgets", Namespaced: true, Kind: "Widget",
+			Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		}},
+	})
+	resolver.AddSchema(widgetGVK, &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"apiVersion": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			"kind":       {SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			"metadata": {SchemaProps: spec.SchemaProps{
+				Type:       []string{"object"},
+				Properties: map[string]spec.Schema{"name": {SchemaProps: spec.SchemaProps{Type: []string{"string"}}}},
+			}},
+			"spec": {SchemaProps: spec.SchemaProps{
+				Type:       []string{"object"},
+				Properties: map[string]spec.Schema{"size": {SchemaProps: spec.SchemaProps{Type: []string{"integer"}}}},
+			}},
+		},
+	}})
+
+	// Premise: the warm mapper alone does not see the new Kind.
+	_, err = rm.RESTMapping(widgetGVK.GroupKind(), widgetGVK.Version)
+	require.True(t, meta.IsNoMatchError(err), "expected the warm deferred mapper to return NoMatch for a kind added after its refresh, got %v", err)
+
+	prog, err := c.Compile(generator.NewGraph("g", generator.WithTemplate("w", map[string]any{
+		"apiVersion": "spot.example.com/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]any{"name": "w1"},
+		"spec":       map[string]any{"size": int64(3)},
+	})))
+	require.NoError(t, err, "a Kind created after the first compile must be mappable without a controller restart")
+	n := prog.Nodes["w"]
+	require.NotNil(t, n)
+	assert.Equal(t, "widgets", n.GVR.Resource)
+	assert.True(t, n.Namespaced)
+}

--- a/pkg/graphengine/schemawatcher/watcher.go
+++ b/pkg/graphengine/schemawatcher/watcher.go
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package schemawatcher watches CustomResourceDefinitions and re-enqueues
-// Graphs whose templates reference a Kind whose schema changed.
+// Package schemawatcher watches CustomResourceDefinitions, invalidates the
+// graph engine's schema / REST-mapping caches, and re-enqueues Graphs whose
+// templates reference a Kind whose schema changed.
 //
-// The package solves two correctness problems:
+// The package solves three correctness problems:
 //
 //  1. Without it, a CRD field added / removed / re-validated never
 //     reaches the compile cache. Graphs that reference the Kind keep
@@ -25,6 +26,11 @@
 //  2. Graphs whose templates use CEL in `apiVersion` or `kind` have
 //     unknowable GroupKind dependencies at compile time. They must
 //     re-reconcile on *any* CRD change to stay current.
+//
+//  3. The compiler's schema and REST-mapping caches are only refreshed by
+//     Compiler.InvalidateSchema, which every CRD event drives through the
+//     SchemaInvalidator whether or not any Graph subscribes — so the watcher
+//     runs regardless of the GraphKind gate.
 //
 // Architecture:
 //
@@ -98,9 +104,10 @@ type Config struct {
 	Graphs GraphInvalidator
 
 	// Schemas is invoked on every CRD event that surfaces a schema
-	// change, once per changed GroupKind. Implementations should drop
-	// any cached schema resolution for the GK so the next compile
-	// sees fresh data.
+	// change, once per changed GroupKind, whether or not any Graph
+	// subscribes to it. Implementations should drop any cached schema
+	// resolution / REST mapping for the GK so the next compile sees fresh
+	// data. Further targets can be added with AddSchemaInvalidator.
 	Schemas SchemaInvalidator
 
 	// EventBuffer is the depth of the channel feeding the source.Source
@@ -116,10 +123,15 @@ type Config struct {
 // Concurrent-safe: mu guards every map access. The CRD informer's event
 // goroutine and per-Graph Subscribe call sites can interleave freely.
 type SchemaWatcher struct {
-	log     logr.Logger
-	cache   ctrlcache.Cache
-	graphs  GraphInvalidator
-	schemas SchemaInvalidator
+	log    logr.Logger
+	cache  ctrlcache.Cache
+	graphs GraphInvalidator
+
+	// schemas are the SchemaInvalidator targets in registration order
+	// (Config.Schemas first). Guarded by schemasMu, not mu, so notify can
+	// snapshot them without the reverse-index lock.
+	schemasMu sync.RWMutex
+	schemas   []SchemaInvalidator
 
 	events chan event.GenericEvent
 	closed atomic.Bool
@@ -175,7 +187,6 @@ func New(log logr.Logger, cfg Config) *SchemaWatcher {
 		log:          log.WithName("schema-watcher"),
 		cache:        cfg.Cache,
 		graphs:       cfg.Graphs,
-		schemas:      cfg.Schemas,
 		events:       make(chan event.GenericEvent, buf),
 		dirty:        make(map[client.ObjectKey]struct{}),
 		wakeup:       make(chan struct{}, 1),
@@ -184,6 +195,9 @@ func New(log logr.Logger, cfg Config) *SchemaWatcher {
 		dynamic:      make(map[client.ObjectKey]struct{}),
 		subs:         make(map[client.ObjectKey]*graphSub),
 		schemaHashes: make(map[schema.GroupKind]string),
+	}
+	if cfg.Schemas != nil {
+		w.schemas = append(w.schemas, cfg.Schemas)
 	}
 	// The drainer forwards coalesced dirty keys onto events. Started here
 	// (not in Start) so events flow even for callers that use the watcher
@@ -241,6 +255,18 @@ func (w *SchemaWatcher) drainLoop() {
 // Graph spec changes and drift events.
 func (w *SchemaWatcher) Source() source.Source {
 	return source.Channel(w.events, &handler.EnqueueRequestForObject{})
+}
+
+// AddSchemaInvalidator registers a further target for schema-changing CRD
+// events, for caches wired after the watcher (the gated Graph controller's
+// impersonated-client cache). nil is ignored.
+func (w *SchemaWatcher) AddSchemaInvalidator(inv SchemaInvalidator) {
+	if inv == nil {
+		return
+	}
+	w.schemasMu.Lock()
+	defer w.schemasMu.Unlock()
+	w.schemas = append(w.schemas, inv)
 }
 
 // Start implements manager.Runnable. It attaches the informer event
@@ -528,16 +554,21 @@ func (w *SchemaWatcher) affectedLocked(gk schema.GroupKind) map[client.ObjectKey
 
 // notify invokes the configured invalidators (schema first, then per
 // graph) and pushes a GenericEvent for each affected Graph. The
-// schema invalidator goes first so the next reconcile finds a clean
+// schema invalidators go first so the next reconcile finds a clean
 // resolver cache; the graph invalidator drops the cached Program;
-// then the enqueue triggers the reconcile.
+// then the enqueue triggers the reconcile. The schema invalidators run
+// even with no subscribers: with the GraphKind gate off there are none,
+// but the compiler still serves every RGD instance controller.
 func (w *SchemaWatcher) notify(gk schema.GroupKind, keys map[client.ObjectKey]struct{}, reason string) {
 	if len(keys) == 0 {
 		w.log.V(2).Info("schema event with no subscribers", "gk", gk, "reason", reason)
 	}
 
-	if w.schemas != nil {
-		w.schemas.InvalidateSchema(gk)
+	w.schemasMu.RLock()
+	invalidators := append([]SchemaInvalidator(nil), w.schemas...)
+	w.schemasMu.RUnlock()
+	for _, inv := range invalidators {
+		inv.InvalidateSchema(gk)
 	}
 	for key := range keys {
 		if w.graphs != nil {

--- a/pkg/graphengine/schemawatcher/watcher_test.go
+++ b/pkg/graphengine/schemawatcher/watcher_test.go
@@ -534,6 +534,65 @@ func TestNoopFallbacks(t *testing.T) {
 	assert.ElementsMatch(t, []client.ObjectKey{graphA}, got)
 }
 
+// TestCRDEventWithNoSubscribersStillInvalidatesSchema: with no Graph
+// subscribed (GraphKind off), every schema-changing CRD event must still reach
+// the schema invalidator while nothing is enqueued.
+func TestCRDEventWithNoSubscribersStillInvalidatesSchema(t *testing.T) {
+	gk := schema.GroupKind{Group: "spot.example.com", Kind: "Widget"}
+	v0 := makeCRD("spot.example.com", "Widget", "v0")
+	v1 := makeCRD("spot.example.com", "Widget", "v1")
+
+	cases := []struct {
+		name  string
+		event func(sw *SchemaWatcher)
+	}{
+		{"add", func(sw *SchemaWatcher) { sw.onAdd(v0) }},
+		{"schema-changing update", func(sw *SchemaWatcher) { sw.onUpdate(v0, v1) }},
+		{"delete", func(sw *SchemaWatcher) { sw.onDelete(v0) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sw, gi, si := newTestWatcher(t)
+			sw.onAdd(v0) // seed the hash so the update is not deduped
+			si.calls = nil
+			tc.event(sw)
+			assert.Equal(t, []schema.GroupKind{gk}, si.snapshot())
+			assert.Empty(t, gi.snapshot())
+			assert.Empty(t, drainEvents(sw, 50*time.Millisecond))
+		})
+	}
+}
+
+// TestAddSchemaInvalidatorFansOut: late-registered invalidators see every
+// schema-changing event in registration order; nil is ignored.
+func TestAddSchemaInvalidatorFansOut(t *testing.T) {
+	var order []string
+	record := func(name string) *funcInvalidator {
+		return &funcInvalidator{fn: func(schema.GroupKind) { order = append(order, name) }}
+	}
+
+	sw := New(logr.Discard(), Config{Schemas: record("config"), EventBuffer: 16})
+	sw.AddSchemaInvalidator(record("added-1"))
+	sw.AddSchemaInvalidator(nil)
+	sw.AddSchemaInvalidator(record("added-2"))
+	sw.onAdd(makeCRD("spot.example.com", "Widget", "v0"))
+	assert.Equal(t, []string{"config", "added-1", "added-2"}, order)
+
+	// Without Config.Schemas only the added targets run.
+	order = nil
+	sw2 := New(logr.Discard(), Config{EventBuffer: 16})
+	sw2.AddSchemaInvalidator(record("only"))
+	sw2.onDelete(makeCRD("spot.example.com", "Widget", "v0"))
+	assert.Equal(t, []string{"only"}, order)
+}
+
+// funcInvalidator adapts a func to SchemaInvalidator.
+type funcInvalidator struct {
+	fn func(schema.GroupKind)
+}
+
+func (f *funcInvalidator) InvalidateSchema(gk schema.GroupKind) { f.fn(gk) }
+
 // TestRequiredDoneCount confirms SubscribedGraphs returns 0 after the
 // last Graph is removed.
 func TestRequiredDoneCount(t *testing.T) {

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -377,6 +377,22 @@ func (e *Environment) setupController() error {
 		return fmt.Errorf("setting up graph revision reconciler: %w", err)
 	}
 
+	// Mirror production (setupGraphEngine): the CRD schema watcher and the Graph
+	// compile cache it invalidates are created regardless of the GraphKind gate.
+	reg := registry.New()
+	sw := schemawatcher.New(
+		zap.New(zap.WriteTo(e.ControllerConfig.LogWriter), zap.UseDevMode(true)).WithName("graph-engine"),
+		schemawatcher.Config{
+			Cache:   e.CtrlManager.GetCache(),
+			Graphs:  reg,
+			Schemas: geCmp,
+		},
+	)
+	if err := e.CtrlManager.Add(sw); err != nil {
+		return fmt.Errorf("adding graph-engine schema watcher to manager: %w", err)
+	}
+	e.SchemaWatcher = sw
+
 	if features.FeatureGate.Enabled(features.GraphKind) {
 		router := watchrouter.NewRouter(
 			zap.New(zap.WriteTo(e.ControllerConfig.LogWriter), zap.UseDevMode(true)).WithName("graph-watch-router"),
@@ -387,20 +403,6 @@ func (e *Environment) setupController() error {
 			return fmt.Errorf("adding graph watch router to manager: %w", err)
 		}
 		e.Router = router
-
-		reg := registry.New()
-		sw := schemawatcher.New(
-			zap.New(zap.WriteTo(e.ControllerConfig.LogWriter), zap.UseDevMode(true)).WithName("graph-schema-watcher"),
-			schemawatcher.Config{
-				Cache:   e.CtrlManager.GetCache(),
-				Graphs:  reg,
-				Schemas: geCmp,
-			},
-		)
-		if err := e.CtrlManager.Add(sw); err != nil {
-			return fmt.Errorf("adding graph schema watcher to manager: %w", err)
-		}
-		e.SchemaWatcher = sw
 
 		exec := executor.NewSimple(e.CtrlManager.GetClient())
 		exec.ApplyConcurrency = e.ControllerConfig.ReconcileConfig.ApplyConcurrency
@@ -420,8 +422,10 @@ func (e *Environment) setupController() error {
 		// grantImpersonatedServiceAccounts) — that keeps Graph behavior unchanged
 		// (the SA can do everything) while still running the impersonated path.
 		// RBAC-confinement is proven separately in a dedicated envtest.
+		// As in production, the impersonated clients use the compiler's mapper and
+		// the client cache is purged by the schema watcher.
 		baseCfg := e.CtrlManager.GetConfig()
-		mapper := e.CtrlManager.GetRESTMapper()
+		mapper := geCmp.RESTMapper()
 		impersonation := ctrlgraph.NewImpersonation(exec, func(user string) (client.Client, error) {
 			cfg := rest.CopyConfig(baseCfg)
 			cfg.Impersonate = rest.ImpersonationConfig{UserName: user}
@@ -435,6 +439,7 @@ func (e *Environment) setupController() error {
 			}
 			return cs.AuthorizationV1(), nil
 		})
+		sw.AddSchemaInvalidator(impersonation)
 
 		graphReconciler := &ctrlgraph.Reconciler{
 			Client:                  e.CtrlManager.GetClient(),

--- a/test/integration/suites/impersonation/confinement_test.go
+++ b/test/integration/suites/impersonation/confinement_test.go
@@ -143,7 +143,7 @@ func TestGraphImpersonationConfinement(t *testing.T) {
 	exec.ConflictDetection = true
 
 	baseCfg := mgr.GetConfig()
-	mapper := mgr.GetRESTMapper()
+	mapper := cmp.RESTMapper()
 	impersonation := ctrlgraph.NewImpersonation(exec, func(user string) (client.Client, error) {
 		ic := rest.CopyConfig(baseCfg)
 		ic.Impersonate = rest.ImpersonationConfig{UserName: user}


### PR DESCRIPTION
## Problem

On a default install (`GraphKind` off), every `ResourceGraphDefinition` instance whose graph references a Kind that did not exist at the controller's first compile — a second RGD's own generated kind (the target of its synthesized status patch node), or a CRD installed after kro started — fails every reconcile with `GraphResolved=False ResolutionFailed: graph-engine build failed: rgdadapter: compile: build node "…": rest mapping for …: no matches for kind "…"` until the controller is restarted, while the RGD itself reports `Active` (it is validated by the old `pkg/graph.Builder`, whose dynamic mapper reloads on `NoMatch`). An RGD with only built-in template kinds and no `status:` block is unaffected.

The graph-engine compiler maps kinds through a `DeferredDiscoveryRESTMapper` over a memory-cached discovery client. That mapper self-heals a `NoMatch` only while its cache is unpopulated; after the first successful refresh it is a frozen snapshot until `Reset()`. The only `Reset()` path is `Compiler.InvalidateSchema`, driven solely by the CRD `SchemaWatcher`, which was created inside the gated Graph controller — yet the same compiler is injected into the RGD reconciler and every instance controller regardless of the gate. The pre-#1355 engine used controller-runtime's dynamic mapper on the instance path and never hit this.

On the Graph path (gate on) a related staleness exists: the impersonated executor clients used the manager's mapper (which never reloads on a same-GVK plural/scope change) and a controller-runtime client memoizes each GVK's REST mapping for its lifetime, so deleting and recreating a CRD under the same GVK with a different plural kept applying through the old plural until restart.

## Fix

- `pkg/graphengine/compiler/context.go`: `buildNode` resolves mappings through the new `restMapping`, which on a `NoMatch` calls `meta.MaybeResetRESTMapper` and retries exactly once (other errors are returned as-is). This alone fixes the default-install failure: a Kind created after the first compile is mappable on the next compile. `TestCompile_KindAddedAfterDiscoveryWarmsIsMappable` pins it against the real deferred mapper.
- `cmd/controller/graphengine.go`, `main.go`: `setupGraphEngine` builds the compiler, the Graph compile cache and the `SchemaWatcher` unconditionally and `setupGraphController` reuses them, so CRD events reach `Compiler.InvalidateSchema` on the RGD path too — evicting a changed CRD's schema ahead of the resolver cache's TTL and resetting the mapper on a same-GVK plural/scope change, which is not a `NoMatch`. `TestCRDEventWithNoSubscribersStillInvalidatesSchema` pins that the watcher invalidates with zero Graph subscribers.
- `pkg/graphengine/compiler/compiler.go`: new `Compiler.RESTMapper()`; `InvalidateSchema` doc now carries the single explanation of the frozen-snapshot behaviour.
- `cmd/controller/graphengine.go`, `pkg/controller/graph/impersonation.go`, `pkg/graphengine/schemawatcher/watcher.go`: the impersonated executor clients are built over `Compiler.RESTMapper()` instead of `mgr.GetRESTMapper()`, and `impersonationCache` implements `SchemaInvalidator` (purge all cached executors), registered through the new `SchemaWatcher.AddSchemaInvalidator` since the cache exists only when the gate is on. Both are needed for a recreated CRD to be applied through its new plural/scope.
- `test/integration/environment/setup.go`, `test/integration/suites/impersonation/confinement_test.go`: mirror the production wiring (ungated watcher, compiler mapper for impersonated clients). `docs/design/proposals/deferred-schema-resolution.md`: the RGD path is now described as not *subscribing* to the watcher rather than not using it.

## Behaviour changes

- Default installs now run the CRD `SchemaWatcher`. It needs full CRD objects, so it adds a structured CRD informer next to the RGD reconciler's metadata-only CRD watch — one extra list/watch and the CRD objects resident in memory; no new RBAC. Its log name is `graph-engine.schema-watcher` (was `graph-schema-watcher.schema-watcher` with the gate on).
- On every leader start the CRD informer's initial list replays an Add per CRD, each resetting the compiler's discovery cache (previously only with the gate on); afterwards every CRD add, schema-changing update and delete does so once, and a compile that hits a `NoMatch` performs one rediscovery per attempt.
- Graph path (gate on): every schema-changing CRD event purges all cached impersonated executors, which are rebuilt on the next reconcile; impersonated clients now see a newly installed CRD after the watcher's reset rather than via controller-runtime's on-demand group reload (dynamic Graphs are re-enqueued on that event).
- Remaining gap: on the RGD/instance path the executor still applies through the manager client and the per-instance program cache keeps the compiled GVR, so a CRD recreated under the same GVK with a different plural/scope still needs a controller restart there (follow-up).
