### PR TITLE
fix(graphengine): enforce resource-identity uniqueness before any write

### DIFF
--- a/pkg/controller/instance/controller_graph_engine_test.go
+++ b/pkg/controller/instance/controller_graph_engine_test.go
@@ -1835,12 +1835,18 @@ func TestReconcileViaGraphEngine_PatchContributions(t *testing.T) {
 		watcher := &fakeInstanceWatcher{}
 		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
 		require.Error(t, err)
-		// The collision is now caught PRE-WRITE by the executor's identity-claim
-		// guard (before cm2's SSA write clobbers cm1), so the error is
-		// ErrDuplicateIdentity rather than the post-apply validateAppliedIdentities
-		// message. (Like any hard apply error it is still delayed-requeued so the
-		// instance retries; the state below reflects the degraded outcome.)
+		// The collision is caught by the executor's pre-walk identity pass (both
+		// names are static), so the error is ErrDuplicateIdentity rather than the
+		// post-apply validateAppliedIdentities message and neither node is applied.
+		// (Like any hard apply error it is still delayed-requeued so the instance
+		// retries; the state below reflects the degraded outcome.)
 		assert.Contains(t, err.Error(), "duplicate resource identity across nodes")
+
+		live := &unstructured.Unstructured{}
+		live.SetAPIVersion("v1")
+		live.SetKind("ConfigMap")
+		getErr := fakeRuntimeCl.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "shared-cm"}, live)
+		assert.True(t, apierrors.IsNotFound(getErr), "shared-cm must not exist after a pre-walk duplicate rejection, got err=%v", getErr)
 
 		stored := getStoredParentObject(t, raw)
 		cond := conditionByType(t, stored, ResourcesReady)

--- a/pkg/graphengine/compiler/compiler.go
+++ b/pkg/graphengine/compiler/compiler.go
@@ -520,15 +520,18 @@ func emitSchemaDependencies(p *Program) {
 	}
 }
 
-// isIdentityFieldPath reports whether path identifies a resource's
-// identity field. metadata.name is identity for every resource;
-// metadata.namespace is identity only for namespaced resources.
-func isIdentityFieldPath(path string, namespaced bool) bool {
+// isIdentityFieldPath reports whether path is one of the fields that make up a
+// rendered object's runtime identity (GVK + namespace + name, the key the
+// runtime's uniqueness check dedupes on): apiVersion, kind and metadata.name
+// always; metadata.namespace for namespaced targets and for dynamic-GVK nodes,
+// whose REST scope is unknown at compile time (buildDynamicNode never sets
+// Namespaced) — the runtime check is the backstop if the target is cluster-scoped.
+func isIdentityFieldPath(path string, namespaced, dynamicGVK bool) bool {
 	switch path {
-	case "metadata.name":
+	case "apiVersion", "kind", "metadata.name":
 		return true
 	case "metadata.namespace":
-		return namespaced
+		return namespaced || dynamicGVK
 	}
 	return false
 }
@@ -654,7 +657,7 @@ func (ctx *CompilationContext) analyzeVariables(n *Node, inspector *ast.Inspecto
 		for _, d := range analysis.nodeDeps {
 			addDependency(n, d)
 		}
-		if isIdentityFieldPath(v.Path, n.Namespaced) {
+		if isIdentityFieldPath(v.Path, n.Namespaced, n.DynamicGVK) {
 			if analysis.inspection != nil && analysis.inspection.UsesOmit() {
 				return nil, fmt.Errorf("variable at %q: omit() cannot be used in resource identity fields", v.Path)
 			}
@@ -676,7 +679,7 @@ func (ctx *CompilationContext) analyzeVariables(n *Node, inspector *ast.Inspecto
 		}
 		if len(missing) > 0 {
 			return nil, fmt.Errorf(
-				"every forEach iterator must appear in metadata.name (or metadata.namespace for namespaced resources) to produce unique identities, missing: %v",
+				"every forEach iterator must appear in an identity field (apiVersion, kind, metadata.name, or metadata.namespace for namespaced (or dynamic-GVK) resources) to produce unique identities, missing: %v",
 				missing,
 			)
 		}

--- a/pkg/graphengine/compiler/compiler_test.go
+++ b/pkg/graphengine/compiler/compiler_test.go
@@ -497,7 +497,7 @@ func TestCompile(t *testing.T) {
 			wantErr: "cluster-scoped but template sets metadata.namespace",
 		},
 		{
-			name: "forEach without iterator use in metadata.name is rejected",
+			name: "forEach without iterator use in any identity field is rejected",
 			graph: generator.NewGraph("g",
 				generator.WithDef("src", map[string]any{"names": []any{"a", "b"}}),
 				generator.WithTemplate("p", map[string]any{
@@ -506,7 +506,7 @@ func TestCompile(t *testing.T) {
 					"spec":     map[string]any{"containers": []any{map[string]any{"name": "c", "image": "nginx"}}},
 				}, generator.ForEachDim("name", "${src.names}")),
 			),
-			wantErr: "every forEach iterator must appear in metadata.name",
+			wantErr: "every forEach iterator must appear in an identity field (apiVersion, kind, metadata.name, or metadata.namespace",
 		},
 		{
 			name: "template missing metadata is rejected",
@@ -1087,7 +1087,77 @@ func TestCompile_DynamicGVK(t *testing.T) {
 		)
 		_, err := newTestCompiler(t).Compile(g)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "forEach iterator")
+		assert.Contains(t, err.Error(), "every forEach iterator must appear in an identity field (apiVersion, kind, metadata.name, or metadata.namespace")
+		assert.Contains(t, err.Error(), "missing: [n]")
+	})
+
+	// Runtime identity is GVK+namespace+name, so an iterator that varies
+	// apiVersion or kind renders distinct objects even with a fixed name.
+	t.Run("forEach iterator appearing only in kind is accepted (heterogeneous-kind collection)", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithNamespace("default"),
+			generator.WithDef("cfg", map[string]any{"kinds": []any{"ConfigMap", "Secret"}}),
+			generator.WithTemplate("res", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "${k}",
+				"metadata":   map[string]any{"name": "fixed"},
+			}, generator.ForEachDim("k", "${cfg.kinds}")),
+		)
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err, "an iterator in kind yields one identity per kind")
+		require.NotNil(t, prog.Nodes["res"])
+		assert.True(t, prog.Nodes["res"].DynamicGVK)
+		assert.True(t, prog.Nodes["res"].IsCollection())
+	})
+
+	t.Run("forEach iterator appearing only in apiVersion is accepted", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithNamespace("default"),
+			generator.WithDef("cfg", map[string]any{"groups": []any{"example.com/v1", "other.example.com/v1"}}),
+			generator.WithTemplate("res", map[string]any{
+				"apiVersion": "${gv}",
+				"kind":       "Widget",
+				"metadata":   map[string]any{"name": "fixed"},
+			}, generator.ForEachDim("gv", "${cfg.groups}")),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err, "an iterator in apiVersion yields one identity per group/version")
+	})
+
+	// A dynamic-GVK node's REST scope is unknown at compile time, so an iterator
+	// that appears only in metadata.namespace must be accepted.
+	t.Run("forEach iterator appearing only in metadata.namespace is accepted on a dynamic-GVK node", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithNamespace("default"),
+			generator.WithDef("cfg", map[string]any{"kind": "ConfigMap", "namespaces": []any{"a", "b"}}),
+			generator.WithTemplate("res", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "${cfg.kind}",
+				"metadata":   map[string]any{"name": "fixed", "namespace": "${ns}"},
+			}, generator.ForEachDim("ns", "${cfg.namespaces}")),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err, "scope is unknown at compile time for a dynamic-GVK node, so namespace counts as identity")
+	})
+
+	t.Run("forEach iterator appearing in none of apiVersion/kind/name/namespace is rejected on a dynamic-GVK node", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithNamespace("default"),
+			generator.WithDef("cfg", map[string]any{"kind": "ConfigMap", "names": []any{"a", "b"}}),
+			generator.WithTemplate("res", map[string]any{
+				"apiVersion": "v1",
+				"kind":       "${cfg.kind}",
+				"metadata":   map[string]any{"name": "fixed", "labels": map[string]any{"item": "${n}"}},
+			}, generator.ForEachDim("n", "${cfg.names}")),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "every forEach iterator must appear in an identity field")
+		assert.Contains(t, err.Error(), "missing: [n]")
 	})
 }
 

