### PR TITLE
test(integration): add default-gates lane and restore deleted unit guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,28 +130,36 @@ go-generate: ## Run go generate against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# Ginkgo flags shared by both integration lanes; they differ only in the
+# feature gates enabled (KRO_INTEGRATION_FEATURE_GATES, see test/README.md).
+INTEGRATION_GINKGO_FLAGS = -p --timeout=8m --cover -coverpkg=github.com/kubernetes-sigs/kro/pkg/...
+
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests. Use WHAT=unit or WHAT=integration, pass extra args after --
+test: manifests generate fmt vet envtest ## Run tests. WHAT=unit|integration (alpha gates on)|integration-default-gates (production gate defaults)|upgrade; extra args after --
 ifeq ($(WHAT),integration)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-		go tool ginkgo -p \
-		--timeout=8m \
-		--cover \
+		go tool ginkgo $(INTEGRATION_GINKGO_FLAGS) \
 		--coverprofile=integration-cover.out \
-		-coverpkg=github.com/kubernetes-sigs/kro/pkg/... \
+		$(filter-out $@,$(MAKECMDGOALS)) \
+		./test/integration/suites/...
+else ifeq ($(WHAT),integration-default-gates)
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	KRO_INTEGRATION_FEATURE_GATES="" \
+		go tool ginkgo $(INTEGRATION_GINKGO_FLAGS) \
+		--coverprofile=integration-default-gates-cover.out \
 		$(filter-out $@,$(MAKECMDGOALS)) \
 		./test/integration/suites/...
 else ifeq ($(WHAT),unit)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-		go test -race ./pkg/... -coverprofile unit-cover.out $(filter-out $@,$(MAKECMDGOALS))
+		go test -race ./pkg/... ./test/integration/environment/... -coverprofile unit-cover.out $(filter-out $@,$(MAKECMDGOALS))
 else ifeq ($(WHAT),upgrade)
 	KRO_UPGRADE_FROM_VERSION=$(KRO_UPGRADE_FROM_VERSION) \
 	KRO_UPGRADE_MODE=$(MODE) \
 	KRO_UPGRADE_SKIP_GR_ASSERTIONS=$(KRO_UPGRADE_SKIP_GR_ASSERTIONS) \
 		go tool ginkgo -v $(filter-out $@,$(MAKECMDGOALS)) ./test/upgrade/...
 else
-	@echo "Error: WHAT must be either 'unit', 'integration', or 'upgrade'"
-	@echo "Usage: make test WHAT=unit|integration|upgrade"
+	@echo "Error: WHAT must be one of 'unit', 'integration', 'integration-default-gates', or 'upgrade'"
+	@echo "Usage: make test WHAT=unit|integration|integration-default-gates|upgrade"
 	@exit 1
 endif
 

