### PR TITLE
fix(instance): persist status on early returns and project author conditions while suspended

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/executor"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/registry"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/rgdadapter"
+	geruntime "github.com/kubernetes-sigs/kro/pkg/graphengine/runtime"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/pkg/metrics"
 	"github.com/kubernetes-sigs/kro/pkg/requeue"
@@ -329,11 +330,19 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (err error
 // built-in conditions report InstanceManaged=True, GraphResolved=True and
 // ResourcesReady=False with reason "ReconciliationSuspended", and no nodes are
 // applied or pruned. Status is persisted so the Reconcile defer emits the
-// condition-transition events/metrics.
+// condition-transition events/metrics. When the RGD declares author conditions,
+// only those go on the wire, re-projected against the current spec.
 func (c *Controller) reconcileSuspended(ctx context.Context, inst *unstructured.Unstructured) error {
+	log := c.log.WithValues(
+		"namespace", inst.GetNamespace(),
+		"name", inst.GetName(),
+		"path", "suspended",
+	)
+
 	// Keep the instance managed even while suspended so deletion still works.
 	patched, err := c.stampInstanceMetadata(ctx, inst)
 	if err != nil {
+		c.persistInstanceNotManaged(ctx, log, inst, err)
 		return err
 	}
 	if patched != nil {
@@ -347,16 +356,71 @@ func (c *Controller) reconcileSuspended(ctx context.Context, inst *unstructured.
 	mark.GraphResolved()
 	mark.ReconciliationSuspended("reconciliation suspended via %s annotation", v1alpha1.InstanceReconcileAnnotation)
 
-	// No nodes are reconciled, so the instance-level state is Active (there is
-	// nothing to mark not-ready beyond the suspend condition). Author conditions
-	// are carried forward from the wire since they cannot be re-evaluated while
-	// suspended.
-	ri := c.client.Dynamic().Resource(c.gvr)
-	var instanceClient dynamic.ResourceInterface = ri
-	if c.namespaced {
-		instanceClient = ri.Namespace(inst.GetNamespace())
+	// No nodes are reconciled, so the instance-level state is Active; only a
+	// degraded author-condition projection lowers it to Error, as on the
+	// normal path.
+	state := v1alpha1.InstanceStateActive
+	var authorConditions []any
+	if c.reconcileConfig.HasAuthorConditions {
+		// Conditions that read only `schema` resolve at the current generation;
+		// those referencing managed resources are data-pending (nothing is
+		// observed while suspended) and keep their previous value. Without a
+		// runtime the previous list is carried forward. No built-in is appended.
+		if rt, rgd, rtErr := c.activeRuntime(inst); rtErr != nil {
+			log.V(1).Info("cannot re-project author conditions while suspended; carrying the previous conditions forward", "error", rtErr)
+			prev, _ := wireStatus["conditions"].([]any)
+			authorConditions = conditionsToInterfaceSlice(decodeConditions(prev))
+		} else {
+			stamped, condErr := c.projectAuthorConditions(rt, rgd, inst, wireStatus)
+			if condErr != nil {
+				log.Error(condErr, "author conditions degraded while suspended; setting state=Error")
+				state = v1alpha1.InstanceStateError
+			}
+			authorConditions = conditionsToInterfaceSlice(stamped)
+		}
 	}
-	return c.persistNodeFreeStatus(ctx, instanceClient, inst, wireStatus, v1alpha1.InstanceStateActive)
+	return c.persistNodeFreeStatus(ctx, c.instanceClient(inst), inst, wireStatus, state, authorConditions)
+}
+
+// activeRuntime builds a Runtime for inst from the latest issued revision,
+// which must be Active, the same way reconcileViaGraphEngine does but without
+// marking conditions or counting metrics. Callers fall back on any error.
+func (c *Controller) activeRuntime(inst *unstructured.Unstructured) (*geruntime.Runtime, *v1alpha1.ResourceGraphDefinition, error) {
+	latest, ok := c.graphResolver.GetLatestRevision()
+	if !ok {
+		return nil, nil, fmt.Errorf("latest issued revision not available")
+	}
+	if latest.State != revisions.RevisionStateActive {
+		return nil, nil, fmt.Errorf("latest issued revision %d is not active (state=%s)", latest.Revision, latest.State)
+	}
+	if latest.RGDSpec == nil {
+		return nil, nil, fmt.Errorf("latest issued revision %d has no RGDSpec", latest.Revision)
+	}
+	if c.graphEngineCompiler == nil {
+		return nil, nil, fmt.Errorf("compiler not wired (WithGraphEngineCompiler not called)")
+	}
+	rgd := &v1alpha1.ResourceGraphDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: latest.OwnerKey,
+		},
+		Spec: *latest.RGDSpec,
+	}
+	rt, _, err := rgdadapter.BuildRuntimeForInstanceCached(rgd, inst, c.graphEngineCompiler, c.programCache, c.runtimeOptions()...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build runtime: %w", err)
+	}
+	return rt, rgd, nil
+}
+
+// persistInstanceNotManaged marks InstanceManaged=False/ManagementFailed (hence
+// Ready=False) after a stampInstanceMetadata failure and best-effort persists
+// it, so the instance does not error-loop with no .status at all. A persist
+// error is only logged; the caller still returns the stamp error.
+func (c *Controller) persistInstanceNotManaged(ctx context.Context, log logr.Logger, inst *unstructured.Unstructured, cause error) {
+	NewConditionsMarkerFor(inst).InstanceNotManaged("finalizer/labeling failed: %v", cause)
+	if err := c.updateConditionsStatus(ctx, inst); err != nil {
+		log.V(1).Info("failed to persist InstanceManaged=False after metadata stamp failure", "error", err)
+	}
 }
 
 // stampInstanceMetadata stamps the kro finalizer and instance-management labels

--- a/pkg/controller/instance/controller_graph_engine.go
+++ b/pkg/controller/instance/controller_graph_engine.go
@@ -133,6 +133,7 @@ func (c *Controller) reconcileViaGraphEngine(
 
 	// Stamp the kro finalizer and management labels on the instance.
 	if patched, err := c.stampInstanceMetadata(ctx, inst); err != nil {
+		c.persistInstanceNotManaged(ctx, log, inst, err)
 		return err
 	} else if patched != nil {
 		inst.Object = patched.Object
@@ -156,11 +157,7 @@ func (c *Controller) reconcileViaGraphEngine(
 	}
 
 	// Build a per-reconcile Runtime.
-	var rtOpts []geruntime.Option
-	if c.reconcileConfig.MaxCollectionSize > 0 {
-		rtOpts = append(rtOpts, geruntime.WithMaxCollectionSize(c.reconcileConfig.MaxCollectionSize))
-	}
-	rt, _, err := rgdadapter.BuildRuntimeForInstanceCached(rgd, inst, c.graphEngineCompiler, c.programCache, rtOpts...)
+	rt, _, err := rgdadapter.BuildRuntimeForInstanceCached(rgd, inst, c.graphEngineCompiler, c.programCache, c.runtimeOptions()...)
 	if err != nil {
 		metrics.InstanceGraphResolutionFailuresTotal.WithLabelValues(gvrStr, "build_failed").Inc()
 		log.Error(err, "graph-engine: BuildRuntimeForInstance failed")
@@ -176,6 +173,14 @@ func (c *Controller) reconcileViaGraphEngine(
 	// but the parent has no inventory tracking them.
 	supersetMeta, applier, preErr := c.preApplyApplySetInventory(ctx, log, inst, rt)
 	if preErr != nil {
+		// Nothing was applied, but the stale prior verdict must not stay on the
+		// wire: persist ResourcesReady=False at the current generation with
+		// state=Error (the classification a hard apply error gets). A persist
+		// failure is only logged; the inventory error is the one to requeue on.
+		mark.ResourcesNotReady("pre-apply applyset inventory failed: %v", preErr)
+		if err := c.persistGraphEngineStatus(ctx, inst, wireStatus, rt, rgd, true); err != nil {
+			log.V(1).Info("graph-engine: failed to persist status after pre-apply inventory failure", "error", err)
+		}
 		return preErr
 	}
 
@@ -304,6 +309,16 @@ func (c *Controller) reconcileViaGraphEngine(
 // namespace/name; cluster-scoped instances key on name alone.
 func instanceKey(inst *unstructured.Unstructured) client.ObjectKey {
 	return client.ObjectKey{Namespace: inst.GetNamespace(), Name: inst.GetName()}
+}
+
+// runtimeOptions returns the per-reconcile Runtime options derived from the
+// reconcile config, shared by every path that builds a Runtime for an instance.
+func (c *Controller) runtimeOptions() []geruntime.Option {
+	var opts []geruntime.Option
+	if c.reconcileConfig.MaxCollectionSize > 0 {
+		opts = append(opts, geruntime.WithMaxCollectionSize(c.reconcileConfig.MaxCollectionSize))
+	}
+	return opts
 }
 
 // notReadyRequeue returns the soft not-ready requeue for key: a capped
@@ -906,13 +921,7 @@ func (c *Controller) persistGraphEngineStatus(
 	}
 
 	if c.reconcileConfig.HasAuthorConditions {
-		authored, incomplete, condErr := rgdadapter.ProjectInstanceConditions(rt, rgd, builtins, c.reconcileConfig.CELCostLimit)
-		prev, _ := wireStatus["conditions"].([]any)
-		previous := decodeConditions(prev)
-		stamped := stampAuthorConditions(authored, previous, inst.GetGeneration())
-		if incomplete {
-			stamped = mergeWithPrevious(stamped, previous)
-		}
+		stamped, condErr := c.projectAuthorConditions(rt, rgd, inst, wireStatus)
 		status["conditions"] = conditionsToInterfaceSlice(stamped)
 		if condErr != nil {
 			c.log.Error(condErr, "graph-engine: author conditions degraded; setting state=Error")
@@ -921,6 +930,28 @@ func (c *Controller) persistGraphEngineStatus(
 	}
 
 	return c.persistConditionsAndState(ctx, inst, wireStatus, status, previousState)
+}
+
+// projectAuthorConditions evaluates the RGD's author conditions against rt and
+// returns the wire-shaped list that replaces kro's built-ins in
+// author-conditions mode, stamped at the current generation; when the
+// projection is incomplete, previously persisted conditions of the missing
+// types are kept. A returned ErrConditionProjectionDegraded still comes with
+// the surviving conditions; the caller reflects it as state=Error.
+func (c *Controller) projectAuthorConditions(
+	rt *geruntime.Runtime,
+	rgd *v1alpha1.ResourceGraphDefinition,
+	inst *unstructured.Unstructured,
+	wireStatus map[string]any,
+) ([]v1alpha1.Condition, error) {
+	authored, incomplete, condErr := rgdadapter.ProjectInstanceConditions(rt, rgd, builtinConditions(inst), c.reconcileConfig.CELCostLimit)
+	prev, _ := wireStatus["conditions"].([]any)
+	previous := decodeConditions(prev)
+	stamped := stampAuthorConditions(authored, previous, inst.GetGeneration())
+	if incomplete {
+		stamped = mergeWithPrevious(stamped, previous)
+	}
+	return stamped, condErr
 }
 
 // isResourceDeleting reports whether err (an executor apply error) signals a

--- a/pkg/controller/instance/controller_graph_engine_test.go
+++ b/pkg/controller/instance/controller_graph_engine_test.go
@@ -143,6 +143,34 @@ func testRGDSpecWithAuthorConditions(condExpr string) *v1alpha1.ResourceGraphDef
 	}
 }
 
+// testRGDSpecWithSchemaAuthorConditions declares `spec.healthy: boolean`, one
+// ConfigMap resource, and two author conditions: AppReady (reads only
+// schema.spec.healthy) and CmReady (reads the ConfigMap node, so data-pending
+// until it is observed).
+func testRGDSpecWithSchemaAuthorConditions() *v1alpha1.ResourceGraphDefinitionSpec {
+	statusBytes, _ := json.Marshal(map[string]any{
+		"conditions": []any{
+			"${runtime.newCondition({type: 'AppReady', status: schema.spec.healthy ? 'True' : 'False', reason: 'CheckedSpec', message: ''})}",
+			"${runtime.newCondition({type: 'CmReady', status: cm.data.key == 'val' ? 'True' : 'False', reason: 'FromConfigMap', message: ''})}",
+		},
+	})
+	return &v1alpha1.ResourceGraphDefinitionSpec{
+		Schema: &v1alpha1.Schema{
+			Kind:       "WebApp",
+			Group:      "kro.run",
+			APIVersion: "v1alpha1",
+			Spec:       apimachineryruntime.RawExtension{Raw: []byte(`{"healthy":"boolean"}`)},
+			Status:     apimachineryruntime.RawExtension{Raw: statusBytes},
+		},
+		Resources: []*v1alpha1.Resource{{
+			ID: "cm",
+			Template: apimachineryruntime.RawExtension{
+				Raw: []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"app-config","namespace":"default"},"data":{"key":"val"}}`),
+			},
+		}},
+	}
+}
+
 func newGraphEngineControllerUnderTest(
 	t *testing.T,
 	raw *dynamicfake.FakeDynamicClient,
@@ -754,20 +782,50 @@ func TestReconcileViaGraphEngine_CompilerGuards(t *testing.T) {
 // 8. reconcileViaGraphEngine: Stamp Metadata Errors
 // -----------------------------------------------------------------------------
 
+// assertInstanceNotManagedPersisted checks the status a stampInstanceMetadata
+// failure must leave on the wire: InstanceManaged=False/ManagementFailed
+// carrying the stamp error, Ready=False, and state=Error.
+func assertInstanceNotManagedPersisted(t *testing.T, stored *unstructured.Unstructured, wantCause string) {
+	t.Helper()
+
+	managed := conditionByType(t, stored, InstanceManaged)
+	assert.Equal(t, metav1.ConditionFalse, managed.Status)
+	require.NotNil(t, managed.Reason)
+	assert.Equal(t, "ManagementFailed", *managed.Reason)
+	require.NotNil(t, managed.Message)
+	assert.Contains(t, *managed.Message, "finalizer/labeling failed")
+	assert.Contains(t, *managed.Message, wantCause)
+
+	ready := conditionByType(t, stored, Ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+
+	status, _, _ := unstructured.NestedMap(stored.Object, "status")
+	require.NotNil(t, status)
+	assert.Equal(t, string(v1alpha1.InstanceStateError), status["state"])
+}
+
+// newInstanceWithCorruptInventory returns an instance carrying ApplySet
+// inventory metadata but no finalizer and no additional-namespaces annotation,
+// so stampInstanceMetadata's ValidateParentInventory guard refuses to install
+// the finalizer.
+func newInstanceWithCorruptInventory() *unstructured.Unstructured {
+	inst := newInstanceObject("demo", "default")
+	inst.SetLabels(map[string]string{
+		applyset.ApplySetParentIDLabel: applyset.ID(inst),
+	})
+	inst.SetAnnotations(map[string]string{
+		applyset.ApplySetToolingAnnotation: applyset.ToolingID(),
+		applyset.ApplySetGKsAnnotation:     "Deployment.apps",
+		// Missing ApplySetAdditionalNamespacesAnnotation -> ValidateParentInventory fails
+	})
+	return inst
+}
+
 func TestReconcileViaGraphEngine_StampMetadata(t *testing.T) {
 	comp := newTestRealCompiler(t)
 
-	t.Run("Corrupted partial ApplySet metadata causes stampInstanceMetadata to fail", func(t *testing.T) {
-		inst := newInstanceObject("demo", "default")
-		// Set partial ApplySet inventory metadata without required hash
-		inst.SetLabels(map[string]string{
-			applyset.ApplySetParentIDLabel: applyset.ID(inst),
-		})
-		inst.SetAnnotations(map[string]string{
-			applyset.ApplySetToolingAnnotation: applyset.ToolingID(),
-			applyset.ApplySetGKsAnnotation:     "Deployment.apps",
-			// Missing ApplySetInventoryHashAnnotation -> ValidateParentInventory fails
-		})
+	t.Run("Corrupted partial ApplySet metadata causes stampInstanceMetadata to fail and persists InstanceManaged=False", func(t *testing.T) {
+		inst := newInstanceWithCorruptInventory()
 
 		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
 		c, _ := newGraphEngineControllerUnderTest(t, raw, testEmptyRGDSpec(), revisions.RevisionStateActive, comp, nil)
@@ -776,9 +834,13 @@ func TestReconcileViaGraphEngine_StampMetadata(t *testing.T) {
 		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot install finalizer with invalid applyset inventory")
+
+		stored := getStoredParentObject(t, raw)
+		assertInstanceNotManagedPersisted(t, stored, "cannot install finalizer with invalid applyset inventory")
+		assert.False(t, metadata.HasInstanceFinalizer(stored), "the finalizer must not be installed on a corrupt inventory")
 	})
 
-	t.Run("Dynamic client error during stampInstanceMetadata is returned", func(t *testing.T) {
+	t.Run("Dynamic client error during stampInstanceMetadata is returned and persists InstanceManaged=False", func(t *testing.T) {
 		inst := newInstanceObject("demo", "default")
 		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
 		raw.PrependReactor("patch", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
@@ -790,7 +852,70 @@ func TestReconcileViaGraphEngine_StampMetadata(t *testing.T) {
 		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed stamping instance metadata")
+
+		// The status write goes through UpdateStatus, not the failing patch verb.
+		stored := getStoredParentObject(t, raw)
+		assertInstanceNotManagedPersisted(t, stored, "patch metadata failed")
 	})
+
+	t.Run("Status persist failure after stamp failure is tolerated and the stamp error is returned", func(t *testing.T) {
+		inst := newInstanceWithCorruptInventory()
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		raw.PrependReactor("update", "webapps", func(action k8stesting.Action) (bool, apimachineryruntime.Object, error) {
+			if action.GetSubresource() == "status" {
+				return true, nil, errors.New("update status failure")
+			}
+			return false, nil, nil
+		})
+
+		c, _ := newGraphEngineControllerUnderTest(t, raw, testEmptyRGDSpec(), revisions.RevisionStateActive, comp, nil)
+		watcher := &fakeInstanceWatcher{}
+		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot install finalizer with invalid applyset inventory",
+			"the original stamp error, not the status persist error, drives the requeue")
+	})
+
+	t.Run("Author-conditions mode writes state=Error and leaves the author list untouched", func(t *testing.T) {
+		// Without a runtime only state=Error lands, as on the other
+		// updateConditionsStatus early exits; built-ins must not leak.
+		inst := newInstanceWithCorruptInventory()
+		require.NoError(t, unstructured.SetNestedMap(inst.Object, map[string]any{
+			"state": string(v1alpha1.InstanceStateActive),
+			"conditions": []any{map[string]any{
+				"type":               "AppReady",
+				"status":             "True",
+				"lastTransitionTime": "2026-01-01T00:00:00Z",
+				"observedGeneration": int64(1),
+			}},
+		}, "status"))
+
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		c, _ := newGraphEngineControllerUnderTest(t, raw, testEmptyRGDSpec(), revisions.RevisionStateActive, comp, nil)
+		c.reconcileConfig.HasAuthorConditions = true
+
+		watcher := &fakeInstanceWatcher{}
+		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
+		require.Error(t, err)
+
+		stored := getStoredParentObject(t, raw)
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateError), status["state"])
+		types := conditionTypesOf(stored)
+		assert.Equal(t, []string{"AppReady"}, types, "built-ins must not leak into the author-owned condition list")
+	})
+}
+
+// conditionTypesOf returns the condition types on the object's wire status in
+// order.
+func conditionTypesOf(obj *unstructured.Unstructured) []string {
+	conds := conditionsFromInstance(obj)
+	out := make([]string, 0, len(conds))
+	for _, c := range conds {
+		out = append(out, string(c.Type))
+	}
+	return out
 }
 
 // -----------------------------------------------------------------------------
@@ -1853,8 +1978,9 @@ func TestReconcileViaGraphEngine_PatchContributions(t *testing.T) {
 		assert.Equal(t, string(v1alpha1.InstanceStateError), status["state"])
 	})
 
-	t.Run("Pre-apply applyset union failure causes delayed requeue", func(t *testing.T) {
+	t.Run("Pre-apply applyset union failure causes delayed requeue and persists ResourcesReady=False", func(t *testing.T) {
 		inst := newInstanceObject("demo", "default")
+		inst.SetGeneration(2)
 		metadata.SetInstanceFinalizer(inst)
 		inst.SetLabels(metadata.NewInstanceLabeler(inst, true).Labels())
 		// Set malformed inventory annotation to cause applier.Union to fail
@@ -1862,6 +1988,17 @@ func TestReconcileViaGraphEngine_PatchContributions(t *testing.T) {
 			applyset.ApplySetGKsAnnotation: "invalid.group.with.bad.chars!/Kind",
 		}
 		inst.SetAnnotations(anns)
+		// Stale gen-1 verdict that must be replaced at generation 2.
+		require.NoError(t, unstructured.SetNestedMap(inst.Object, map[string]any{
+			"state": string(v1alpha1.InstanceStateActive),
+			"conditions": []any{map[string]any{
+				"type":               Ready,
+				"status":             "True",
+				"reason":             "Ready",
+				"lastTransitionTime": "2026-01-01T00:00:00Z",
+				"observedGeneration": int64(1),
+			}},
+		}, "status"))
 		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
 		spec := testRGDSpecWithConfigMap("app-config", "")
 		fakeRuntimeCl := newFakeRuntimeClient(t)
@@ -1872,6 +2009,86 @@ func TestReconcileViaGraphEngine_PatchContributions(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, requeue.IsRequeueError(err))
 		assert.Contains(t, err.Error(), "pre-apply applyset union failed")
+
+		stored := getStoredParentObject(t, raw)
+		rr := conditionByType(t, stored, ResourcesReady)
+		assert.Equal(t, metav1.ConditionFalse, rr.Status)
+		require.NotNil(t, rr.Reason)
+		assert.Equal(t, "NotReady", *rr.Reason)
+		require.NotNil(t, rr.Message)
+		assert.Contains(t, *rr.Message, "pre-apply applyset inventory failed")
+		assert.Contains(t, *rr.Message, "pre-apply applyset union failed")
+		assert.Equal(t, int64(2), rr.ObservedGeneration)
+
+		ready := conditionByType(t, stored, Ready)
+		assert.Equal(t, metav1.ConditionFalse, ready.Status)
+		assert.Equal(t, int64(2), ready.ObservedGeneration)
+		assert.Equal(t, metav1.ConditionTrue, conditionByType(t, stored, InstanceManaged).Status)
+		assert.Equal(t, metav1.ConditionTrue, conditionByType(t, stored, GraphResolved).Status)
+
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateError), status["state"],
+			"a hard pre-apply failure is classified like a hard apply error")
+
+		cmList := &unstructured.UnstructuredList{}
+		cmList.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "ConfigMapList"})
+		require.NoError(t, fakeRuntimeCl.List(context.Background(), cmList))
+		assert.Empty(t, cmList.Items, "no child may be applied when the pre-apply inventory failed")
+	})
+
+	t.Run("Pre-apply applyset union failure with author conditions projects them at the current generation", func(t *testing.T) {
+		inst := newInstanceObject("demo", "default")
+		inst.SetGeneration(2)
+		metadata.SetInstanceFinalizer(inst)
+		inst.SetLabels(metadata.NewInstanceLabeler(inst, true).Labels())
+		inst.SetAnnotations(map[string]string{
+			applyset.ApplySetGKsAnnotation: "invalid.group.with.bad.chars!/Kind",
+		})
+		require.NoError(t, unstructured.SetNestedField(inst.Object, false, "spec", "healthy"))
+		require.NoError(t, unstructured.SetNestedMap(inst.Object, map[string]any{
+			"state": string(v1alpha1.InstanceStateActive),
+			"conditions": []any{
+				map[string]any{
+					"type":               "AppReady",
+					"status":             "True",
+					"reason":             "CheckedSpec",
+					"lastTransitionTime": "2026-01-01T00:00:00Z",
+					"observedGeneration": int64(1),
+				},
+				map[string]any{
+					"type":               "CmReady",
+					"status":             "True",
+					"reason":             "FromConfigMap",
+					"lastTransitionTime": "2026-01-01T00:00:00Z",
+					"observedGeneration": int64(1),
+				},
+			},
+		}, "status"))
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		spec := testRGDSpecWithSchemaAuthorConditions()
+		fakeRuntimeCl := newFakeRuntimeClient(t)
+		c, _ := newGraphEngineControllerUnderTest(t, raw, spec, revisions.RevisionStateActive, comp, fakeRuntimeCl)
+		c.reconcileConfig.HasAuthorConditions = true
+
+		watcher := &fakeInstanceWatcher{}
+		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pre-apply applyset union failed")
+
+		stored := getStoredParentObject(t, raw)
+		appReady := conditionByType(t, stored, "AppReady")
+		assert.Equal(t, metav1.ConditionFalse, appReady.Status, "schema-only condition follows spec.healthy=false")
+		assert.Equal(t, int64(2), appReady.ObservedGeneration)
+		cmReady := conditionByType(t, stored, "CmReady")
+		assert.Equal(t, metav1.ConditionTrue, cmReady.Status, "resource-referencing condition is data-pending and keeps its previous value")
+		assert.Equal(t, int64(1), cmReady.ObservedGeneration)
+		assert.ElementsMatch(t, []string{"AppReady", "CmReady"}, conditionTypesOf(stored),
+			"kro's built-ins must not leak into the author-owned condition list")
+
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateError), status["state"])
 	})
 
 	t.Run("candidateMetadata includes conditional nodes without poisoning IsIgnored", func(t *testing.T) {

--- a/pkg/controller/instance/controller_test.go
+++ b/pkg/controller/instance/controller_test.go
@@ -406,3 +406,179 @@ func TestReconcile_FailedRevisionDoesNotDelayedRequeue(t *testing.T) {
 	require.NotNil(t, cond.Message)
 	assert.Contains(t, *cond.Message, "latest issued revision 1 failed")
 }
+
+// -----------------------------------------------------------------------------
+// reconcileSuspended
+// -----------------------------------------------------------------------------
+
+// newSuspendedInstance returns a managed instance at generation 2 carrying the
+// reconcile-suspended annotation and spec.healthy=false, whose wire status
+// still holds AppReady=True and CmReady=True from generation 1.
+func newSuspendedInstance(t *testing.T) *unstructured.Unstructured {
+	t.Helper()
+	inst := newInstanceObject("demo", "default")
+	inst.SetGeneration(2)
+	metadata.SetInstanceFinalizer(inst)
+	inst.SetLabels(metadata.NewInstanceLabeler(inst, true).Labels())
+	inst.SetAnnotations(map[string]string{
+		v1alpha1.InstanceReconcileAnnotation: v1alpha1.ReconcileSuspended,
+	})
+	require.NoError(t, unstructured.SetNestedField(inst.Object, false, "spec", "healthy"))
+	require.NoError(t, unstructured.SetNestedMap(inst.Object, map[string]any{
+		"state":    string(v1alpha1.InstanceStateActive),
+		"endpoint": "https://example.test",
+		"conditions": []any{
+			map[string]any{
+				"type":               "AppReady",
+				"status":             "True",
+				"reason":             "CheckedSpec",
+				"lastTransitionTime": "2026-01-01T00:00:00Z",
+				"observedGeneration": int64(1),
+			},
+			map[string]any{
+				"type":               "CmReady",
+				"status":             "True",
+				"reason":             "FromConfigMap",
+				"lastTransitionTime": "2026-01-01T00:00:00Z",
+				"observedGeneration": int64(1),
+			},
+		},
+	}, "status"))
+	return inst
+}
+
+// TestReconcileSuspended_AuthorConditions checks that a suspended instance gets
+// its author conditions re-projected against the current spec (schema-only
+// conditions at the current generation, resource-referencing ones kept at
+// their previous value) and that no built-in is injected into the author list.
+func TestReconcileSuspended_AuthorConditions(t *testing.T) {
+	comp := newTestRealCompiler(t)
+
+	t.Run("schema-only condition follows the new spec at the current generation, no built-in leaks", func(t *testing.T) {
+		inst := newSuspendedInstance(t)
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		controller, _ := newGraphEngineControllerUnderTest(t, raw, testRGDSpecWithSchemaAuthorConditions(), revisions.RevisionStateActive, comp, nil)
+		controller.reconcileConfig.HasAuthorConditions = true
+
+		require.NoError(t, controller.reconcileSuspended(context.Background(), inst))
+
+		stored := getStoredParentObject(t, raw)
+		appReady := conditionByType(t, stored, "AppReady")
+		assert.Equal(t, metav1.ConditionFalse, appReady.Status, "AppReady must follow spec.healthy=false")
+		assert.Equal(t, int64(2), appReady.ObservedGeneration, "AppReady must be stamped at the current generation")
+		require.NotNil(t, appReady.LastTransitionTime)
+		assert.NotEqual(t, "2026-01-01T00:00:00Z", appReady.LastTransitionTime.UTC().Format(time.RFC3339),
+			"lastTransitionTime must advance on a status flip")
+
+		cmReady := conditionByType(t, stored, "CmReady")
+		assert.Equal(t, metav1.ConditionTrue, cmReady.Status, "a resource-referencing condition is data-pending while suspended and keeps its previous value")
+		assert.Equal(t, int64(1), cmReady.ObservedGeneration)
+
+		assert.ElementsMatch(t, []string{"AppReady", "CmReady"}, conditionTypesOf(stored),
+			"only author conditions may be on the wire: ResourcesReady/ReconciliationSuspended must not leak")
+
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateActive), status["state"],
+			"state stays Active while suspended, as before the Graph engine")
+		assert.Equal(t, "https://example.test", status["endpoint"], "author status fields are carried forward")
+		assert.True(t, metadata.HasInstanceFinalizer(stored), "the instance stays managed while suspended")
+	})
+
+	t.Run("no active revision carries the previous author conditions forward without leaking built-ins", func(t *testing.T) {
+		inst := newSuspendedInstance(t)
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		// Empty revision registry: no runtime can be built.
+		controller, _ := newGraphEngineControllerUnderTest(t, raw, nil, "", comp, nil)
+		controller.reconcileConfig.HasAuthorConditions = true
+
+		require.NoError(t, controller.reconcileSuspended(context.Background(), inst))
+
+		stored := getStoredParentObject(t, raw)
+		appReady := conditionByType(t, stored, "AppReady")
+		assert.Equal(t, metav1.ConditionTrue, appReady.Status)
+		assert.Equal(t, int64(1), appReady.ObservedGeneration, "without a runtime the previous verdict is preserved verbatim")
+		assert.ElementsMatch(t, []string{"AppReady", "CmReady"}, conditionTypesOf(stored),
+			"the fallback must not inject kro's built-ins either")
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateActive), status["state"])
+	})
+
+	t.Run("degraded author projection sets state=Error, as on the normal path", func(t *testing.T) {
+		inst := newSuspendedInstance(t)
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		// Two expressions producing the same condition type: both copies are
+		// dropped and the projection reports ErrConditionProjectionDegraded.
+		spec := testEmptyRGDSpec()
+		spec.Schema.Status = apimachineryruntime.RawExtension{Raw: []byte(`{"conditions":[` +
+			`"${runtime.newCondition({type: 'Dup', status: 'True'})}",` +
+			`"${runtime.newCondition({type: 'Dup', status: 'False'})}"]}`)}
+		controller, _ := newGraphEngineControllerUnderTest(t, raw, spec, revisions.RevisionStateActive, comp, nil)
+		controller.reconcileConfig.HasAuthorConditions = true
+
+		require.NoError(t, controller.reconcileSuspended(context.Background(), inst))
+
+		stored := getStoredParentObject(t, raw)
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateError), status["state"])
+		assert.NotContains(t, conditionTypesOf(stored), ResourcesReady)
+	})
+
+	t.Run("without author conditions the built-ins report ReconciliationSuspended", func(t *testing.T) {
+		inst := newSuspendedInstance(t)
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		controller, _ := newGraphEngineControllerUnderTest(t, raw, testRGDSpecWithSchemaAuthorConditions(), revisions.RevisionStateActive, comp, nil)
+
+		require.NoError(t, controller.reconcileSuspended(context.Background(), inst))
+
+		stored := getStoredParentObject(t, raw)
+		rr := conditionByType(t, stored, ResourcesReady)
+		assert.Equal(t, metav1.ConditionFalse, rr.Status)
+		require.NotNil(t, rr.Reason)
+		assert.Equal(t, "ReconciliationSuspended", *rr.Reason)
+		assert.Equal(t, metav1.ConditionTrue, conditionByType(t, stored, InstanceManaged).Status)
+		assert.Equal(t, metav1.ConditionTrue, conditionByType(t, stored, GraphResolved).Status)
+		assert.Equal(t, metav1.ConditionFalse, conditionByType(t, stored, Ready).Status)
+		assert.Nil(t, findCondition(stored, "AppReady"), "leftover author conditions are dropped when the RGD declares none")
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateActive), status["state"])
+	})
+}
+
+// TestReconcileSuspended_StampMetadataFailurePersistsInstanceNotManaged is the
+// suspend-path twin of the graph-engine stamp-failure test: the corrupt
+// inventory must surface as InstanceManaged=False/ManagementFailed on the wire.
+func TestReconcileSuspended_StampMetadataFailurePersistsInstanceNotManaged(t *testing.T) {
+	comp := newTestRealCompiler(t)
+	inst := newInstanceWithCorruptInventory()
+	anns := inst.GetAnnotations()
+	anns[v1alpha1.InstanceReconcileAnnotation] = v1alpha1.ReconcileLegacyDisabled
+	inst.SetAnnotations(anns)
+
+	raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+	controller, _ := newGraphEngineControllerUnderTest(t, raw, testEmptyRGDSpec(), revisions.RevisionStateActive, comp, nil)
+
+	err := controller.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "demo", Namespace: "default"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot install finalizer with invalid applyset inventory")
+
+	stored := getStoredParentObject(t, raw)
+	assertInstanceNotManagedPersisted(t, stored, "cannot install finalizer with invalid applyset inventory")
+	assert.False(t, metadata.HasInstanceFinalizer(stored))
+}
+
+// findCondition returns the condition of the given type from the object's wire
+// status, or nil when absent (unlike conditionByType, which fails the test).
+func findCondition(obj *unstructured.Unstructured, condType string) *v1alpha1.Condition {
+	for _, c := range conditionsFromInstance(obj) {
+		if string(c.Type) == condType {
+			return &c
+		}
+	}
+	return nil
+}

--- a/pkg/controller/instance/status.go
+++ b/pkg/controller/instance/status.go
@@ -193,15 +193,16 @@ func (c *Controller) updateConditionsStatus(ctx context.Context, inst *unstructu
 // runtime. Status projections and author conditions that cannot be evaluated
 // during early deletion are preserved from the wire.
 func (c *Controller) updateDeletionStatus(dcx *DeletionContext) error {
-	return c.persistNodeFreeStatus(dcx.Ctx, dcx.InstanceClient(), dcx.Instance, dcx.WireStatus, dcx.State)
+	return c.persistNodeFreeStatus(dcx.Ctx, dcx.InstanceClient(), dcx.Instance, dcx.WireStatus, dcx.State, deletionConditions(dcx.Instance, dcx.WireStatus))
 }
 
 // persistNodeFreeStatus assembles and persists instance status for the two
 // engine-free paths (deletion and suspend). The caller must already have
 // stamped the built-in conditions onto inst via a ConditionsMarker. It carries
 // the wire status forward (minus conditions/state), applies the given
-// lifecycle state, preserves author conditions via deletionConditions when the
-// RGD owns the condition surface, and writes through the skip-identical
+// lifecycle state, replaces the built-in conditions with authorConditions when
+// the RGD owns the condition surface (deletion passes deletionConditions,
+// suspend the re-projected list), and writes through the skip-identical
 // persistStatus guard.
 func (c *Controller) persistNodeFreeStatus(
 	ctx context.Context,
@@ -209,6 +210,7 @@ func (c *Controller) persistNodeFreeStatus(
 	inst *unstructured.Unstructured,
 	wireStatus map[string]any,
 	state v1alpha1.InstanceState,
+	authorConditions []any,
 ) error {
 	previousState, _ := wireStatus["state"].(string)
 	status := initialStatus(inst, state)
@@ -218,7 +220,7 @@ func (c *Controller) persistNodeFreeStatus(
 		}
 	}
 	if c.reconcileConfig.HasAuthorConditions {
-		status["conditions"] = deletionConditions(inst, wireStatus)
+		status["conditions"] = authorConditions
 	}
 	return c.persistStatus(ctx, instanceClient, inst, wireStatus, status, previousState)
 }

--- a/test/integration/suites/core/instance_conditions_test.go
+++ b/test/integration/suites/core/instance_conditions_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +29,7 @@ import (
 
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	ctrlinstance "github.com/kubernetes-sigs/kro/pkg/controller/instance"
+	"github.com/kubernetes-sigs/kro/pkg/controller/instance/applyset"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
@@ -270,6 +272,91 @@ var _ = Describe("Instance Conditions", func() {
 				}
 			}
 		}, 20*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+	})
+
+	It("surfaces InstanceManaged=False when the finalizer cannot be installed on a corrupt ApplySet inventory", func(ctx SpecContext) {
+		// stampInstanceMetadata refuses the finalizer when the ApplySet inventory
+		// is invalid; that refusal happens before any other status is written and
+		// must still reach the instance's own status.
+		rgd := generator.NewResourceGraphDefinition("test-instance-conditions-corrupt-inventory",
+			generator.WithSchema(
+				"TestInstanceCorruptInventory", "v1alpha1",
+				map[string]any{
+					"configData": "string",
+				},
+				nil,
+			),
+			generator.WithResource("configmap", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name": "${schema.metadata.name}",
+				},
+				"data": map[string]any{
+					"config": "${schema.spec.configData}",
+				},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		// The tooling annotation alone marks the object as an ApplySet parent;
+		// without the applyset.kubernetes.io/id label the inventory is invalid.
+		instance := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TestInstanceCorruptInventory",
+				"metadata": map[string]any{
+					"name":      "test-instance-corrupt-inventory",
+					"namespace": namespace,
+					"annotations": map[string]any{
+						applyset.ApplySetToolingAnnotation: applyset.ToolingID(),
+					},
+				},
+				"spec": map[string]any{
+					"configData": "test-data",
+				},
+			},
+		}
+		createInstanceWithCleanup(ctx, instance)
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{
+				Name:      "test-instance-corrupt-inventory",
+				Namespace: namespace,
+			}, instance)).To(Succeed())
+
+			managed := findInstanceConditionByType(instance, ctrlinstance.InstanceManaged)
+			g.Expect(managed).ToNot(BeNil(), "InstanceManaged must be written even though the reconcile failed before marking anything else")
+			g.Expect(managed["status"]).To(Equal("False"))
+			g.Expect(managed["reason"]).To(Equal("ManagementFailed"))
+			g.Expect(managed["message"]).To(ContainSubstring("cannot install finalizer with invalid applyset inventory"))
+			g.Expect(managed["message"]).To(ContainSubstring(applyset.ApplySetParentIDLabel))
+
+			ready := findInstanceConditionByType(instance, ctrlinstance.Ready)
+			g.Expect(ready).ToNot(BeNil())
+			g.Expect(ready["status"]).To(Equal("False"))
+
+			state, _, _ := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(state).To(Equal(string(krov1alpha1.InstanceStateError)))
+
+			g.Expect(instance.GetFinalizers()).To(BeEmpty(), "the finalizer must not be installed on a corrupt inventory")
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		// Nothing was applied: the guard fires before the engine runs.
+		Consistently(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{
+				Name:      "test-instance-corrupt-inventory",
+				Namespace: namespace,
+			}, &corev1.ConfigMap{})
+			g.Expect(err).To(MatchError(errors.IsNotFound, "no child may be applied while the instance cannot be managed"))
+		}, 3*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
 	})
 
 })

--- a/test/integration/suites/core/instance_custom_conditions_test.go
+++ b/test/integration/suites/core/instance_custom_conditions_test.go
@@ -659,6 +659,165 @@ var _ = Describe("Instance Custom Conditions", func() {
 		}).WithContext(ctx).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(Succeed())
 	})
 
+	It("re-projects schema-only author conditions while suspended and never leaks built-ins", func(ctx SpecContext) {
+		// While suspended, schema-only author conditions follow the spec at the
+		// new generation, resource-referencing ones keep their last value, and no
+		// built-in is injected; suspension is visible to authors only through
+		// runtime.condition(schema, 'ResourcesReady') (the Paused condition).
+		rgdName := "test-cc-suspended"
+		instanceKind := "TestCcSuspended"
+
+		rgd := generator.NewResourceGraphDefinition(rgdName,
+			generator.WithSchema(
+				instanceKind, "v1alpha1",
+				map[string]any{
+					"name":    "string",
+					"healthy": "boolean | default=true",
+				},
+				map[string]any{
+					"conditions": []any{
+						`${runtime.newCondition({type: 'AppReady', status: schema.spec.healthy ? 'True' : 'False',
+							reason: 'CheckedSpec', message: ''})}`,
+						`${runtime.newCondition({type: 'CmReady', status: configmap.data.foo == 'demo' ? 'True' : 'False',
+							reason: 'FromConfigMap', message: ''})}`,
+						`${runtime.newCondition({type: 'Paused',
+							status: runtime.condition(schema, 'ResourcesReady').reason == 'ReconciliationSuspended' ? 'True' : 'False',
+							reason: runtime.condition(schema, 'ResourcesReady').reason, message: ''})}`,
+					},
+				},
+			),
+			generator.WithResource("configmap", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}"},
+				"data":       map[string]any{"foo": "${schema.spec.name}"},
+			}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+			"kind":       instanceKind,
+			"metadata":   map[string]any{"name": "demo", "namespace": namespace},
+			"spec":       map[string]any{"name": "demo", "healthy": true},
+		}}
+		createInstanceWithCleanup(ctx, instance)
+
+		builtins := []string{
+			ctrlinstance.InstanceManaged, ctrlinstance.GraphResolved,
+			ctrlinstance.ResourcesReady, ctrlinstance.Ready,
+		}
+		expectNoBuiltins := func(g Gomega) {
+			for _, builtin := range builtins {
+				g.Expect(findInstanceConditionByType(instance, builtin)).To(BeNil(),
+					"kro's built-in %s must not leak onto the author-owned condition list", builtin)
+			}
+		}
+
+		// Converge at generation 1: every author condition is projected.
+		var generation1 int64
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, instance)).To(Succeed())
+			generation1 = instance.GetGeneration()
+			for _, condType := range []string{"AppReady", "CmReady"} {
+				c := findInstanceConditionByType(instance, condType)
+				g.Expect(c).ToNot(BeNil(), "%s should be on the wire", condType)
+				g.Expect(c["status"]).To(Equal("True"), "%s should be True", condType)
+				g.Expect(c["observedGeneration"]).To(Equal(generation1))
+			}
+			paused := findInstanceConditionByType(instance, "Paused")
+			g.Expect(paused).ToNot(BeNil())
+			g.Expect(paused["status"]).To(Equal("False"))
+			expectNoBuiltins(g)
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+
+		// Flip spec.healthy and suspend reconciliation in the SAME update.
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, instance)).To(Succeed())
+			g.Expect(unstructured.SetNestedField(instance.Object, false, "spec", "healthy")).To(Succeed())
+			ann := instance.GetAnnotations()
+			if ann == nil {
+				ann = map[string]string{}
+			}
+			ann[krov1alpha1.InstanceReconcileAnnotation] = krov1alpha1.ReconcileSuspended
+			instance.SetAnnotations(ann)
+			g.Expect(env.Client.Update(ctx, instance)).To(Succeed())
+		}).WithContext(ctx).WithTimeout(20 * time.Second).WithPolling(time.Second).Should(Succeed())
+
+		var generation2 int64
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, instance)).To(Succeed())
+			generation2 = instance.GetGeneration()
+			g.Expect(generation2).To(BeNumerically(">", generation1))
+
+			appReady := findInstanceConditionByType(instance, "AppReady")
+			g.Expect(appReady).ToNot(BeNil())
+			g.Expect(appReady["status"]).To(Equal("False"),
+				"a schema-only author condition must follow the spec change delivered with the suspend annotation")
+			g.Expect(appReady["observedGeneration"]).To(Equal(generation2),
+				"the re-projected condition must be stamped at the new generation")
+
+			paused := findInstanceConditionByType(instance, "Paused")
+			g.Expect(paused).ToNot(BeNil())
+			g.Expect(paused["status"]).To(Equal("True"))
+			g.Expect(paused["reason"]).To(Equal("ReconciliationSuspended"),
+				"runtime.condition(schema, 'ResourcesReady') is where authors see suspension")
+			g.Expect(paused["observedGeneration"]).To(Equal(generation2))
+
+			cmReady := findInstanceConditionByType(instance, "CmReady")
+			g.Expect(cmReady).ToNot(BeNil(), "a resource-referencing condition must not disappear while suspended")
+			g.Expect(cmReady["status"]).To(Equal("True"), "its last written value is preserved")
+			g.Expect(cmReady["observedGeneration"]).To(Equal(generation1),
+				"nothing is observed while suspended, so it is carried at its previous generation")
+
+			expectNoBuiltins(g)
+			state, _, _ := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(state).To(Equal(string(krov1alpha1.InstanceStateActive)))
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+
+		// Stable across later cycles.
+		Consistently(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, instance)).To(Succeed())
+			expectNoBuiltins(g)
+			g.Expect(findInstanceConditionByType(instance, "AppReady")["status"]).To(Equal("False"))
+			g.Expect(findInstanceConditionByType(instance, "CmReady")["observedGeneration"]).To(Equal(generation1))
+		}).WithContext(ctx).WithTimeout(5 * time.Second).WithPolling(time.Second).Should(Succeed())
+
+		// Resume (and flip the spec back) in one update: every author condition
+		// is re-projected at the new generation, still without built-ins.
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, instance)).To(Succeed())
+			g.Expect(unstructured.SetNestedField(instance.Object, true, "spec", "healthy")).To(Succeed())
+			ann := instance.GetAnnotations()
+			delete(ann, krov1alpha1.InstanceReconcileAnnotation)
+			instance.SetAnnotations(ann)
+			g.Expect(env.Client.Update(ctx, instance)).To(Succeed())
+		}).WithContext(ctx).WithTimeout(20 * time.Second).WithPolling(time.Second).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, instance)).To(Succeed())
+			generation3 := instance.GetGeneration()
+			g.Expect(generation3).To(BeNumerically(">", generation2))
+			for _, condType := range []string{"AppReady", "CmReady"} {
+				c := findInstanceConditionByType(instance, condType)
+				g.Expect(c).ToNot(BeNil())
+				g.Expect(c["status"]).To(Equal("True"), "%s should be True again after resuming", condType)
+				g.Expect(c["observedGeneration"]).To(Equal(generation3), "%s should be re-projected after resuming", condType)
+			}
+			paused := findInstanceConditionByType(instance, "Paused")
+			g.Expect(paused).ToNot(BeNil())
+			g.Expect(paused["status"]).To(Equal("False"))
+			expectNoBuiltins(g)
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
+	})
+
 	It("removes leftover author conditions after the conditions block is removed", func(ctx SpecContext) {
 		rgdName := "test-cc-block-removed"
 		instanceKind := "TestCcBlockRemoved"


### PR DESCRIPTION
## Problem

Three early exits of the RGD instance controller (`pkg/controller/instance/`) return without writing any status. When `stampInstanceMetadata` fails persistently — e.g. an instance restored from a backup whose ApplySet inventory fails `ValidateParentInventory` — the instance has no `.status` at all while the controller error-loops, and the guard's remediation text is only in the controller log. When `preApplyApplySetInventory` fails (a malformed `applyset.kubernetes.io/contains-group-kinds` annotation, or a rejected inventory patch), an instance that was `Ready=True`/`ACTIVE` at generation N keeps reporting exactly that after a spec change at N+1 whose children never converge. The pre-rewrite engine persisted status on both.

While suspended via `kro.run/reconcile: suspended`, an RGD that declares author conditions got kro's built-in `ResourcesReady=False/ReconciliationSuspended` injected into the author-owned condition list, and the author conditions were carried verbatim from the wire, so a spec change delivered together with the annotation was not reflected (old `observedGeneration`, stale status). The pre-rewrite engine re-evaluated author conditions while suspended.

## Fix

- `controller.go`, `controller_graph_engine.go`: a `stampInstanceMetadata` failure on either the graph-engine or the suspend path now marks `InstanceManaged=False/ManagementFailed` (`finalizer/labeling failed: <cause>`) and persists it through the existing `updateConditionsStatus` early-exit writer (`persistInstanceNotManaged`) before returning the stamp error; a persist error is only logged.
- `controller_graph_engine.go`: a `preApplyApplySetInventory` failure now marks `ResourcesReady=False/NotReady` (`pre-apply applyset inventory failed: …`) and persists through `persistGraphEngineStatus` with `degraded=true` before returning the same requeue error; with author conditions they are projected as on the normal path.
- `controller.go` `reconcileSuspended`: with author conditions, the list is re-projected against a runtime built from the latest issued revision, which must be Active (`activeRuntime`, sharing `runtimeOptions` with the apply path), through `projectAuthorConditions`, factored out of `persistGraphEngineStatus`. Conditions that read only `schema` resolve at the current generation, conditions referencing managed resources are data-pending and keep their previous value, and no built-in is appended; when no runtime can be built the previous author conditions are carried forward. Suspension stays visible to authors through `runtime.condition(schema, 'ResourcesReady')`.
- `status.go` `persistNodeFreeStatus`: takes the author-owned condition list as a parameter; deletion keeps passing `deletionConditions`.

## Behaviour changes

- Stamp failure (both paths): the instance now carries `InstanceManaged=False/ManagementFailed` with the cause, `Ready=False`, `GraphResolved` and `ResourcesReady` as `Unknown/AwaitingReconciliation`, and `state: ERROR`. The pre-rewrite engine wrote `state: ACTIVE` here (its state manager had seen no nodes); `ERROR` matches the other `updateConditionsStatus` early exits. With author conditions only `state: ERROR` is written. The finalizer is still not installed and the returned error is unchanged.
- Pre-apply inventory failure: `ResourcesReady=False/NotReady` and `Ready=False` at the current generation, `InstanceManaged`/`GraphResolved` `True`, `state: ERROR`. The pre-rewrite engine wrote `state: IN_PROGRESS` here; `ERROR` is the classification a hard apply error gets. The requeue error and metrics are unchanged.
- Suspension with author conditions: only author conditions are on the wire, schema-only ones follow the current spec at the current generation, `state` stays `ACTIVE` (`ERROR` only for a degraded projection, as on the normal path). Upgrade caveat: an instance that was already suspended under the previous release keeps the `ResourcesReady/ReconciliationSuspended` entry that release injected until it is resumed — condition types the projection cannot produce while suspended are carried forward from the wire. Suspension without author conditions and deletion are unchanged.
- The pre-existing stamp-failure and pre-apply unit tests, which asserted only the returned error, now also assert the persisted status; no assertion was removed.