--- a/pkg/graphengine/compiler/patch_test.go
+++ b/pkg/graphengine/compiler/patch_test.go
@@ -97,7 +97,8 @@ func TestCompilePatch_ForEachRequiresIteratorInName(t *testing.T) {
 
 	_, err := newTestCompiler(t).Compile(g)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "every forEach iterator must appear in metadata.name")
+	assert.Contains(t, err.Error(), "every forEach iterator must appear in an identity field")
+	assert.Contains(t, err.Error(), "missing: [n]")
 }
 
 // TestCompilePatch_ForEachFansOut verifies a patch node CAN carry forEach when

--- a/pkg/graphengine/compiler/validation.go
+++ b/pkg/graphengine/compiler/validation.go
@@ -115,9 +115,10 @@ func validateKindCompatibility(n *expv1alpha1.Node) error {
 		// fans the same contribution out across every rendered target (e.g. a
 		// status writeback to each claimant CR). Name-required and endpoint
 		// derivation are enforced later against the unmarshalled payload
-		// (derivePatchEndpoint); iterator→identity coverage (each rendered patch
-		// must resolve to a distinct name) is enforced in analyzeVariables so a
-		// forEach patch can't silently patch one target N times.
+		// (derivePatchEndpoint); iterator→identity coverage is enforced in
+		// analyzeVariables, and overlapping axis values are rejected after
+		// expansion by the runtime (validateUniqueIdentities), so a forEach patch
+		// can't silently patch one target N times.
 		return nil
 	}
 	if len(n.ForEach) == 0 {

--- a/pkg/graphengine/executor/duplicate_identity_test.go
+++ b/pkg/graphengine/executor/duplicate_identity_test.go
@@ -17,47 +17,145 @@ package executor
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/kubernetes-sigs/kro/pkg/applyset"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/compiler"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/watchrouter"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
 )
 
-// TestApply_RejectsDuplicateIdentityBeforeWrite pins finding 207/1627: two
-// DISTINCT template nodes rendering the same object identity (GVK+ns+name) must
-// be rejected with a hard ErrDuplicateIdentity BEFORE the second node's write,
-// so the second node cannot clobber the first's object. The pre-write claim
-// guard (prepareItem) fires as soon as the second node is prepared.
+// sharedCM renders a ConfigMap template named "shared" whose data.from records
+// which node produced it.
+func sharedCM(from string) map[string]any {
+	return map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "shared"},
+		"data":     map[string]any{"from": from},
+	}
+}
+
+// previousSharedCM is a user-owned live ConfigMap default/shared (no kro labels).
+func previousSharedCM() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "shared", "namespace": "default"},
+		"data":     map[string]any{"from": "previous"},
+	}}
+}
+
+// writeCounter counts every mutating request issued through the fake client.
+type writeCounter struct{ n atomic.Int64 }
+
+func (c *writeCounter) funcs() interceptor.Funcs {
+	count := func() { c.n.Add(1) }
+	return interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			count()
+			return cl.Create(ctx, obj, opts...)
+		},
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			count()
+			return cl.Update(ctx, obj, opts...)
+		},
+		Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			count()
+			return cl.Patch(ctx, obj, patch, opts...)
+		},
+		Apply: func(ctx context.Context, cl client.WithWatch, obj apimachineryruntime.ApplyConfiguration, opts ...client.ApplyOption) error {
+			count()
+			return cl.Apply(ctx, obj, opts...)
+		},
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			count()
+			return cl.Delete(ctx, obj, opts...)
+		},
+		DeleteAllOf: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error {
+			count()
+			return cl.DeleteAllOf(ctx, obj, opts...)
+		},
+		SubResourcePatch: func(ctx context.Context, cl client.Client, sub string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			count()
+			return cl.SubResource(sub).Patch(ctx, obj, patch, opts...)
+		},
+		SubResourceUpdate: func(ctx context.Context, cl client.Client, sub string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			count()
+			return cl.SubResource(sub).Update(ctx, obj, opts...)
+		},
+	}
+}
+
+// rgdPathLabeler stamps the labels the instance controller's labeler would
+// (applyset part-of, kro.run/owned); a live object carrying them was adopted.
+func rgdPathLabeler(obj *unstructured.Unstructured) {
+	l := obj.GetLabels()
+	if l == nil {
+		l = map[string]string{}
+	}
+	l[applyset.ApplysetPartOfLabel] = "applyset-test"
+	l[metadata.OwnedLabel] = "true"
+	obj.SetLabels(l)
+}
+
+func getSharedCM(t *testing.T, cl client.Client) *unstructured.Unstructured {
+	t.Helper()
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(configMapGVK)
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Namespace: "default", Name: "shared"}, got))
+	return got
+}
+
+// TestApply_RejectsDuplicateIdentityBeforeWrite: two template nodes with static
+// names rendering the same object are rejected by the pre-walk pass before ANY
+// write — a pre-existing user object is neither modified nor adopted (labelled).
 func TestApply_RejectsDuplicateIdentityBeforeWrite(t *testing.T) {
 	t.Parallel()
 
-	// Two template nodes, cm1 and cm2, both render ConfigMap default/shared.
 	g := generator.NewGraph("g",
 		generator.WithNamespace("default"),
-		generator.WithTemplate("cm1", map[string]any{
-			"apiVersion": "v1", "kind": "ConfigMap",
-			"metadata": map[string]any{"name": "shared"},
-			"data":     map[string]any{"from": "cm1"},
-		}),
-		generator.WithTemplate("cm2", map[string]any{
-			"apiVersion": "v1", "kind": "ConfigMap",
-			"metadata": map[string]any{"name": "shared"},
-			"data":     map[string]any{"from": "cm2"},
-		}),
+		generator.WithTemplate("cm1", sharedCM("cm1")),
+		generator.WithTemplate("cm2", sharedCM("cm2")),
 	)
 
-	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
-	_, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+	writes := &writeCounter{}
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(previousSharedCM()).
+		WithInterceptorFuncs(writes.funcs()).
+		Build()
+	before := getSharedCM(t, cl)
+
+	res, err := NewSimple(cl).ApplyWithLabeler(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{}, rgdPathLabeler)
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrDuplicateIdentity),
 		"a cross-node duplicate identity must surface ErrDuplicateIdentity, got %v", err)
 	assert.False(t, errors.Is(err, ErrNotReady),
 		"a duplicate identity is a permanent graph error, not a soft not-ready")