--- a/pkg/graph/schema/field_descriptor_test.go
+++ b/pkg/graph/schema/field_descriptor_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestGenerateSchemaFromCELTypes_NestedFields(t *testing.T) {
+	result, err := GenerateSchemaFromCELTypes(map[string]*cel.Type{
+		"status.parent.child": cel.StringType,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	status, ok := result.Properties["status"]
+	require.True(t, ok)
+	assert.Equal(t, "object", status.Type)
+
+	parent, ok := status.Properties["parent"]
+	require.True(t, ok)
+	assert.Equal(t, "object", parent.Type)
+
+	child, ok := parent.Properties["child"]
+	require.True(t, ok)
+	assert.Equal(t, "string", child.Type)
+}
+
+func TestGenerateSchemaFromCELTypes_NestedArrayFields(t *testing.T) {
+	result, err := GenerateSchemaFromCELTypes(map[string]*cel.Type{
+		"status.parents[0].child": cel.StringType,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	status, ok := result.Properties["status"]
+	require.True(t, ok)
+
+	parents, ok := status.Properties["parents"]
+	require.True(t, ok)
+	require.Equal(t, "array", parents.Type)
+	require.NotNil(t, parents.Items)
+	require.NotNil(t, parents.Items.Schema)
+	assert.Equal(t, "object", parents.Items.Schema.Type)
+
+	child, ok := parents.Items.Schema.Properties["child"]
+	require.True(t, ok)
+	assert.Equal(t, "string", child.Type)
+}
+
+// A trailing index makes the leaf the array's items schema, not a property.
+func TestGenerateSchemaFromCELTypes_ArrayLeaf(t *testing.T) {
+	result, err := GenerateSchemaFromCELTypes(map[string]*cel.Type{
+		"status.names[0]": cel.StringType,
+	}, nil)
+	require.NoError(t, err)
+
+	names, ok := result.Properties["status"].Properties["names"]
+	require.True(t, ok)
+	require.Equal(t, "array", names.Type)
+	require.NotNil(t, names.Items)
+	require.NotNil(t, names.Items.Schema)
+	assert.Equal(t, &extv1.JSONSchemaProps{Type: "string"}, names.Items.Schema)
+	assert.Empty(t, names.Properties, "an array leaf must not also grow object properties")
+}
+
+func TestGenerateSchemaFromCELTypes_ComplexPath(t *testing.T) {
+	result, err := GenerateSchemaFromCELTypes(map[string]*cel.Type{
+		"status.parents[0].children[0].metadata.labels[0].key": cel.StringType,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	status, ok := result.Properties["status"]
+	require.True(t, ok)
+	assert.Equal(t, "object", status.Type)
+
+	parents, ok := status.Properties["parents"]
+	require.True(t, ok)
+	require.Equal(t, "array", parents.Type)
+	require.NotNil(t, parents.Items)
+	require.NotNil(t, parents.Items.Schema)
+
+	children, ok := parents.Items.Schema.Properties["children"]
+	require.True(t, ok)
+	require.Equal(t, "array", children.Type)
+	require.NotNil(t, children.Items)
+	require.NotNil(t, children.Items.Schema)
+
+	metadata, ok := children.Items.Schema.Properties["metadata"]
+	require.True(t, ok)
+	assert.Equal(t, "object", metadata.Type)
+
+	labels, ok := metadata.Properties["labels"]
+	require.True(t, ok)
+	require.Equal(t, "array", labels.Type)
+	require.NotNil(t, labels.Items)
+	require.NotNil(t, labels.Items.Schema)
+
+	key, ok := labels.Items.Schema.Properties["key"]
+	require.True(t, ok)
+	assert.Equal(t, "string", key.Type)
+}
+
+// Sibling fields under the same array index share one items schema.
+func TestGenerateSchemaFromCELTypes_SiblingArrayFieldsMerge(t *testing.T) {
+	result, err := GenerateSchemaFromCELTypes(map[string]*cel.Type{
+		"status.parents[0].name":     cel.StringType,
+		"status.parents[0].ready":    cel.BoolType,
+		"status.parents[0].replicas": cel.IntType,
+	}, nil)
+	require.NoError(t, err)
+
+	parents, ok := result.Properties["status"].Properties["parents"]
+	require.True(t, ok)
+	require.Equal(t, "array", parents.Type)
+	require.NotNil(t, parents.Items)
+	require.NotNil(t, parents.Items.Schema)
+
+	item := parents.Items.Schema
+	assert.Equal(t, "object", item.Type)
+	assert.Equal(t, map[string]extv1.JSONSchemaProps{
+		"name":     {Type: "string"},
+		"ready":    {Type: "boolean"},
+		"replicas": {Type: "integer"},
+	}, item.Properties)
+}

--- a/pkg/graphengine/rgdadapter/status_projection_test.go
+++ b/pkg/graphengine/rgdadapter/status_projection_test.go
@@ -110,3 +110,54 @@ func TestProjectInstanceConditions_DataPendingIsIncompleteNotAnError(t *testing.
 	assert.True(t, incomplete, "the caller needs to know a condition was skipped")
 	assert.Empty(t, conditions)
 }
+
+// One failing author condition is dropped and reported as degraded; the
+// well-formed sibling still surfaces.
+func TestProjectInstanceConditions_FatalErrorInOneExpressionSkippedNotAborted(t *testing.T) {
+	const good = "${runtime.newCondition({type: 'Good', status: 'True', reason: 'Fine', message: 'sibling survives'})}"
+
+	tests := []struct {
+		name        string
+		bad         string
+		wantInError string
+	}{
+		{
+			name:        "evaluation error is skipped, not aborted",
+			bad:         "${1 / 0}",
+			wantInError: "division by zero",
+		},
+		{
+			name:        "non-condition value is skipped, not aborted",
+			bad:         "${'not a condition'}",
+			wantInError: "must return a Condition or list(Condition)",
+		},
+		{
+			name:        "list of non-conditions is skipped, not aborted",
+			bad:         "${['still', 'not', 'conditions']}",
+			wantInError: "list element is not a Condition",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The bad expression comes first so the loop must continue past it.
+			rgd := buildRGDWithStatus(map[string]any{
+				"conditions": []any{tt.bad, good},
+			})
+			rt := compileAndSeedRuntime(t, rgd, projectionInstance(), nil)
+
+			conditions, incomplete, err := ProjectInstanceConditions(rt, rgd, nil, 0)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrConditionProjectionDegraded), "got %v", err)
+			assert.Contains(t, err.Error(), tt.wantInError)
+			assert.Contains(t, err.Error(), tt.bad, "the error must name the offending expression")
+			assert.True(t, incomplete)
+
+			require.Len(t, conditions, 1, "the well-formed sibling must survive")
+			assert.Equal(t, "Good", conditions[0].ConditionType)
+			assert.Equal(t, "True", conditions[0].Status)
+			assert.Equal(t, "Fine", conditions[0].Reason)
+			assert.Equal(t, "sibling survives", conditions[0].Message)
+		})
+	}
+}

--- a/scripts/ci/presubmits/integration-tests-default-gates
+++ b/scripts/ci/presubmits/integration-tests-default-gates
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Runs the envtest integration suites with kro's production feature-gate
+# defaults (every alpha gate off); see test/README.md.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
+
+# Build
+go build ./cmd/...
+
+make test WHAT=integration-default-gates

--- a/test/README.md
+++ b/test/README.md
@@ -58,6 +58,17 @@ controllers, you should:
 11. Repeat until all the RGD instances are created
 12. Do the same for updates and deletions
 
+### Feature-gate lanes
+
+The integration suites run in two lanes selected by the
+`KRO_INTEGRATION_FEATURE_GATES` environment variable (see
+`test/integration/environment/featuregates.go`). `make test WHAT=integration`
+leaves it unset and enables the alpha gates the suite has specs for
+(`CELOmitFunction=true,GraphKind=true`); `make test WHAT=integration-default-gates`
+exports it empty and runs with production defaults (every alpha gate off), so
+specs whose container is decorated with `requiresFeatureGate(features.X)` are
+skipped. Run both lanes; extra ginkgo arguments go after `--` in either.
+
 ## E2e tests
 
 E2E tests for kro should focus on validating the entire system's behavior in a

--- a/test/integration/environment/featuregates.go
+++ b/test/integration/environment/featuregates.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package environment
+
+import (
+	"os"
+	"strings"
+)
+
+// FeatureGatesEnv selects the kro feature gates an integration suite enables
+// before it starts the controller manager, in --feature-gates syntax
+// ("Name=bool,Name=bool"). Unset keeps the suite's own gate set; empty or
+// "none" enables nothing (a stock install's configuration); anything else is
+// passed verbatim to features.FeatureGate.Set.
+const FeatureGatesEnv = "KRO_INTEGRATION_FEATURE_GATES"
+
+// featureGatesNone spells out an empty FeatureGatesEnv for shells where an
+// empty exported variable is indistinguishable from an unset one.
+const featureGatesNone = "none"
+
+// FeatureGatesFromEnv resolves FeatureGatesEnv, returning fallback when the
+// variable is unset and "" when nothing should be enabled.
+func FeatureGatesFromEnv(fallback string) string {
+	value, set := os.LookupEnv(FeatureGatesEnv)
+	if !set {
+		return fallback
+	}
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, featureGatesNone) {
+		return ""
+	}
+	return value
+}

--- a/test/integration/environment/featuregates_test.go
+++ b/test/integration/environment/featuregates_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package environment
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeatureGatesFromEnv(t *testing.T) {
+	const fallback = "CELOmitFunction=true,GraphKind=true"
+
+	tests := []struct {
+		name  string
+		unset bool
+		value string
+		want  string
+	}{
+		{
+			name:  "unset keeps the suite's own gate set",
+			unset: true,
+			want:  fallback,
+		},
+		{
+			name: "exported empty enables nothing",
+			want: "",
+		},
+		{
+			name:  "whitespace-only is treated as empty",
+			value: "  ",
+			want:  "",
+		},
+		{
+			name:  "the literal none enables nothing",
+			value: "none",
+			want:  "",
+		},
+		{
+			name:  "none is matched case-insensitively",
+			value: "None",
+			want:  "",
+		},
+		{
+			name:  "an explicit spec is passed through verbatim",
+			value: "GraphKind=true",
+			want:  "GraphKind=true",
+		},
+		{
+			name:  "surrounding whitespace is trimmed from an explicit spec",
+			value: " CELOmitFunction=false,GraphKind=true ",
+			want:  "CELOmitFunction=false,GraphKind=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv registers the restore; Unsetenv then makes the variable absent.
+			t.Setenv(FeatureGatesEnv, tt.value)
+			if tt.unset {
+				require.NoError(t, os.Unsetenv(FeatureGatesEnv))
+			}
+			assert.Equal(t, tt.want, FeatureGatesFromEnv(fallback))
+		})
+	}
+}

--- a/test/integration/environment/graph_helpers.go
+++ b/test/integration/environment/graph_helpers.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -278,14 +278,11 @@ func (e *Environment) UpdateGraphSpec(t TestingT, key types.NamespacedName, muta
 	t.Fatalf("UpdateGraphSpec %s: gave up after 10 conflict retries", key)
 }
 
-// isConflictErr reports whether err is a 409 from the API server.
-// Kept inline (rather than depending on apimachinery's IsConflict)
-// because the import surface here is already busy.
+// isConflictErr reports whether err is a 409 Conflict from the API server. It
+// matches on the status reason, so every conflict shape is retried, not only
+// the optimistic-concurrency message text.
 func isConflictErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), "the object has been modified")
+	return apierrors.IsConflict(err)
 }
 
 // Eventually polls fn until it returns nil or the timeout fires. The

--- a/test/integration/environment/graph_helpers_test.go
+++ b/test/integration/environment/graph_helpers_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package environment
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsConflictErr(t *testing.T) {
+	graphs := schema.GroupResource{Group: "kro.run", Resource: "graphs"}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not a conflict",
+		},
+		{
+			name: "optimistic concurrency 409 from Update",
+			err:  apierrors.NewConflict(graphs, "g", errors.New("the object has been modified; please apply your changes to the latest version and try again")),
+			want: true,
+		},
+		{
+			name: "server-side apply field-manager 409",
+			err: apierrors.NewApplyConflict([]metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldManagerConflict,
+				Message: "conflict with \"other\"",
+				Field:   ".spec.nodes",
+			}}, "Apply failed with 1 conflict: conflict with \"other\": .spec.nodes"),
+			want: true,
+		},
+		{
+			name: "a non-409 API error is not retried",
+			err:  apierrors.NewNotFound(graphs, "g"),
+		},
+		{
+			name: "a plain error carrying the 409 message text is not an API conflict",
+			err:  errors.New("the object has been modified"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isConflictErr(tt.err))
+		})
+	}
+}

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -377,6 +377,8 @@ func (e *Environment) setupController() error {
 		return fmt.Errorf("setting up graph revision reconciler: %w", err)
 	}
 