+	assert.Contains(t, err.Error(), `nodes "cm1" and "cm2" both render v1/ConfigMap/default/shared`)
+
+	assert.Empty(t, res.Applied, "nothing may be recorded as applied when the collision is caught pre-walk")
+	assert.Zero(t, writes.n.Load(), "no apply/patch/create request may reach the cluster")
+
+	after := getSharedCM(t, cl)
+	assert.Equal(t, before.Object, after.Object, "the user's live object must be byte-identical")
+	data, _, _ := unstructured.NestedStringMap(after.Object, "data")
+	assert.Equal(t, "previous", data["from"])
+	assert.NotContains(t, after.GetLabels(), applyset.ApplysetPartOfLabel, "the user's object must not be adopted into the applyset")
+	assert.NotContains(t, after.GetLabels(), metadata.OwnedLabel)
+	assert.NotContains(t, after.GetLabels(), metadata.NodeIDLabel)
 }
 
 // TestApply_RejectsDuplicateIdentityWithinOneCollection pins finding 3901183693:
@@ -67,6 +165,7 @@ func TestApply_RejectsDuplicateIdentityBeforeWrite(t *testing.T) {
 // The forEach iterator appears in metadata.namespace (satisfying the compile-
 // time uniqueness guard), but the values "" and "default" both default to the
 // Graph namespace "default", so both rows resolve to ConfigMap default/shared.
+// (The Def-sourced axis is not resolvable pre-walk; the per-item claim catches it.)
 func TestApply_RejectsDuplicateIdentityWithinOneCollection(t *testing.T) {
 	t.Parallel()
 
@@ -86,6 +185,177 @@ func TestApply_RejectsDuplicateIdentityWithinOneCollection(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrDuplicateIdentity),
 		"two collection rows colliding on one identity must surface ErrDuplicateIdentity, got %v", err)
+}
+
+// TestApply_RejectsResolvableCollectionSelfCollisionBeforeWrite: with a literal
+// (pre-walk resolvable) axis, the same collision is caught by the pre-walk pass
+// before either row is written.
+func TestApply_RejectsResolvableCollectionSelfCollisionBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("cm", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "shared", "namespace": "${ns}"},
+			"data":     map[string]any{"k": "v"},
+		}, generator.ForEachDim("ns", "${['', 'default']}")),
+	)
+
+	writes := &writeCounter{}
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).WithInterceptorFuncs(writes.funcs()).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrDuplicateIdentity), "got %v", err)
+	assert.Contains(t, err.Error(), `node "cm" renders v1/ConfigMap/default/shared more than once`)
+	assert.Empty(t, res.Applied)
+	assert.Zero(t, writes.n.Load(), "neither row may be written")
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(configMapGVK)
+	err = cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "shared"}, got)
+	assert.True(t, apierrors.IsNotFound(err), "the object must not exist, got err=%v", err)
+}
+
+// TestApply_DynamicallyNamedDuplicateIsStillRejectedDuringWalk pins the
+// coverage limit of the pre-walk pass: cm2's name depends on cm1's published
+// output, so it is only claimed per item during the walk — after cm1 has been
+// applied — and the collision still rejects cm2 before its write.
+func TestApply_DynamicallyNamedDuplicateIsStillRejectedDuringWalk(t *testing.T) {
+	t.Parallel()
+
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("cm1", sharedCM("cm1")),
+		generator.WithTemplate("cm2", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "${cm1.metadata.name}"},
+			"data":     map[string]any{"from": "cm2"},
+		}),
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(previousSharedCM()).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrDuplicateIdentity), "got %v", err)
+	assert.Contains(t, err.Error(), `nodes "cm1" and "cm2" both render v1/ConfigMap/default/shared`)
+
+	// cm1 landed; cm2 was refused before its write.
+	require.Len(t, res.Applied, 1)
+	assert.Equal(t, "cm1", res.Applied[0].NodeID)
+	data, _, _ := unstructured.NestedStringMap(getSharedCM(t, cl).Object, "data")
+	assert.Equal(t, "cm1", data["from"], "cm2 must never overwrite the object")
+}
+
+// TestApply_WalkClaimCannotConsumeAnotherNodesReservation: a dynamically named
+// node reached before the static node that reserved the same identity is
+// refused (a reservation is only consumable by its owner), so the reserving
+// node still writes its object.
+func TestApply_WalkClaimCannotConsumeAnotherNodesReservation(t *testing.T) {
+	t.Parallel()
+
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("src", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "src"},
+			"data":     map[string]any{"target": "shared"},
+		}),
+		generator.WithTemplate("dyn", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "${src.data.target}"},
+			"data":     map[string]any{"from": "dyn"},
+		}),
+		generator.WithTemplate("static", sharedCM("static")),
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `nodes "static" and "dyn" both render v1/ConfigMap/default/shared`)
+	ids := make([]string, 0, len(res.Applied))
+	for _, mr := range res.Applied {
+		ids = append(ids, mr.NodeID)
+	}
+	assert.ElementsMatch(t, []string{"src", "static"}, ids)
+	data, _, _ := unstructured.NestedStringMap(getSharedCM(t, cl).Object, "data")
+	assert.Equal(t, "static", data["from"], "dyn must not write under static's reservation")
+}
+
+// TestApply_ChildFrameCollisionIsRejectedBeforeAnyChildWrite: a subgraph child
+// frame runs the pre-walk pass too, so two colliding child nodes are refused
+// before any child write while the parent's own node is unaffected.
+func TestApply_ChildFrameCollisionIsRejectedBeforeAnyChildWrite(t *testing.T) {
+	t.Parallel()
+
+	childCM := func(from string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "child-shared"},
+			"data":     map[string]any{"from": from},
+		}
+	}
+	child := generator.NewGraph("child",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("resA", childCM("sub/resA")),
+		generator.WithTemplate("resB", childCM("sub/resB")),
+	)
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("cm", sharedCM("cm")),
+		generator.WithSubgraph("sub", child),
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrDuplicateIdentity), "got %v", err)
+	assert.Contains(t, err.Error(), `nodes "sub/resA" and "sub/resB" both render v1/ConfigMap/default/child-shared`)
+
+	require.Len(t, res.Applied, 1, "only the parent's own node may have been applied")
+	assert.Equal(t, "cm", res.Applied[0].NodeID)
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(configMapGVK)
+	getErr := cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "child-shared"}, got)
+	assert.True(t, apierrors.IsNotFound(getErr), "neither child node may write, got err=%v", getErr)
+}
+
+// TestApply_ChildFrameCollisionWithParentIdentityIsRejected: a child node's
+// pre-walk reservation fails against an identity the parent frame already
+// claimed (shared claim set), so the child never writes.
+func TestApply_ChildFrameCollisionWithParentIdentityIsRejected(t *testing.T) {
+	t.Parallel()
+
+	child := generator.NewGraph("child",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("res", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			// Captured from the parent frame, so resolvable in the child's pre-pass.
+			"metadata": map[string]any{"name": "${cm.metadata.name}"},
+			"data":     map[string]any{"from": "sub/res"},
+		}),
+	)
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("cm", sharedCM("cm")),
+		generator.WithSubgraph("sub", child),
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrDuplicateIdentity), "got %v", err)
+	assert.Contains(t, err.Error(), `nodes "cm" and "sub/res" both render v1/ConfigMap/default/shared`)
+
+	require.Len(t, res.Applied, 1, "only the parent node may have been applied")
+	assert.Equal(t, "cm", res.Applied[0].NodeID)
+	data, _, _ := unstructured.NestedStringMap(getSharedCM(t, cl).Object, "data")
+	assert.Equal(t, "cm", data["from"], "the child node must never write")
 }
 
 // TestApply_AllowsDistinctIdentities confirms the guard does not false-positive