+	// Gated like cmd/controller/main.go so a suite run with GraphKind off boots
+	// the stock component set; e.Router and e.SchemaWatcher stay nil then.
 	if features.FeatureGate.Enabled(features.GraphKind) {
 		router := watchrouter.NewRouter(
 			zap.New(zap.WriteTo(e.ControllerConfig.LogWriter), zap.UseDevMode(true)).WithName("graph-watch-router"),

--- a/test/integration/suites/core/graph_compilation_test.go
+++ b/test/integration/suites/core/graph_compilation_test.go
@@ -23,10 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Compilation", func() {
+var _ = Describe("Graph Compilation", requiresFeatureGate(features.GraphKind), func() {
 	It("exercises the Accepted condition for valid and invalid Graph specs", func() {
 		t := GinkgoT()
 		tests := []struct {

--- a/test/integration/suites/core/graph_contagious_test.go
+++ b/test/integration/suites/core/graph_contagious_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
@@ -33,7 +34,7 @@ import (
 // its downstream dependents: a child of an ignored node is itself ignored,
 // even if its own includeWhen evaluates true. Cases are layered to prove
 // transitivity end-to-end.
-var _ = Describe("Graph Contagious Ignore", func() {
+var _ = Describe("Graph Contagious Ignore", requiresFeatureGate(features.GraphKind), func() {
 	It("propagates includeWhen=false contagiously to downstream dependents", func() {
 		t := GinkgoT()
 		tests := []struct {

--- a/test/integration/suites/core/graph_deftypes_test.go
+++ b/test/integration/suites/core/graph_deftypes_test.go
@@ -23,13 +23,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
 // Exercises the def-schema inference path: the compiler synthesizes an
 // OpenAPI schema from the def literal, so a misspelled field on a downstream
 // CEL reference fails at compile time instead of at apply.
-var _ = Describe("Graph Def Type Inference", func() {
+var _ = Describe("Graph Def Type Inference", requiresFeatureGate(features.GraphKind), func() {
 	It("catches typos on def field references at compile time", func() {
 		t := GinkgoT()
 		tests := []struct {

--- a/test/integration/suites/core/graph_drift_test.go
+++ b/test/integration/suites/core/graph_drift_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
@@ -44,7 +45,7 @@ func getDriftRouterEnv(t environment.TestingT) *environment.Environment {
 	return testEnv
 }
 
-var _ = Describe("Graph Drift", func() {
+var _ = Describe("Graph Drift", requiresFeatureGate(features.GraphKind), func() {
 	It("recreates deleted child solely via watch event", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/graph_foreach_test.go
+++ b/test/integration/suites/core/graph_foreach_test.go
@@ -27,10 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph ForEach", func() {
+var _ = Describe("Graph ForEach", requiresFeatureGate(features.GraphKind), func() {
 	It("expands single-dimension forEach to per-item children", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/graph_multigraph_test.go
+++ b/test/integration/suites/core/graph_multigraph_test.go
@@ -25,10 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Multi-Graph Isolation", func() {
+var _ = Describe("Graph Multi-Graph Isolation", requiresFeatureGate(features.GraphKind), func() {
 	It("isolates independent graphs watching different resources of the same GVR", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/graph_nesting_collision_test.go
+++ b/test/integration/suites/core/graph_nesting_collision_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
@@ -44,7 +45,7 @@ import (
 // and, behaviorally, that each subgraph's drift watch is routed to ITS OWN
 // items and does not cross-match the sibling's (the watch selector is keyed on
 // the same token as the label).
-var _ = Describe("Graph Nesting NodeID Collision", func() {
+var _ = Describe("Graph Nesting NodeID Collision", requiresFeatureGate(features.GraphKind), func() {
 	subgraphNode := func(t environment.TestingT, id, cmName string) expv1alpha1.Node {
 		return expv1alpha1.Node{
 			ID: id,

--- a/test/integration/suites/core/graph_nesting_test.go
+++ b/test/integration/suites/core/graph_nesting_test.go
@@ -24,10 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Nesting", func() {
+var _ = Describe("Graph Nesting", requiresFeatureGate(features.GraphKind), func() {
 	It("captures parent def and applies child in nested subgraph", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/graph_patch_test.go
+++ b/test/integration/suites/core/graph_patch_test.go
@@ -26,10 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Patch", func() {
+var _ = Describe("Graph Patch", requiresFeatureGate(features.GraphKind), func() {
 	It("contributes fields to pre-existing resources and releases them on node removal", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/graph_readiness_test.go
+++ b/test/integration/suites/core/graph_readiness_test.go
@@ -25,10 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Readiness", func() {
+var _ = Describe("Graph Readiness", requiresFeatureGate(features.GraphKind), func() {
 	It("evaluates readyWhen conditions and sets Graph Ready status", func() {
 		t := GinkgoT()
 		tests := []struct {

--- a/test/integration/suites/core/graph_reconcile_test.go
+++ b/test/integration/suites/core/graph_reconcile_test.go
@@ -27,13 +27,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
 var configMapGVK = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 
-var _ = Describe("Graph Reconcile", func() {
+var _ = Describe("Graph Reconcile", requiresFeatureGate(features.GraphKind), func() {
 	It("applies, updates, and deletes resources cleanly with finalizer management", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/graph_refwatch_test.go
+++ b/test/integration/suites/core/graph_refwatch_test.go
@@ -25,10 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Ref Watch", func() {
+var _ = Describe("Graph Ref Watch", requiresFeatureGate(features.GraphKind), func() {
 	It("stays not-ready when external reference object is missing", func() {
 		t := GinkgoT()
 		tests := []struct {

--- a/test/integration/suites/core/graph_schemawatch_test.go
+++ b/test/integration/suites/core/graph_schemawatch_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
@@ -129,7 +130,7 @@ func lowerASCII(s string) string {
 	return string(out)
 }
 
-var _ = Describe("Graph Schema Watch", func() {
+var _ = Describe("Graph Schema Watch", requiresFeatureGate(features.GraphKind), func() {
 	It("indexes static dependencies in the schema watcher reverse index", func() {
 		t := GinkgoT()
 		testEnv := getSchemaWatchEnv(t)

--- a/test/integration/suites/core/graph_smoke_test.go
+++ b/test/integration/suites/core/graph_smoke_test.go
@@ -25,10 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Smoke", func() {
+var _ = Describe("Graph Smoke", requiresFeatureGate(features.GraphKind), func() {
 	It("boots and accepts a trivial Graph", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/graph_tracking_test.go
+++ b/test/integration/suites/core/graph_tracking_test.go
@@ -26,10 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
 )
 
-var _ = Describe("Graph Tracking", func() {
+var _ = Describe("Graph Tracking", requiresFeatureGate(features.GraphKind), func() {
 	It("records applied resources in status.ManagedResources", func() {
 		t := GinkgoT()
 		ns := env.CreateNamespace(t)

--- a/test/integration/suites/core/omit_test.go
+++ b/test/integration/suites/core/omit_test.go
@@ -28,10 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/features"
 	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
 )
 
-var _ = Describe("Omit", func() {
+var _ = Describe("Omit", requiresFeatureGate(features.CELOmitFunction), func() {
 	var namespace string
 
 	BeforeEach(func(ctx SpecContext) {

--- a/test/integration/suites/core/setup_test.go
+++ b/test/integration/suites/core/setup_test.go
@@ -17,12 +17,15 @@ package core_test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/component-base/featuregate"
 
 	ctrlinstance "github.com/kubernetes-sigs/kro/pkg/controller/instance"
 	"github.com/kubernetes-sigs/kro/pkg/features"
@@ -31,13 +34,45 @@ import (
 
 var env *environment.Environment
 
-func TestCore(t *testing.T) {
-	// Enable alpha feature gates for integration test coverage.
-	if err := features.FeatureGate.Set("CELOmitFunction=true"); err != nil {
-		t.Fatalf("failed to enable CELOmitFunction feature gate: %v", err)
+// fullFeatureGates is enabled when environment.FeatureGatesEnv is unset: the
+// alpha gates this suite has dedicated specs for.
+const fullFeatureGates = "CELOmitFunction=true,GraphKind=true"
+
+const featureGateLabelPrefix = "feature-gate:"
+
+// requiresFeatureGate labels a container whose specs need the given alpha gate;
+// the top-level BeforeEach below skips them when the gate is off.
+func requiresFeatureGate(gate featuregate.Feature) Labels {
+	return Label(featureGateLabelPrefix + string(gate))
+}
+
+// Skips gate-labelled specs whose gate is off. It must stay at the top level:
+// Ginkgo then runs neither the container's BeforeEach nor its AfterEach for a
+// skipped spec, so no fixtures are created or torn down.
+var _ = BeforeEach(func() {
+	for _, label := range CurrentSpecReport().Labels() {
+		name, ok := strings.CutPrefix(label, featureGateLabelPrefix)
+		if !ok {
+			continue
+		}
+		gate := featuregate.Feature(name)
+		if _, known := features.FeatureGate.GetAll()[gate]; !known {
+			Fail(fmt.Sprintf("spec is labelled with unknown feature gate %q", name))
+		}
+		if !features.FeatureGate.Enabled(gate) {
+			Skip(fmt.Sprintf("requires feature gate %s=true, which is off in this lane (%s=%q)",
+				name, environment.FeatureGatesEnv, os.Getenv(environment.FeatureGatesEnv)))
+		}
 	}
-	if err := features.FeatureGate.Set("GraphKind=true"); err != nil {
-		t.Fatalf("failed to enable GraphKind feature gate: %v", err)
+})
+
+func TestCore(t *testing.T) {
+	// Gates are process-global and consulted while the manager is wired, so
+	// they must be set before the suite boots (see environment.FeatureGatesEnv).
+	if gates := environment.FeatureGatesFromEnv(fullFeatureGates); gates != "" {
+		if err := features.FeatureGate.Set(gates); err != nil {
+			t.Fatalf("failed to enable feature gates %q: %v", gates, err)
+		}
 	}
 
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
## Problem

The envtest integration suite unconditionally enabled the alpha feature gates `CELOmitFunction` and `GraphKind` before booting, so `make test WHAT=integration` — the only integration lane CI runs — never exercised the configuration a stock kro install actually runs (both gates default off; the helm chart ships `featureGates: {}`). Anything that only happens with a gate off, such as the component set wired outside the `GraphKind` block or the `optional.none()` → `null` rendering path with `CELOmitFunction` off, had no coverage.

Two unit guards were also deleted in the engine rewrite without replacement: the status-schema tests for array-index paths (`status.parents[0].child` must yield `type: array` with an `items` schema, or the generated CRD rejects the list kro then writes), and the test that one failing author-condition expression is dropped and reported as degraded while its well-formed siblings still surface. The test helper `isConflictErr` also matched a 409 by message substring instead of by status reason.

## Fix

- `test/integration/environment/featuregates.go`: `KRO_INTEGRATION_FEATURE_GATES` selects the gates the core suite enables before it starts the manager (same `Name=bool,…` syntax as `--feature-gates`): unset keeps the suite's own set, empty or `none` enables nothing, anything else is passed through verbatim. `TestFeatureGatesFromEnv` pins the parsing.
- `test/integration/suites/core/setup_test.go`: `TestCore` reads the variable (unset behaves exactly as before: `CELOmitFunction=true,GraphKind=true`). `requiresFeatureGate(gate)` labels a container `feature-gate:<Name>`, and a top-level `BeforeEach` skips labelled specs whose gate is off and fails on an unknown gate name; because it is top-level, a skipped spec runs neither its container's `BeforeEach` nor its `AfterEach`.
- Gate labels on the 15 Graph-kind containers (`graph_*_test.go` except `graph_rgd_*`, which drive the engine directly and need no controller) and on the `Omit` container — 42 specs, every one of which creates a `Graph` object or templates `omit()`.
- `Makefile`: new `make test WHAT=integration-default-gates` runs the same suites with the variable exported empty and its own coverprofile; `WHAT=integration` is unchanged; `WHAT=unit` now also runs `./test/integration/environment/...`. `scripts/ci/presubmits/integration-tests-default-gates` mirrors `integration-tests`, and `test/README.md` documents the two lanes.
- `pkg/graph/schema/field_descriptor_test.go` (restored): `GenerateSchemaFromCELTypes` with indexed paths — nested array, deep mixed path, index as the leaf, and sibling fields merging into one items schema.
- `pkg/graphengine/rgdadapter/status_projection_test.go`: `TestProjectInstanceConditions_FatalErrorInOneExpressionSkippedNotAborted` drives an evaluation error, a scalar non-condition and a list of non-conditions through `ProjectInstanceConditions` ahead of a good condition, asserting `ErrConditionProjectionDegraded`, `incomplete=true` and the surviving condition.
- `test/integration/environment/graph_helpers.go`: `isConflictErr` is now `apierrors.IsConflict(err)`; `TestIsConflictErr` covers the Update and server-side-apply 409 shapes, a non-409 API error, and a plain error that merely carries the message text.

## Behaviour changes

- `make test WHAT=integration` runs the same specs with the same gates and skips none; spec names now carry `[feature-gate:…]` labels. `make test WHAT=unit` additionally runs the `test/integration/environment` package (no envtest, about a second).
- `make test WHAT=integration-default-gates` is red on today's `main`: 31 specs fail (a few fewer in some runs, since the trigger depends on discovery-cache timing), all with `rest mapping for …: no matches for kind …`, because with `GraphKind` off nothing resets the graph-engine compiler's REST mapper — the bug fixed in #8. With that fix applied on top, the lane is fully green. CI should run the new presubmit as non-blocking until #8 merges, then make it blocking.
- `isConflictErr`: an error that is not an API `Status` but whose text contains "the object has been modified" is no longer treated as a conflict; the controller-runtime client never produces such a value.