@@ -112,4 +382,165 @@ func TestApply_AllowsDistinctIdentities(t *testing.T) {
 
 	require.NoError(t, err, "distinct identities must not trip the duplicate guard")
 	assert.Len(t, res.Applied, 2, "both distinct objects apply")
+}
+
+// TestApply_WalkReclaimOfPreWalkReservationIsNotADuplicate: the walk's per-item
+// claim consumes the node's own pre-walk reservation (scalar and every
+// collection row) instead of reporting it as a duplicate.
+func TestApply_WalkReclaimOfPreWalkReservationIsNotADuplicate(t *testing.T) {
+	t.Parallel()
+
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("single", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "single"},
+			"data":     map[string]any{"k": "v"},
+		}),
+		generator.WithTemplate("many", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "many-${n}"},
+			"data":     map[string]any{"k": "v"},
+		}, generator.ForEachDim("n", "${['a', 'b', 'c']}")),
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.NoError(t, err, "a node re-claiming what it reserved pre-walk is not a duplicate")
+	assert.Len(t, res.Applied, 4)
+	for _, name := range []string{"single", "many-a", "many-b", "many-c"} {
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(configMapGVK)
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: name}, got), "missing %q", name)
+	}
+}
+
+// TestApply_ExcludedNodeReservesNoIdentity: an includeWhen:false node reserves
+// nothing, so a sibling rendering the same identity applies cleanly.
+func TestApply_ExcludedNodeReservesNoIdentity(t *testing.T) {
+	t.Parallel()
+
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithTemplate("off", sharedCM("off")),
+		generator.WithIncludeWhen("${false}"),
+		generator.WithTemplate("on", sharedCM("on")),
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.NoError(t, err)
+	require.Len(t, res.Applied, 1)
+	assert.Equal(t, "on", res.Applied[0].NodeID)
+	data, _, _ := unstructured.NestedStringMap(getSharedCM(t, cl).Object, "data")
+	assert.Equal(t, "on", data["from"])
+}
+
+// TestApply_UndecidableIncludeWhenReservesNoIdentity: a node whose includeWhen
+// is still data-pending before the walk (here on a Def not yet published)
+// reserves nothing, so two mutually exclusive writers of one identity are not
+// a false duplicate.
+func TestApply_UndecidableIncludeWhenReservesNoIdentity(t *testing.T) {
+	t.Parallel()
+
+	g := generator.NewGraph("g",
+		generator.WithNamespace("default"),
+		generator.WithDef("selector", map[string]any{"mode": "b"}),
+		generator.WithTemplate("modeA", sharedCM("modeA")),
+		generator.WithIncludeWhen("${selector.mode == 'a'}"),
+		generator.WithTemplate("modeB", sharedCM("modeB")),
+		generator.WithIncludeWhen("${selector.mode == 'b'}"),
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	res, err := NewSimple(cl).Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+
+	require.NoError(t, err, "mutually exclusive writers of one identity must not be reported as a duplicate")
+	require.Len(t, res.Applied, 1)
+	assert.Equal(t, "modeB", res.Applied[0].NodeID)
+	data, _, _ := unstructured.NestedStringMap(getSharedCM(t, cl).Object, "data")
+	assert.Equal(t, "modeB", data["from"])
+}
+
+// TestApply_SoftDepPlaceholderIsNotReserved pins the pre-walk pass's purity
+// gate. "summary" soft-references template "a" (WithSoftDependencies, as the RGD
+// adapter compiles its status node), so a is seeded {} before the walk; "b"
+// names itself from a via optional chaining (fallback against the placeholder,
+// "real" against a's published value) and "c" statically renders the fallback.
+// The pass must not reserve b's placeholder-derived identity, or b/c would be a
+// false duplicate. The Def-mediated row pins that purity is transitive.
+func TestApply_SoftDepPlaceholderIsNotReserved(t *testing.T) {
+	t.Parallel()
+
+	realCM := map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "a"},
+		"data":     map[string]any{"k": "real"},
+	}
+	namedCM := func(nameExpr string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": nameExpr},
+			"data":     map[string]any{"k": "v"},
+		}
+	}
+	cases := []struct {
+		name string
+		mid  []generator.GraphOption // the node(s) between a and c
+	}{
+		{
+			name: "identity optional-chains the soft-seeded template directly",
+			mid:  []generator.GraphOption{generator.WithTemplate("b", namedCM("${a.?data.k.orValue('fallback')}"))},
+		},
+		{
+			name: "identity reads a Def that optional-chains the soft-seeded template",
+			mid: []generator.GraphOption{
+				generator.WithDef("d", map[string]any{"name": "${a.?data.k.orValue('fallback')}"}),
+				generator.WithTemplate("b", namedCM("${d.name}")),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := []generator.GraphOption{
+				generator.WithNamespace("default"),
+				generator.WithTemplate("a", realCM),
+			}
+			opts = append(opts, tc.mid...)
+			opts = append(opts,
+				generator.WithTemplate("c", namedCM("fallback")),
+				generator.WithDef("summary", map[string]any{"aVal": "${a.data.k}"}),
+			)
+			rt := compileAndBuild(t, generator.NewGraph("g", opts...), compiler.WithSoftDependencies("summary"))
+			require.Equal(t, map[string]any{}, rt.Scope()["a"], "precondition: a is seeded as a soft-dependency placeholder")
+			// Seed Def nodes into scope exactly as both controllers do before Apply.
+			for _, n := range rt.Nodes() {
+				if n.Kind() != compiler.NodeKindDef {
+					continue
+				}
+				if desired, err := n.Resolve(); err == nil && len(desired) > 0 {
+					n.SetObserved(desired, desired)
+					rt.Set(n.ID(), desired[0].Object)
+				}
+			}
+
+			cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+			res, err := NewSimple(cl).Apply(context.Background(), rt, watchrouter.NoopWatcher{})
+
+			require.NoError(t, err, "a placeholder-derived identity must not be reserved against a node that really renders it")
+			ids := make([]string, 0, len(res.Applied))
+			for _, mr := range res.Applied {
+				ids = append(ids, mr.NodeID)
+			}
+			assert.ElementsMatch(t, []string{"a", "b", "c"}, ids)
+			for _, name := range []string{"a", "real", "fallback"} {
+				got := &unstructured.Unstructured{}
+				got.SetGroupVersionKind(configMapGVK)
+				require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: name}, got), "missing %q", name)
+			}
+		})
+	}
 }

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -99,17 +99,11 @@ type Simple struct {
 	// the node-path annotation — derives from this via qualifiedPath /
 	// nodeIDToken so all three agree by construction.
 	nodePrefix string
-	// identityClaims records which node has claimed each rendered object
-	// identity (GVK+namespace+name) during a single Apply walk, so a SECOND
-	// node rendering the same identity is refused BEFORE its SSA write instead
-	// of clobbering the first node's object (and, for the standalone-Graph
-	// path, before two same-Graph template managers force-reclaim each other's
-	// fields forever while the Graph reports Ready). It is created per top-level
-	// Apply and shared across subgraph child walks (applySubgraph copies the
-	// executor by value, carrying this pointer) so a collision between template
-	// nodes in different frames targeting one cluster object is caught too.
-	// Nil outside an Apply walk; the post-apply validateAppliedIdentities check
-	// remains as a backstop.
+	// identityClaims records which node owns each rendered object identity
+	// (GVK+namespace+name) during one Apply: reserved pre-walk (reserveIdentities)
+	// and claimed per item before each SSA write (prepareItem), so two nodes
+	// rendering one object never both write it. Created per top-level Apply and
+	// shared with subgraph child walks (applySubgraph copies the executor by value).
 	identityClaims *identityClaimSet
 	// OnToleratedRejection, when non-nil, is invoked for each collection item
 	// whose UPDATE was rejected on an already-existing object and tolerated
@@ -122,37 +116,69 @@ type Simple struct {
 	OnToleratedRejection func(ToleratedRejection)
 }
 
-// identityClaimSet is the per-Apply set of claimed object identities, guarded by
-// a mutex because collection items apply in parallel.
+// identityClaimSet is the per-Apply set of reserved/claimed object identities,
+// guarded by a mutex because collection items apply in parallel.
 type identityClaimSet struct {
-	mu    sync.Mutex
-	owner map[string]string // identity key -> qualified node ID that claimed it
+	mu     sync.Mutex
+	claims map[string]identityClaim // identity key -> owning node + phase
 }
 
-// claim records that qualifiedNodeID intends to write the object identified by
-// identityKey. It returns a non-nil error when that identity was ALREADY claimed
-// this walk — the caller turns that into a hard error before any write. Every
-// claim is fresh: the claim set is created once per top-level Apply (see Apply),
-// and a single walk visits each node exactly once, so a legitimate write never
-// re-claims an identity. A second claim therefore always means two rows collide
-// on one final object — whether from two different nodes, or from a SINGLE
-// collection node whose forEach produced two rows that resolve to the same
-// identity (e.g. namespaces "" and "default" defaulting to the same object).
-// Both are rejected: concurrent writes to one object let a nondeterministic
-// last-writer win while the node still reports success.
+// identityClaim is the frame-qualified path of the node owning an identity and
+// whether that node's walk has already claimed it (a pre-walk reservation
+// leaves claimed false; the owner's per-item claim flips it exactly once).
+type identityClaim struct {
+	owner   string
+	claimed bool
+}
+
+// duplicateError renders the hard ErrDuplicateIdentity naming the node that
+// holds identityKey and the node that tried to take it.
+func duplicateError(identityKey, owner, claimant string) error {
+	if owner == claimant {
+		return fmt.Errorf("%w: node %q renders %s more than once",
+			ErrDuplicateIdentity, claimant, identityKey)
+	}
+	return fmt.Errorf("%w: nodes %q and %q both render %s",
+		ErrDuplicateIdentity, owner, claimant, identityKey)
+}
+
+// reserve records, before the walk, that qualifiedNodeID intends to write
+// identityKey. Any prior entry — another node's or this node's own — is a
+// duplicate; nothing has been written yet, so the Apply fails with nothing applied.
+func (c *identityClaimSet) reserve(identityKey, qualifiedNodeID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.claims[identityKey]; ok {
+		return duplicateError(identityKey, existing.owner, qualifiedNodeID)
+	}
+	c.claims[identityKey] = identityClaim{owner: qualifiedNodeID}
+	return nil
+}
+
+// claim records, immediately before an SSA write, that qualifiedNodeID is about
+// to write identityKey. A reservation by the same node is consumed exactly once;
+// any other prior entry (another node, or a second row of this node) is a duplicate.
 func (c *identityClaimSet) claim(identityKey, qualifiedNodeID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if owner, ok := c.owner[identityKey]; ok {
-		if owner == qualifiedNodeID {
-			return fmt.Errorf("%w: node %q renders %s more than once",
-				ErrDuplicateIdentity, qualifiedNodeID, identityKey)
-		}
-		return fmt.Errorf("%w: nodes %q and %q both render %s",
-			ErrDuplicateIdentity, owner, qualifiedNodeID, identityKey)
+	existing, ok := c.claims[identityKey]
+	if !ok {
+		c.claims[identityKey] = identityClaim{owner: qualifiedNodeID, claimed: true}
+		return nil
 	}
-	c.owner[identityKey] = qualifiedNodeID
+	if existing.owner != qualifiedNodeID || existing.claimed {
+		return duplicateError(identityKey, existing.owner, qualifiedNodeID)
+	}
+	existing.claimed = true
+	c.claims[identityKey] = existing
 	return nil
+}
+
+// identityKeyOf is the claim-set key "<group/version>/<Kind>/<namespace>/<name>"
+// shared by reserve and claim; obj must already be namespace-defaulted.
+func identityKeyOf(obj *unstructured.Unstructured) string {
+	gvk := obj.GroupVersionKind()
+	return fmt.Sprintf("%s/%s/%s/%s", gvk.GroupVersion().String(), gvk.Kind, obj.GetNamespace(), obj.GetName())
 }
 
 // NewSimple constructs a Simple executor bound to the given client.
@@ -235,6 +261,10 @@ var _ Interface = (*Simple)(nil)
 // its own dependents cascade-block via the readiness map. Gating is opt-in
 // via GateReadiness; when it is off every reachable node is applied
 // regardless of upstream readiness.
+//
+// Before the walk, reserveIdentities rejects two nodes rendering the same
+// object with a hard ErrDuplicateIdentity before anything in this frame is
+// written; the per-item claim inside the walk covers nodes it could not resolve.
 func (s *Simple) Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.Watcher) (ApplyResult, error) {
 	// Establish the per-Apply identity-claim set at the top-level walk. A
 	// subgraph child walk (applySubgraph copies the executor by value) inherits
@@ -243,8 +273,15 @@ func (s *Simple) Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.W
 	// Apply creates it.
 	if s.identityClaims == nil {
 		child := *s
-		child.identityClaims = &identityClaimSet{owner: map[string]string{}}
+		child.identityClaims = &identityClaimSet{claims: map[string]identityClaim{}}
 		return child.Apply(ctx, rt, w)
+	}
+
+	// A collision among the nodes resolvable now is a permanent graph
+	// misconfiguration: fail the whole frame before any write. Runs per frame,
+	// so a child-frame collision aborts before any child write too.
+	if err := s.reserveIdentities(rt); err != nil {
+		return ApplyResult{}, err
 	}
 
 	var result ApplyResult
@@ -363,6 +400,59 @@ func (s *Simple) Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.W
 		return result, errors.Join(hardErrs...)
 	}
 	return result, firstSoft
+}
+
+// reserveIdentities renders every template node that is resolvable before the
+// walk, namespace-defaults each object as prepareItem will, and reserves its
+// identity; a collision is a hard ErrDuplicateIdentity before any write. Only
+// templates whose hard dependencies are, transitively, Def nodes are considered:
+// the runtime seeds soft-dependency targets with an empty object, so an optional
+// access like ${a.?data.k.orValue("x")} resolves against the placeholder to an
+// identity the walk never renders, and reserving it would false-positive. Nodes
+// skipped here (data-pending, unmappable, ignored) are claimed per item in the walk.
+func (s *Simple) reserveIdentities(rt *runtime.Runtime) error {
+	// pure: Def nodes whose hard deps are transitively Defs; rt.Nodes() is
+	// topological, so a dependency is decided before its dependents.
+	pure := make(map[string]bool, len(rt.Nodes()))
+	for _, n := range rt.Nodes() {
+		depsPure := true
+		for _, depID := range n.Spec().HardDepIDs() {
+			if !pure[depID] {
+				depsPure = false
+				break
+			}
+		}
+		if n.Kind() == compiler.NodeKindDef && depsPure {
+			pure[n.ID()] = true
+		}
+		if n.Kind() != compiler.NodeKindTemplate || !depsPure {
+			continue
+		}
+		if ignored, err := n.IsIgnored(); err != nil || ignored {
+			continue
+		}
+		desired, err := n.Resolve()
+		if err != nil {
+			continue
+		}
+		// Unmappable objects (e.g. dynamic-GVK CRD not installed) are not
+		// applied by the walk either; let it surface the condition.
+		mappings, err := s.buildMappings(n, desired)
+		if err != nil {
+			continue
+		}
+		owner := s.qualifiedPath(n.ID())
+		for i, obj := range desired {
+			s.defaultNamespace(rt, mappings[i].namespaced, obj)
+			if mappings[i].namespaced && obj.GetNamespace() == "" {
+				continue // prepareItem rejects this item as a hard error
+			}
+			if err := s.identityClaims.reserve(identityKeyOf(obj), owner); err != nil {
+				return fmt.Errorf("apply %q: %w", n.ID(), err)
+			}
+		}
+	}
+	return nil
 }
 
 func (s *Simple) applyNodeByKind(
@@ -653,16 +743,12 @@ func (s *Simple) prepareItem(rt *runtime.Runtime, n *runtime.Node, obj *unstruct
 		return fmt.Errorf("node %q: namespaced resource %s/%s must set metadata.namespace when the instance is cluster-scoped", n.ID(), obj.GetKind(), obj.GetName())
 	}
 	// Pre-write duplicate-identity guard: claim this object's identity BEFORE
-	// the SSA write. If another node already claimed it this walk, refuse now so
+	// the SSA write. If another node already holds it this walk, refuse now so
 	// the second node cannot clobber the first's object (RGD path) or force-
-	// reclaim its fields forever (standalone-Graph path). The identity key
-	// matches validateAppliedIdentities (apiVersion/kind/namespace/name); the
-	// owner is the frame-qualified node path so a legitimate re-claim by the same
-	// node is allowed while a cross-node collision is a hard error.
+	// reclaim its fields forever (standalone-Graph path). A reservation this
+	// node made in reserveIdentities is consumed here, not mistaken for a collision.
 	if s.identityClaims != nil {
-		gvk := obj.GroupVersionKind()
-		identityKey := fmt.Sprintf("%s/%s/%s/%s", gvk.GroupVersion().String(), gvk.Kind, obj.GetNamespace(), obj.GetName())
-		if err := s.identityClaims.claim(identityKey, s.qualifiedPath(n.ID())); err != nil {
+		if err := s.identityClaims.claim(identityKeyOf(obj), s.qualifiedPath(n.ID())); err != nil {
 			return err
 		}
 	}

--- a/pkg/graphengine/runtime/collection.go
+++ b/pkg/graphengine/runtime/collection.go
@@ -43,10 +43,11 @@ func identityKey(obj *unstructured.Unstructured) string {
 }
 
 // validateUniqueIdentities returns an error if any two objects in objs
-// share the same identityKey. Called after forEach expansion to catch
-// the case where the user's identity-field expressions don't actually
-// produce distinct names — otherwise SSA would reject the duplicates
-// with a confusing field-manager error.
+// share the same identityKey. Called after forEach expansion of a template
+// or patch collection to catch the case where the user's identity-field
+// expressions don't actually produce distinct identities — otherwise SSA
+// would reject duplicate templates with a confusing field-manager error,
+// and a duplicate patch would silently land on one target twice.
 func validateUniqueIdentities(objs []*unstructured.Unstructured) error {
 	seen := make(map[string]struct{}, len(objs))
 	for _, obj := range objs {

--- a/pkg/graphengine/runtime/helpers_test.go
+++ b/pkg/graphengine/runtime/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/compiler"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
 )
@@ -374,26 +375,51 @@ func TestIsIgnored_Memoized(t *testing.T) {
 }
 
 // TestResolve_DuplicateIdentities pins the post-expansion uniqueness guard:
-// a collection whose identity-field expressions collapse to the same name
-// across instances is rejected rather than handed to SSA.
+// a template or patch collection whose identity-field expressions collapse to
+// the same identity across rows is rejected rather than handed to SSA.
 func TestResolve_DuplicateIdentities(t *testing.T) {
 	t.Parallel()
-	g := generator.NewGraph("g",
-		// Two identical iterator values render the same metadata.name, so
-		// the rendered objects share an identity.
-		generator.WithDef("src", map[string]any{"names": []any{"dup", "dup"}}),
-		generator.WithTemplate("p", map[string]any{
-			"apiVersion": "v1", "kind": "ConfigMap",
-			"metadata": map[string]any{"name": "${'cm-' + n}"},
-			"data":     map[string]any{"k": "v"},
-		}, generator.ForEachDim("n", "${src.names}")),
-	)
-	prog := compileGraph(t, g)
-	rt := New(prog, g)
-	setFirst(rt, "src")
+	cases := []struct {
+		name string
+		node generator.GraphOption
+	}{
+		{
+			name: "template collection",
+			node: generator.WithTemplate("p", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${'cm-' + n}"},
+				"data":     map[string]any{"k": "v"},
+			}, generator.ForEachDim("n", "${src.names}")),
+		},
+		{
+			name: "patch collection",
+			node: func(g *expv1alpha1.Graph) {
+				generator.WithPatchManifest("p", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "${'cm-' + n}"},
+					"data":     map[string]any{"k": "v"},
+				})(g)
+				g.Spec.Nodes[len(g.Spec.Nodes)-1].ForEach = []expv1alpha1.ForEachDimension{{"n": "${src.names}"}}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := generator.NewGraph("g",
+				// Two identical iterator values render the same metadata.name, so
+				// the rendered objects share an identity.
+				generator.WithDef("src", map[string]any{"names": []any{"dup", "dup"}}),
+				tc.node,
+			)
+			prog := compileGraph(t, g)
+			rt := New(prog, g)
+			setFirst(rt, "src")
 
-	_, err := rt.Node("p").Resolve()
-	assert.ErrorContains(t, err, "duplicate identity")
+			_, err := rt.Node("p").Resolve()
+			assert.ErrorContains(t, err, "duplicate identity in collection")
+		})
+	}
 }
 
 // TestComputeIgnored_DepErrorPropagates pins the contagious-error branch:

--- a/pkg/graphengine/runtime/node.go
+++ b/pkg/graphengine/runtime/node.go
@@ -318,11 +318,12 @@ func (n *Node) Resolve() ([]*unstructured.Unstructured, error) {
 		}
 		out = append(out, obj)
 	}
-	// For template-kind collections, defend against the case where
-	// identity-field expressions silently produce duplicate names — kro
-	// catches it at compile time via iterator-coverage analysis, but
-	// runtime values can still collide if def-sourced values overlap.
-	if n.spec.Kind == compiler.NodeKindTemplate && n.IsCollection() {
+	// For template and patch collections, defend against the case where
+	// identity-field expressions silently produce duplicate identities — kro
+	// catches the structural case at compile time via iterator-coverage
+	// analysis, but overlapping axis values can still collide (a patch would
+	// then land on one target twice under one field manager).
+	if (n.spec.Kind == compiler.NodeKindTemplate || n.spec.Kind == compiler.NodeKindPatch) && n.IsCollection() {
 		if err := validateUniqueIdentities(out); err != nil {
 			metrics.NodeEvalErrorsTotal.Inc()
 			return nil, fmt.Errorf("node %q: %w", n.spec.ID, err)

--- a/test/integration/suites/core/duplicate_identity_test.go
+++ b/test/integration/suites/core/duplicate_identity_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/applyset"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+	"github.com/kubernetes-sigs/kro/test/integration/environment"
+)
+
+// Two resources of one RGD that render the same object identity are rejected
+// before any write: a pre-existing user object with that identity is neither
+// modified nor adopted, and survives the instance's deletion.
+var _ = Describe("Duplicate resource identity", func() {
+	var namespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		namespace = fmt.Sprintf("test-%s", rand.String(5))
+		Expect(env.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(env.Client.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})).To(Succeed())
+	})
+
+	It("rejects the instance before any write and never adopts or prunes the user's object", func(ctx SpecContext) {
+		const sharedName = "dup-shared"
+
+		By("pre-creating a user-owned ConfigMap with the identity both resources will render")
+		userCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: sharedName, Namespace: namespace},
+			Data:       map[string]string{"from": "previous"},
+		}
+		Expect(env.Client.Create(ctx, userCM)).To(Succeed())
+		pristine := &corev1.ConfigMap{}
+		Expect(env.Client.Get(ctx, types.NamespacedName{Name: sharedName, Namespace: namespace}, pristine)).To(Succeed())
+
+		By("creating an RGD whose two ConfigMap resources both render metadata.name=${schema.spec.name}")
+		sharedConfigMap := func(from string) map[string]any {
+			return map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": "${schema.spec.name}"},
+				"data":       map[string]any{"from": from},
+			}
+		}
+		rgd := generator.NewResourceGraphDefinition("test-dup-identity",
+			generator.WithSchema(
+				"TestDupIdentity", "v1alpha1",
+				map[string]any{"name": "string"},
+				nil,
+			),
+			generator.WithResource("cma", sharedConfigMap("cma"), nil, nil),
+			generator.WithResource("cmb", sharedConfigMap("cmb"), nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("creating an instance that names the pre-existing ConfigMap")
+		instance := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
+				"kind":       "TestDupIdentity",
+				"metadata":   map[string]any{"name": "dup-instance", "namespace": namespace},
+				"spec":       map[string]any{"name": sharedName},
+			},
+		}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+
+		By("waiting for the instance to report ERROR with the duplicate-identity message")
+		Eventually(func(g Gomega, ctx SpecContext) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: "dup-instance", Namespace: namespace}, instance)).To(Succeed())
+
+			state, found, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(state).To(Equal("ERROR"))
+
+			conditions, found, err := unstructured.NestedSlice(instance.Object, "status", "conditions")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			var resourcesReady map[string]any
+			for _, cond := range conditions {
+				if c, ok := cond.(map[string]any); ok && c["type"] == "ResourcesReady" {
+					resourcesReady = c
+					break
+				}
+			}
+			g.Expect(resourcesReady).ToNot(BeNil())
+			g.Expect(resourcesReady["status"]).To(Equal("False"))
+			g.Expect(resourcesReady["message"]).To(ContainSubstring("duplicate resource identity"))
+			g.Expect(resourcesReady["message"]).To(ContainSubstring(`"cma"`))
+			g.Expect(resourcesReady["message"]).To(ContainSubstring(`"cmb"`))
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("verifying the user's ConfigMap was never written, adopted, or labelled")
+		assertUntouched := func(g Gomega, ctx SpecContext) {
+			live := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: sharedName, Namespace: namespace}, live)).To(Succeed())
+			g.Expect(live.Data).To(HaveKeyWithValue("from", "previous"))
+			g.Expect(live.Labels).ToNot(HaveKey(applyset.ApplysetPartOfLabel))
+			g.Expect(live.Labels).ToNot(HaveKey(metadata.OwnedLabel))
+			g.Expect(live.Labels).ToNot(HaveKey(metadata.NodeIDLabel))
+			g.Expect(live.Labels).ToNot(HaveKey(metadata.InstanceLabel))
+			g.Expect(live.OwnerReferences).To(BeEmpty())
+			// No write at all: the resourceVersion is the one from creation.
+			g.Expect(live.ResourceVersion).To(Equal(pristine.ResourceVersion))
+		}
+		Consistently(assertUntouched, 3*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		By("deleting the ERROR instance and verifying the user's ConfigMap survives")
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		Eventually(func(g Gomega, ctx SpecContext) {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: "dup-instance", Namespace: namespace}, instance)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "instance should be gone, got err=%v", err)
+		}, 30*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+
+		Consistently(assertUntouched, 3*time.Second, 250*time.Millisecond).WithContext(ctx).Should(Succeed())
+	})
+})
+
+// A forEach iterator that varies only `kind` renders one distinct identity per
+// kind, so the Graph compiles and converges one ConfigMap and one Secret
+// sharing a fixed name.
+var _ = Describe("Graph heterogeneous-kind forEach", func() {
+	It("accepts an iterator that appears only in kind and converges one object per kind", func() {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+
+		g := &krov1alpha1.Graph{
+			ObjectMeta: metav1.ObjectMeta{Name: "hetero", Namespace: ns},
+			Spec: krov1alpha1.GraphSpec{
+				Nodes: []krov1alpha1.Node{
+					{
+						ID:  "kinds",
+						Def: environment.RawExt(t, map[string]any{"items": []string{"ConfigMap", "Secret"}}),
+					},
+					{
+						ID:      "res",
+						ForEach: []krov1alpha1.ForEachDimension{{"k": "${kinds.items}"}},
+						Template: environment.RawExt(t, map[string]any{
+							"apiVersion": "v1",
+							"kind":       "${k}",
+							// The name is FIXED: only the kind distinguishes the rows.
+							"metadata": map[string]any{"name": "hetero-shared"},
+						}),
+					},
+				},
+			},
+		}
+		env.CreateGraph(t, g)
+
+		env.AwaitCondition(t,
+			types.NamespacedName{Namespace: ns, Name: "hetero"},
+			krov1alpha1.GraphConditionTypeReady,
+			metav1.ConditionTrue, 20*time.Second)
+
+		environment.Eventually(t, 15*time.Second, 100*time.Millisecond, func() error {
+			ctx := env.Context()
+			cm := &corev1.ConfigMap{}
+			if err := env.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: "hetero-shared"}, cm); err != nil {
+				return fmt.Errorf("ConfigMap: %w", err)
+			}
+			sec := &corev1.Secret{}
+			if err := env.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: "hetero-shared"}, sec); err != nil {
+				return fmt.Errorf("Secret: %w", err)
+			}
+			for kind, labels := range map[string]map[string]string{"ConfigMap": cm.Labels, "Secret": sec.Labels} {
+				if labels[metadata.NodeIDLabel] != "res" {
+					return fmt.Errorf("%s: node-id label=%q want %q", kind, labels[metadata.NodeIDLabel], "res")
+				}
+			}
+			return nil
+		})
+
+		got := env.GetGraph(t, types.NamespacedName{Namespace: ns, Name: "hetero"})
+		kinds := make([]string, 0, len(got.Status.ManagedResources))
+		for _, mr := range got.Status.ManagedResources {
+			kinds = append(kinds, mr.Kind)
+		}
+		Expect(kinds).To(ConsistOf("ConfigMap", "Secret"), "one managed resource per rendered kind")
+	})
+})


### PR DESCRIPTION
## Problem

When two nodes of one graph render the same object (same GVK, namespace and name — e.g. two ConfigMap resources both named `${schema.spec.name}`), the executor only noticed when the second node was reached in the topological walk. By then the first node had already been server-side applied. On the RGD path that apply is forced under the shared field manager, so if a user-owned object with that name already existed it was adopted (applyset `part-of` label, `kro.run/owned`, data overwritten); the instance then went `ERROR`, and deleting it pruned the user's object. The pre-rewrite engine projected the whole desired set (`applyset.Project`) before applying anything, so nothing was written.

Two smaller gaps in the same area: a forEach `patch` node whose axis contains duplicate values (`${["a","a"]}`) reached `Ready=True` while patching one target twice and recording two identical contribution rows — the byte-identical `template` variant was rejected — and the compile-time iterator-coverage rule only counted `metadata.name`/`metadata.namespace`, so `forEach: [{k: ${["ConfigMap","Secret"]}}]` with `kind: ${k}` and a fixed name was rejected although every rendered identity is distinct.

## Fix

- `executor/simple.go`: `Simple.Apply` runs a pre-walk pass (`reserveIdentities`) at the top of every frame, root and subgraph child alike. It renders each template node that is resolvable before the walk, namespace-defaults the objects as `prepareItem` does, and reserves their identities in the per-Apply claim set; any collision returns the hard `ErrDuplicateIdentity` before anything is written, with `ApplyResult{}` empty. The claim set is two-phase: the walk's per-item claim consumes the node's own reservation once and rejects any other prior entry.
- `executor/simple.go`: the pass only considers templates whose hard dependencies are, transitively, Def nodes. The runtime seeds soft-dependency targets (templates the synthesized status node reads) with an empty object, so an identity field like `${a.?data.k.orValue("fallback")}` would otherwise resolve against the placeholder and reserve an identity the walk never renders, false-positiving against a node that really renders it. Pinned by `TestApply_SoftDepPlaceholderIsNotReserved`.
- `runtime/node.go`: `Resolve` runs `validateUniqueIdentities` for patch collections as well as template collections, so duplicate axis values fail with `duplicate identity in collection` before any write.
- `compiler/compiler.go`: `isIdentityFieldPath` counts `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` when the target is namespaced or the node is dynamic-GVK (scope unknown at compile time); the coverage error lists these fields. `omit()` is therefore also rejected in `apiVersion`/`kind`.

## Behaviour changes

- A graph with two resolvable nodes rendering the same object now fails the whole frame before any write: `ResourcesReady=False` / `resource reconciliation failed: apply "cmb": executor: duplicate resource identity across nodes: nodes "cma" and "cmb" both render v1/ConfigMap/<ns>/<name>`, nothing created, adopted or pruned. Because no node in the frame runs, the RGD's synthesized author-status patch node does not run that cycle either (controller-owned conditions and state are still written).
- A collision the pass cannot see — a node whose identity depends on another node's published output — is still caught only per item during the walk, so the first colliding node is applied (and a pre-existing object it names is adopted) before the second is refused, as before.
- Upgrade: an object adopted by an earlier duplicate-identity apply stays adopted; deleting that instance still prunes it. The fix prevents new adoptions, it cannot un-adopt.
- forEach patch collections with duplicate axis values now fail hard instead of converging while double-patching one target.
- Graphs/RGDs with a forEach iterator only in `kind`/`apiVersion`, or only in `metadata.namespace` on a dynamic-GVK node, now compile. The compile error for an uncovered iterator changed from `every forEach iterator must appear in metadata.name (or metadata.namespace for namespaced resources) …` to `every forEach iterator must appear in an identity field (apiVersion, kind, metadata.name, or metadata.namespace for namespaced (or dynamic-GVK) resources) …`; the two existing tests that pinned the old wording (`compiler_test.go`, `patch_test.go`) assert the new one.
