### PR TITLE
fix(graph): surface status-write failures, cap inventories, project forEach patches

### DIFF
--- a/api/v1alpha1/graph_types.go
+++ b/api/v1alpha1/graph_types.go
@@ -51,14 +51,23 @@ type GraphSpec struct {
 	// of the Graph's namespace, confining resource access to that namespace by
 	// default.
 	//
+	// An explicit empty string is equivalent to omitting the field (templating
+	// tools such as Helm and Kustomize render an unset value as "").
+	//
 	// The kro controller ServiceAccount must be granted the "impersonate" verb
 	// on serviceaccounts for this to take effect.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	// +kubebuilder:validation:MaxLength=253
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
+
+// GraphInventoryMaxItems is the MaxItems cap on GraphStatus.ManagedResources and
+// GraphStatus.Contributions. The controller checks inventories against it before
+// a status write so an oversized inventory becomes a condition, not a rejection.
+// Markers cannot reference constants: keep the two MaxItems=5000 markers equal.
+const GraphInventoryMaxItems = 5000
 
 // GraphStatus defines the observed state of a Graph.
 type GraphStatus struct {
@@ -73,14 +82,9 @@ type GraphStatus struct {
 	// prune, it reflects the currently-applied set; on errors, it preserves
 	// the union of previously-known and newly-applied resources.
 	//
-	// MaxItems bounds the inventory so a runaway forEach expansion cannot push
-	// the Graph object past etcd's object-size limit (~1.5Mi) — which would fail
-	// the status write and, because teardown reads this list, jeopardize cleanup.
-	// The practical limiter is the per-node forEach cap
-	// (runtime.DefaultMaxCollectionSize, default 1000); this ceiling is set well
-	// above any realistic aggregate (each entry is a few short strings + a UID,
-	// so 5000 entries stays comfortably under the etcd limit even during the
-	// write-ahead phase, which transiently holds previous ∪ next).
+	// MaxItems keeps the Graph object within etcd's request-size limit; the value
+	// must equal GraphInventoryMaxItems. The cap counts entries, so unusually long
+	// names can still make a full list too large to write.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxItems=5000
@@ -111,7 +115,11 @@ type GraphStatus struct {
 	// RBAC-separable: a principal with only spec/metadata edit rights cannot
 	// forge the release inventory.
 	//
+	// MaxItems bounds the ledger for the same reason ManagedResources is bounded;
+	// the value must equal GraphInventoryMaxItems.
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxItems=5000
 	Contributions []Contribution `json:"contributions,omitempty"`
 }
 

--- a/api/v1alpha1/graph_types_test.go
+++ b/api/v1alpha1/graph_types_test.go
@@ -15,8 +15,13 @@
 package v1alpha1
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // serviceAccountNamePattern must stay in sync with the
@@ -24,8 +29,10 @@ import (
 // graph_types.go. The pattern is only enforced by the apiserver via the
 // generated CRD OpenAPI schema, so this test guards the regex contract that
 // the marker encodes: a Kubernetes ServiceAccount name is an RFC 1123
-// subdomain (dots allowed), not a bare RFC 1123 label.
-const serviceAccountNamePattern = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+// subdomain (dots allowed), not a bare RFC 1123 label — or the empty string,
+// which means the namespace default. TestGraphCRD_MarkersMatchConstants asserts
+// the generated CRD carries this exact pattern.
+const serviceAccountNamePattern = `^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 
 func TestGraphSpec_ServiceAccountNamePattern(t *testing.T) {
 	re := regexp.MustCompile(serviceAccountNamePattern)
@@ -42,13 +49,18 @@ func TestGraphSpec_ServiceAccountNamePattern(t *testing.T) {
 		// rejected by the old bare-label pattern.
 		{name: "dotted subdomain", value: "my.service.account", allowed: true},
 		{name: "dotted with hyphens", value: "my-app.team-a.example", allowed: true},
+		// Helm/Kustomize render an unset value as ""; it means the namespace default.
+		{name: "empty means namespace default", value: "", allowed: true},
 		{name: "leading uppercase rejected", value: "Bad_Name", allowed: false},
 		{name: "underscore rejected", value: "bad_name", allowed: false},
 		{name: "leading dot rejected", value: ".invalid", allowed: false},
 		{name: "trailing dot rejected", value: "invalid.", allowed: false},
 		{name: "double dot rejected", value: "a..b", allowed: false},
 		{name: "leading hyphen rejected", value: "-invalid", allowed: false},
-		{name: "empty rejected", value: "", allowed: false},
+		// The empty alternative must not loosen anything else.
+		{name: "single space rejected", value: " ", allowed: false},
+		{name: "lone dot rejected", value: ".", allowed: false},
+		{name: "lone hyphen rejected", value: "-", allowed: false},
 	}
 
 	for _, tt := range tests {
@@ -58,5 +70,58 @@ func TestGraphSpec_ServiceAccountNamePattern(t *testing.T) {
 				t.Errorf("pattern.MatchString(%q) = %v, want %v", tt.value, got, tt.allowed)
 			}
 		})
+	}
+}
+
+// TestGraphCRD_MarkersMatchConstants pins the generated CRD
+// (helm/crds/kro.run_graphs.yaml) to this package: the two MaxItems markers must
+// equal GraphInventoryMaxItems (markers cannot reference constants) and the
+// serviceAccountName pattern must be the one the regex test exercises. Run with
+// `go test ./api/...`; `make test WHAT=unit` covers ./pkg/... only.
+func TestGraphCRD_MarkersMatchConstants(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "helm", "crds", "kro.run_graphs.yaml"))
+	if err != nil {
+		t.Fatalf("read generated Graph CRD: %v", err)
+	}
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := yaml.Unmarshal(raw, &crd); err != nil {
+		t.Fatalf("unmarshal Graph CRD: %v", err)
+	}
+	if len(crd.Spec.Versions) != 1 || crd.Spec.Versions[0].Schema == nil || crd.Spec.Versions[0].Schema.OpenAPIV3Schema == nil {
+		t.Fatalf("Graph CRD: want exactly one served version with an OpenAPI v3 schema, got %d versions", len(crd.Spec.Versions))
+	}
+	root := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+
+	status, ok := root.Properties["status"]
+	if !ok {
+		t.Fatalf("Graph CRD schema has no status property")
+	}
+	for _, field := range []string{"managedResources", "contributions"} {
+		prop, ok := status.Properties[field]
+		if !ok {
+			t.Errorf("status.%s: missing from the CRD schema", field)
+			continue
+		}
+		if prop.MaxItems == nil {
+			t.Errorf("status.%s: no maxItems in the CRD; the +kubebuilder:validation:MaxItems marker is missing", field)
+			continue
+		}
+		if *prop.MaxItems != GraphInventoryMaxItems {
+			t.Errorf("status.%s: CRD maxItems=%d but GraphInventoryMaxItems=%d; the marker and the constant must agree",
+				field, *prop.MaxItems, GraphInventoryMaxItems)
+		}
+	}
+
+	spec, ok := root.Properties["spec"]
+	if !ok {
+		t.Fatalf("Graph CRD schema has no spec property")
+	}
+	sa, ok := spec.Properties["serviceAccountName"]
+	if !ok {
+		t.Fatalf("spec.serviceAccountName: missing from the CRD schema")
+	}
+	if sa.Pattern != serviceAccountNamePattern {
+		t.Errorf("spec.serviceAccountName: CRD pattern %q differs from the pattern this test exercises %q",
+			sa.Pattern, serviceAccountNamePattern)
 	}
 }

--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -402,6 +402,9 @@ A Graph object exposes three standard conditions managed by the controller:
   - Status `False` with reason `WaitingForReadiness` when apply succeeded but `readyWhen` expressions evaluate false.
   - Status `False` with reason `DataPending` when a node's CEL expression references data the cluster has not surfaced yet (e.g. pending status fields).
   - Status `False` with reason `ApplyFailed` when the executor encounters a hard error applying resources.
+  - Status `False` with reason `WriteAheadFailed` when the pre-apply inventory write was refused; nothing was applied.
+  - Status `False` with reason `StatusWriteFailed` when the apply was clean but the post-apply contribution ledger could not be persisted.
+  - Status `False` with reason `InventoryTooLarge` when a status inventory would exceed the CRD's `maxItems` cap (5000); the controller fails closed.
 - **`Ready`** (`kro.run/v1alpha1` `GraphConditionTypeReady`): Root aggregate condition rolled up from `Accepted` and `ResourcesConverged`.
   - Status `True` when both `Accepted` and `ResourcesConverged` are `True`.
   - Status `False` when either condition is `False`.
@@ -415,6 +418,9 @@ A Graph object exposes three standard conditions managed by the controller:
 | `ResourcesConverged` | False   | `WaitingForReadiness`| Applied, but readyWhen conditions not yet met|
 | `ResourcesConverged` | False   | `DataPending`        | Waiting for upstream cluster data in scope   |
 | `ResourcesConverged` | False   | `ApplyFailed`        | Hard failure during resource apply           |
+| `ResourcesConverged` | False   | `WriteAheadFailed`   | Pre-apply inventory write refused; nothing applied |
+| `ResourcesConverged` | False   | `StatusWriteFailed`  | Post-apply contribution ledger write refused |
+| `ResourcesConverged` | False   | `InventoryTooLarge`  | Inventory exceeds the status `maxItems` cap; failed closed |
 | `Ready`              | True    | `Ready`              | All dependent conditions True (graph ready)  |
 | `Ready`              | False   | _(from dependent)_   | Spec invalid or apply failed                 |
 | `Ready`              | Unknown | _(from dependent)_   | Still reconciling or waiting on readiness    |
@@ -436,8 +442,8 @@ ServiceAccount resolved in the Graph's **own namespace**
 
 - `spec.serviceAccountName`, when set, selects which ServiceAccount in the Graph's namespace to
   impersonate.
-- When unset, kro impersonates that namespace's `default` ServiceAccount, confining resource access
-  to the namespace by default.
+- When unset (omitted or an explicit `""`), kro impersonates that namespace's `default`
+  ServiceAccount, confining resource access to the namespace by default.
 - The ServiceAccount is **always** resolved in the Graph's own namespace, so a Graph can never
   escalate beyond the RBAC granted to a ServiceAccount a caller in that namespace could already use.
   A Graph author cannot name a ServiceAccount in another namespace.

--- a/helm/crds/kro.run_graphs.yaml
+++ b/helm/crds/kro.run_graphs.yaml
@@ -231,10 +231,13 @@ spec:
                   of the Graph's namespace, confining resource access to that namespace by
                   default.
 
+                  An explicit empty string is equivalent to omitting the field (templating
+                  tools such as Helm and Kustomize render an unset value as "").
+
                   The kro controller ServiceAccount must be granted the "impersonate" verb
                   on serviceaccounts for this to take effect.
                 maxLength: 253
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
             required:
             - nodes
@@ -311,6 +314,9 @@ spec:
                   Persisted on the status subresource (not a metadata annotation) so it is
                   RBAC-separable: a principal with only spec/metadata edit rights cannot
                   forge the release inventory.
+
+                  MaxItems bounds the ledger for the same reason ManagedResources is bounded;
+                  the value must equal GraphInventoryMaxItems.
                 items:
                   description: |-
                     Contribution is a lightweight record of a patch node's field-manager
@@ -353,6 +359,7 @@ spec:
                   - kind
                   - name
                   type: object
+                maxItems: 5000
                 type: array
               managedResources:
                 description: |-
@@ -363,14 +370,9 @@ spec:
                   prune, it reflects the currently-applied set; on errors, it preserves
                   the union of previously-known and newly-applied resources.
 
-                  MaxItems bounds the inventory so a runaway forEach expansion cannot push
-                  the Graph object past etcd's object-size limit (~1.5Mi) — which would fail
-                  the status write and, because teardown reads this list, jeopardize cleanup.
-                  The practical limiter is the per-node forEach cap
-                  (runtime.DefaultMaxCollectionSize, default 1000); this ceiling is set well
-                  above any realistic aggregate (each entry is a few short strings + a UID,
-                  so 5000 entries stays comfortably under the etcd limit even during the
-                  write-ahead phase, which transiently holds previous ∪ next).
+                  MaxItems keeps the Graph object within etcd's request-size limit; the value
+                  must equal GraphInventoryMaxItems. The cap counts entries, so unusually long
+                  names can still make a full list too large to write.
                 items:
                   description: |-
                     ManagedResource is a lightweight pointer to a cluster resource the Graph

--- a/pkg/controller/graph/controller.go
+++ b/pkg/controller/graph/controller.go
@@ -197,6 +197,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // no-op: Release GETs the target first and treats absent as already-released).
 // Each side only writes when its union grows, so a steady state does not rewrite
 // status every cycle.
+//
+// Both inventories are checked against the MaxItems cap before anything is
+// written or applied, and a refused write leaves g.Status.ManagedResources at
+// what the server holds, so the caller's condition write is not refused too.
 func (r *Reconciler) writeAheadIntent(
 	ctx context.Context,
 	g *expv1alpha1.Graph,
@@ -205,14 +209,24 @@ func (r *Reconciler) writeAheadIntent(
 	priorContribs []executor.Contribution,
 ) ([]expv1alpha1.ManagedResource, error) {
 	intent := unionManagedResources(previous, intendedManagedResources(rt))
+	intentContribs := UnionContributions(priorContribs, intendedContributions(rt))
+
+	// Fail closed: a Graph whose inventory cannot be persisted must not be
+	// applied — an untracked resource is one teardown can never delete.
+	if err := checkInventoryCaps(len(intent), len(intentContribs)); err != nil {
+		return nil, err
+	}
+
 	if len(intent) > len(previous) {
 		g.Status.ManagedResources = intent
 		if err := r.persistManagedResources(ctx, g); err != nil {
+			// The server still holds previous; do not let updateStatus re-send
+			// the list that was just refused.
+			g.Status.ManagedResources = previous
 			return nil, fmt.Errorf("write-ahead managed-resource intent: %w", err)
 		}
 	}
 
-	intentContribs := UnionContributions(priorContribs, intendedContributions(rt))
 	if len(intentContribs) > len(priorContribs) {
 		if err := r.persistContributions(ctx, g, intentContribs); err != nil {
 			return nil, fmt.Errorf("write-ahead patch-contribution intent: %w", err)
@@ -346,6 +360,15 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 	// the inventory from shrinking below the pre-apply superset.
 	intent, err := r.writeAheadIntent(ctx, g, rt, previous, priorContribs)
 	if err != nil {
+		// Nothing was applied; say why, or a fresh Graph is left with no status
+		// at all (writeAheadIntent left the inventory at what the server holds,
+		// so this condition write is not refused for the same reason).
+		var tooLarge *inventoryTooLargeError
+		if errors.As(err, &tooLarge) {
+			marker.ResourcesInventoryTooLarge("refusing to apply: " + err.Error())
+		} else {
+			marker.ResourcesWriteAheadFailed(err.Error())
+		}
 		return err
 	}
 
@@ -407,6 +430,24 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 	superset := func() []expv1alpha1.ManagedResource {
 		return unionManagedResources(unionManagedResources(previous, result.Applied), intent)
 	}
+
+	// The ledger the write-ahead persisted plus what the executor observed. The
+	// error branches must persist this, not prior ∪ observed: a soft not-ready
+	// cycle observes fewer rows than intended, and shrinking the ledger back each
+	// cycle is a second status write per reconcile that re-enqueues the Graph.
+	ledgerUnion := UnionContributions(fromAPIContributions(g.Status.Contributions), result.Contributions)
+
+	// Post-apply cap check: the executor can apply identities the projection could
+	// not see (a forEach axis fed by upstream status, a dynamic GVK). Everything
+	// persisted below is a subset of superset() or ledgerUnion. Fail closed: keep
+	// the write-ahead union (with observed UIDs, so it stays deletable) and skip
+	// prune/release, whose bookkeeping could not be recorded either.
+	if err := checkInventoryCaps(len(superset()), len(ledgerUnion)); err != nil {
+		marker.ResourcesInventoryTooLarge("applied resources exceed the trackable inventory: " + err.Error())
+		g.Status.ManagedResources = adoptUIDs(intent, result.Applied)
+		return joinHardApplyErr(err, applyErr, hardErr)
+	}
+
 	if !hardErr {
 		if len(pruneCandidates) > 0 {
 			if err := ex.Delete(ctx, pruneCandidates); err != nil {
@@ -458,7 +499,7 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 	if applyErr != nil {
 		// Soft or hard failure — keep the union so a future reconcile can
 		// release contributions we couldn't observe cleanly this cycle.
-		if err := r.persistContributions(ctx, g, UnionContributions(priorContribs, result.Contributions)); err != nil {
+		if err := r.persistContributions(ctx, g, ledgerUnion); err != nil {
 			return errors.Join(fmt.Errorf("apply: %w", applyErr), err)
 		}
 		if !errors.Is(applyErr, executor.ErrNotReady) {
@@ -480,16 +521,30 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 			// Ready=True with the error only in the log (symmetric with the
 			// prune-failure branch).
 			marker.ResourcesReleaseFailed(err.Error())
-			if perr := r.persistContributions(ctx, g, UnionContributions(priorContribs, result.Contributions)); perr != nil {
+			if perr := r.persistContributions(ctx, g, ledgerUnion); perr != nil {
 				return errors.Join(fmt.Errorf("release contributions: %w", err), perr)
 			}
 			return fmt.Errorf("release contributions: %w", err)
 		}
 	}
 	if err := r.persistContributions(ctx, g, result.Contributions); err != nil {
-		return err
+		// Apply was clean but the release ledger did not land: the contributed
+		// fields have nothing recorded to release them from, so the Graph has not
+		// converged (symmetric with the prune- and release-failure branches).
+		marker.ResourcesInventoryPersistFailed(err.Error())
+		return fmt.Errorf("persist contributions: %w", err)
 	}
 	return nil
+}
+
+// joinHardApplyErr keeps a hard apply error visible alongside the cap error. A
+// soft ErrNotReady is not joined: it would reclassify the cycle as a benign
+// requeue and hide the cap refusal.
+func joinHardApplyErr(capErr, applyErr error, hard bool) error {
+	if hard {
+		return errors.Join(capErr, applyErr)
+	}
+	return capErr
 }
 
 // persistContributions writes the patch-contribution release inventory onto
@@ -702,6 +757,10 @@ func (r *Reconciler) setUnmanaged(ctx context.Context, g *expv1alpha1.Graph) err
 //
 // The DeepEqual short-circuit avoids no-op writes, which keeps the
 // generation churn down and prevents needless re-reconciles.
+//
+// Conditions and ManagedResources travel in one patch, so reconcileGraph keeps
+// g.Status.ManagedResources under the MaxItems cap on every return path — a
+// refused inventory would take the conditions down with it.
 func (r *Reconciler) updateStatus(ctx context.Context, g *expv1alpha1.Graph) error {
 	logger := log.FromContext(ctx)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -889,4 +948,25 @@ func (m *ConditionsMarker) ResourcesReleaseFailed(msg string) {
 // to why deletion is blocked; recording it lets an operator see the cause.
 func (m *ConditionsMarker) ResourcesDeleteFailed(msg string) {
 	m.cs.SetFalse(ResourcesConverged, "DeleteFailed", msg)
+}
+
+// ResourcesWriteAheadFailed marks ResourcesConverged=False with reason
+// "WriteAheadFailed" when the pre-apply inventory write was refused, so the
+// executor was not run this cycle.
+func (m *ConditionsMarker) ResourcesWriteAheadFailed(msg string) {
+	m.cs.SetFalse(ResourcesConverged, "WriteAheadFailed", msg)
+}
+
+// ResourcesInventoryPersistFailed marks ResourcesConverged=False with reason
+// "StatusWriteFailed" when the apply was clean but the post-apply contribution
+// ledger could not be persisted, leaving contributed fields with no release entry.
+func (m *ConditionsMarker) ResourcesInventoryPersistFailed(msg string) {
+	m.cs.SetFalse(ResourcesConverged, "StatusWriteFailed", msg)
+}
+
+// ResourcesInventoryTooLarge marks ResourcesConverged=False with reason
+// "InventoryTooLarge" when a status inventory would exceed the CRD's MaxItems
+// cap; the reconciler fails closed rather than let the apiserver refuse the write.
+func (m *ConditionsMarker) ResourcesInventoryTooLarge(msg string) {
+	m.cs.SetFalse(ResourcesConverged, "InventoryTooLarge", msg)
 }

--- a/pkg/controller/graph/controller_test.go
+++ b/pkg/controller/graph/controller_test.go
@@ -51,6 +51,7 @@ import (
 type fakeExecutor struct {
 	applyErr     error
 	applyResult  executor.ApplyResult
+	applyCalls   int // counts Apply invocations so fail-closed paths can assert none happened
 	deleteErr    error
 	deleteCalls  [][]expv1alpha1.ManagedResource // captures every Delete invocation in order
 	releaseErr   error
@@ -58,6 +59,7 @@ type fakeExecutor struct {
 }
 
 func (f *fakeExecutor) Apply(context.Context, *krotruntime.Runtime, watchrouter.Watcher) (executor.ApplyResult, error) {
+	f.applyCalls++
 	return f.applyResult, f.applyErr
 }
 func (f *fakeExecutor) Delete(_ context.Context, resources []expv1alpha1.ManagedResource) error {

--- a/pkg/controller/graph/reconcile_findings_test.go
+++ b/pkg/controller/graph/reconcile_findings_test.go
@@ -15,6 +15,7 @@
 package graph
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -22,9 +23,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	memory "k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,7 +39,9 @@ import (
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/executor"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/registry"
 	krotruntime "github.com/kubernetes-sigs/kro/pkg/graphengine/runtime"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/watchrouter"
+	testk8s "github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
 )
 
 // templateProgram builds a minimal compiled Program with a single static
@@ -74,23 +82,25 @@ func emptyNodeProgram(nodeID string) *compiler.Program {
 	}
 }
 
-// applyObservingExecutor records the ManagedResources PERSISTED on the API
-// server at the moment Apply is entered, by reading them back through a
-// captured client. This is what lets a test assert the pre-apply write-ahead
-// (Finding A) landed on the server before any resource was applied.
+// applyObservingExecutor records the ManagedResources and Contributions
+// persisted on the API server at the moment Apply is entered, so a test can
+// assert the write-ahead landed before any resource was applied.
 type applyObservingExecutor struct {
 	fakeExecutor
 	cl  client.Client
 	key types.NamespacedName
 	// persistedAtApply is the server-side inventory observed when Apply ran.
 	persistedAtApply []expv1alpha1.ManagedResource
-	observed         bool
+	// contribsAtApply is the server-side ledger observed when Apply ran.
+	contribsAtApply []expv1alpha1.Contribution
+	observed        bool
 }
 
 func (e *applyObservingExecutor) Apply(ctx context.Context, rt *krotruntime.Runtime, w watchrouter.Watcher) (executor.ApplyResult, error) {
 	got := &expv1alpha1.Graph{}
 	if err := e.cl.Get(ctx, e.key, got); err == nil {
 		e.persistedAtApply = got.Status.ManagedResources
+		e.contribsAtApply = got.Status.Contributions
 		e.observed = true
 	}
 	return e.fakeExecutor.Apply(ctx, rt, w)
@@ -595,4 +605,483 @@ func TestReconcile_ErrorPathKeepsIntentSuperset(t *testing.T) {
 		"intent superset must survive a soft-error cycle in persisted status")
 	assert.Equal(t, "Widget", got.Status.ManagedResources[0].Kind)
 	assert.Equal(t, "w", got.Status.ManagedResources[0].Name)
+}
+
+// statusPatchGate wraps a client and refuses every Status().Patch whose merge
+// body touches the named status field, letting all other status writes through
+// (an apiserver that rejects one inventory write but accepts the conditions).
+type statusPatchGate struct {
+	client.Client
+	field    string
+	err      error
+	rejected int // number of status patches refused
+}
+
+func (c *statusPatchGate) Status() client.StatusWriter {
+	return &gatedStatusWriter{StatusWriter: c.Client.Status(), gate: c}
+}
+
+type gatedStatusWriter struct {
+	client.StatusWriter
+	gate *statusPatchGate
+}
+
+func (w *gatedStatusWriter) Patch(ctx context.Context, obj client.Object, p client.Patch, opts ...client.SubResourcePatchOption) error {
+	data, err := p.Data(obj)
+	if err != nil {
+		return err
+	}
+	if bytes.Contains(data, []byte(`"`+w.gate.field+`"`)) {
+		w.gate.rejected++
+		return w.gate.err
+	}
+	return w.StatusWriter.Patch(ctx, obj, p, opts...)
+}
+
+// manyManagedResources fabricates n distinct, UID-bearing ManagedResource entries.
+func manyManagedResources(nodeID string, n int) []expv1alpha1.ManagedResource {
+	out := make([]expv1alpha1.ManagedResource, 0, n)
+	for i := range n {
+		out = append(out, expv1alpha1.ManagedResource{
+			NodeID:     nodeID,
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Namespace:  "default",
+			Name:       fmt.Sprintf("cm-%d", i),
+			UID:        fmt.Sprintf("uid-%d", i),
+		})
+	}
+	return out
+}
+
+// manyContributions fabricates n distinct ledger rows under one field manager.
+func manyContributions(fieldManager string, n int) []executor.Contribution {
+	out := make([]executor.Contribution, 0, n)
+	for i := range n {
+		out = append(out, executor.Contribution{
+			APIVersion:   "v1",
+			Kind:         "ConfigMap",
+			Namespace:    "default",
+			Name:         fmt.Sprintf("target-%d", i),
+			FieldManager: fieldManager,
+		})
+	}
+	return out
+}
+
+// requireConverged asserts the ResourcesConverged condition on g has the given
+// status and reason, and that the Ready root followed it.
+func requireConverged(t *testing.T, g *expv1alpha1.Graph, status metav1.ConditionStatus, reason string) *expv1alpha1.Condition {
+	t.Helper()
+	rc := findCondition(g.Status.Conditions, ResourcesConverged)
+	require.NotNil(t, rc, "ResourcesConverged must be present")
+	assert.Equal(t, status, rc.Status)
+	require.NotNil(t, rc.Reason)
+	assert.Equal(t, reason, *rc.Reason)
+	ready := findCondition(g.Status.Conditions, Ready)
+	require.NotNil(t, ready, "Ready must be present")
+	assert.Equal(t, status, ready.Status, "Ready must follow ResourcesConverged")
+	return rc
+}
+
+// compileGraph compiles g with the real compiler bound to the fake schema
+// resolver, so projection tests exercise the compiled forEach/CEL machinery.
+func compileGraph(t *testing.T, g *expv1alpha1.Graph) *compiler.Program {
+	t.Helper()
+	r, disco := testk8s.NewFakeResolver()
+	rm := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disco))
+	p, err := compiler.NewCompilerWithDependencies(r, rm).Compile(g)
+	require.NoError(t, err)
+	return p
+}
+
+// forEachPatchGraph builds a Graph whose forEach patch node "p" contributes data
+// to the ConfigMap named by each element of a Def node's list.
+func forEachPatchGraph(ns string, names []any) *expv1alpha1.Graph {
+	g := generator.NewGraph("g",
+		generator.WithNamespace(ns),
+		generator.WithDef("src", map[string]any{"names": names}),
+		generator.WithPatchManifest("p", map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "${n}"},
+			"data":       map[string]any{"patched": "yes"},
+		}),
+	)
+	g.Spec.Nodes[len(g.Spec.Nodes)-1].ForEach = []expv1alpha1.ForEachDimension{{"n": "${src.names}"}}
+	return g
+}
+
+// TestReconcile_ForEachPatchWriteAheadPersistsEveryTarget: for a forEach patch
+// node the server-side ledger must hold one row per target before Apply runs.
+func TestReconcile_ForEachPatchWriteAheadPersistsEveryTarget(t *testing.T) {
+	t.Parallel()
+	key := types.NamespacedName{Namespace: "default", Name: "g"}
+
+	spec := forEachPatchGraph("default", []any{"claim-a", "claim-b", "claim-c"})
+	g := graph("g", withFinalizer, func(g *expv1alpha1.Graph) {
+		g.SetUID("uid-foreach-reconcile")
+		g.Spec = spec.Spec
+	})
+	cl := newClient(t, g)
+
+	obs := &applyObservingExecutor{cl: cl, key: key}
+	fc := &fakeCompiler{program: compileGraph(t, g)}
+	r := &Reconciler{Client: cl, Compiler: fc, Registry: registry.New(), Executor: obs}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	require.True(t, obs.observed, "Apply must have been called")
+
+	require.Len(t, obs.contribsAtApply, 3,
+		"the write-ahead ledger must hold one row per forEach target BEFORE Apply runs")
+	wantFM := executor.PatchFieldManager("uid-foreach-reconcile", "p")
+	names := make([]string, 0, 3)
+	for _, c := range obs.contribsAtApply {
+		names = append(names, c.Name)
+		assert.Equal(t, wantFM, c.FieldManager, "every row carries the executor's per-node field manager")
+		assert.Equal(t, "default", c.Namespace)
+	}
+	assert.ElementsMatch(t, []string{"claim-a", "claim-b", "claim-c"}, names)
+	assert.Empty(t, obs.persistedAtApply, "a patch node owns nothing; no managed-resource intent")
+}
+
+// ledgerWriteRecorder wraps a client and records the row count carried by every
+// Status().Patch that touches status.contributions, so a test can assert the
+// write pattern, not just the final ledger (every status write re-enqueues).
+type ledgerWriteRecorder struct {
+	client.Client
+	writes []int
+}
+
+func (c *ledgerWriteRecorder) Status() client.StatusWriter {
+	return &recordingStatusWriter{StatusWriter: c.Client.Status(), rec: c}
+}
+
+type recordingStatusWriter struct {
+	client.StatusWriter
+	rec *ledgerWriteRecorder
+}
+
+func (w *recordingStatusWriter) Patch(ctx context.Context, obj client.Object, p client.Patch, opts ...client.SubResourcePatchOption) error {
+	data, err := p.Data(obj)
+	if err != nil {
+		return err
+	}
+	if bytes.Contains(data, []byte(`"contributions"`)) {
+		n := -1
+		if g, ok := obj.(*expv1alpha1.Graph); ok {
+			n = len(g.Status.Contributions)
+		}
+		w.rec.writes = append(w.rec.writes, n)
+	}
+	return w.StatusWriter.Patch(ctx, obj, p, opts...)
+}
+
+// TestReconcile_SoftPathKeepsWriteAheadLedger: a patch node whose target does
+// not exist yet (ErrNotReady, fewer rows observed than projected) must persist
+// exactly one ledger write per Graph — the write-ahead — and never shrink it;
+// writing it back down each cycle re-enqueues the Graph in a hot loop.
+func TestReconcile_SoftPathKeepsWriteAheadLedger(t *testing.T) {
+	t.Parallel()
+	key := types.NamespacedName{Namespace: "default", Name: "g"}
+	fm := executor.PatchFieldManager("uid-soft-ledger", "p")
+	contrib := func(name string) executor.Contribution {
+		return executor.Contribution{APIVersion: "v1", Kind: "ConfigMap", Namespace: "default", Name: name, FieldManager: fm}
+	}
+
+	cases := []struct {
+		name      string
+		program   func(t *testing.T, g *expv1alpha1.Graph) *compiler.Program
+		observed  []executor.Contribution // what the executor reports alongside ErrNotReady
+		wantRows  int                     // write-ahead rows == steady-state ledger size
+		wantNames []string
+	}{
+		{
+			// Three targets, none present yet.
+			name: "forEach patch over absent targets",
+			program: func(t *testing.T, g *expv1alpha1.Graph) *compiler.Program {
+				g.Spec = forEachPatchGraph("default", []any{"claim-a", "claim-b", "claim-c"}).Spec
+				return compileGraph(t, g)
+			},
+			wantRows:  3,
+			wantNames: []string{"claim-a", "claim-b", "claim-c"},
+		},
+		{
+			name: "singleton patch over an absent target",
+			program: func(*testing.T, *expv1alpha1.Graph) *compiler.Program {
+				return patchProgram("p", "v1", "ConfigMap", "default", "target")
+			},
+			wantRows:  1,
+			wantNames: []string{"target"},
+		},
+		{
+			// Two of three targets exist; the third row stays as a write-ahead ghost.
+			name: "forEach patch with a subset of targets present",
+			program: func(t *testing.T, g *expv1alpha1.Graph) *compiler.Program {
+				g.Spec = forEachPatchGraph("default", []any{"claim-a", "claim-b", "claim-c"}).Spec
+				return compileGraph(t, g)
+			},
+			observed:  []executor.Contribution{contrib("claim-a"), contrib("claim-b")},
+			wantRows:  3,
+			wantNames: []string{"claim-a", "claim-b", "claim-c"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := graph("g", withFinalizer, func(g *expv1alpha1.Graph) { g.SetUID("uid-soft-ledger") })
+			prog := tc.program(t, g)
+			cl := newClient(t, g)
+			rec := &ledgerWriteRecorder{Client: cl}
+			exec := &fakeExecutor{
+				applyErr:    fmt.Errorf("apply %q: patch target not found: %w", "p", executor.ErrNotReady),
+				applyResult: executor.ApplyResult{Contributions: tc.observed},
+			}
+			r := &Reconciler{Client: rec, Compiler: &fakeCompiler{program: prog}, Registry: registry.New(), Executor: exec}
+
+			// First cycle: one write-ahead write, and no write back down.
+			res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+			require.NoError(t, err, "a not-ready target is a soft requeue")
+			assert.Positive(t, res.RequeueAfter)
+			assert.Equal(t, []int{tc.wantRows}, rec.writes,
+				"exactly one ledger write (the write-ahead) per cycle; a second, smaller write is the N->0 drop")
+
+			got := &expv1alpha1.Graph{}
+			require.NoError(t, cl.Get(context.Background(), key, got))
+			require.Len(t, got.Status.Contributions, tc.wantRows, "the soft path must not shrink the ledger below the write-ahead")
+			names := make([]string, 0, len(got.Status.Contributions))
+			for _, c := range got.Status.Contributions {
+				names = append(names, c.Name)
+				assert.Equal(t, fm, c.FieldManager)
+			}
+			assert.ElementsMatch(t, tc.wantNames, names)
+
+			// Second cycle: the server already holds the intent; nothing to write.
+			_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+			require.NoError(t, err)
+			assert.Equal(t, []int{tc.wantRows}, rec.writes, "a steady-state soft cycle must issue no ledger write at all")
+			require.NoError(t, cl.Get(context.Background(), key, got))
+			assert.Len(t, got.Status.Contributions, tc.wantRows)
+		})
+	}
+}
+
+// TestReconcile_ContributionPersistFailureFlipsConverged: a refused post-apply
+// ledger write after a clean apply must flip ResourcesConverged to
+// False/StatusWriteFailed and be returned, not leave Ready=True with an empty ledger.
+func TestReconcile_ContributionPersistFailureFlipsConverged(t *testing.T) {
+	t.Parallel()
+	key := types.NamespacedName{Namespace: "default", Name: "g"}
+
+	g := graph("g", withFinalizer)
+	cl := newClient(t, g)
+	// Refuse only ledger writes; the conditions write must still land.
+	gate := &statusPatchGate{Client: cl, field: "contributions", err: errors.New("etcdserver: request is too large")}
+
+	exec := &fakeExecutor{applyResult: executor.ApplyResult{
+		Contributions: manyContributions("kro-graphengine.patch.abc.def", 3),
+	}}
+	// A payload-less node has no write-ahead, so the only ledger write is the
+	// post-apply persist under test.
+	r := &Reconciler{Client: gate, Compiler: &fakeCompiler{program: emptyNodeProgram("p")}, Registry: registry.New(), Executor: exec}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.Error(t, err, "a refused contribution-ledger write must be returned, not swallowed")
+	assert.Contains(t, err.Error(), "persist contributions")
+	assert.Contains(t, err.Error(), "request is too large")
+	assert.GreaterOrEqual(t, gate.rejected, 1, "the ledger write must have been attempted and refused")
+
+	got := &expv1alpha1.Graph{}
+	require.NoError(t, cl.Get(context.Background(), key, got))
+	rc := requireConverged(t, got, metav1.ConditionFalse, "StatusWriteFailed")
+	require.NotNil(t, rc.Message)
+	assert.Contains(t, *rc.Message, "request is too large")
+	acc := findCondition(got.Status.Conditions, GraphAccepted)
+	require.NotNil(t, acc)
+	assert.Equal(t, metav1.ConditionTrue, acc.Status, "the Graph still compiled")
+	assert.Empty(t, got.Status.Contributions, "nothing landed on the server; status must not pretend otherwise")
+}
+
+// TestReconcile_WriteAheadRejectedStillPublishesConditions: a refused write-ahead
+// must publish Accepted=True and ResourcesConverged=False/WriteAheadFailed with
+// nothing applied, and the conditions write must not re-send the refused list.
+func TestReconcile_WriteAheadRejectedStillPublishesConditions(t *testing.T) {
+	t.Parallel()
+	key := types.NamespacedName{Namespace: "default", Name: "g"}
+
+	g := graph("g", withFinalizer)
+	cl := newClient(t, g)
+	rejection := apierrors.NewInvalid(
+		schema.GroupKind{Group: "kro.run", Kind: "Graph"}, "g",
+		field.ErrorList{field.TooMany(field.NewPath("status", "managedResources"), 6000, 5000)})
+	// Refuse the write-ahead (carries managedResources); let conditions through.
+	gate := &statusPatchGate{Client: cl, field: "managedResources", err: rejection}
+
+	exec := &fakeExecutor{}
+	fc := &fakeCompiler{program: templateProgram("widget", "example.com/v1", "Widget", "default", "w")}
+	r := &Reconciler{Client: gate, Compiler: fc, Registry: registry.New(), Executor: exec}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write-ahead managed-resource intent")
+	assert.Equal(t, 0, exec.applyCalls, "a refused write-ahead must fail closed: nothing applied")
+	assert.Equal(t, 1, gate.rejected, "exactly the write-ahead was refused; the conditions write must not carry the refused list")
+
+	got := &expv1alpha1.Graph{}
+	require.NoError(t, cl.Get(context.Background(), key, got))
+	require.NotEmpty(t, got.Status.Conditions, "a Graph whose write-ahead was refused must not be left with no status at all")
+	acc := findCondition(got.Status.Conditions, GraphAccepted)
+	require.NotNil(t, acc)
+	assert.Equal(t, metav1.ConditionTrue, acc.Status, "Accepted/Compiled is still reported")
+	rc := requireConverged(t, got, metav1.ConditionFalse, "WriteAheadFailed")
+	require.NotNil(t, rc.Message)
+	assert.Contains(t, *rc.Message, "must have at most 5000 items")
+	assert.Empty(t, got.Status.ManagedResources, "the refused inventory must not have landed")
+}
+
+// TestReconcile_InventoryTooLargeFailsClosed: an inventory over
+// GraphInventoryMaxItems yields ResourcesConverged=False/InventoryTooLarge naming
+// the count and cap; before apply the executor is not run, and the server-side
+// inventory never grows past what it held.
+func TestReconcile_InventoryTooLargeFailsClosed(t *testing.T) {
+	t.Parallel()
+	limit := expv1alpha1.GraphInventoryMaxItems
+	key := types.NamespacedName{Namespace: "default", Name: "g"}
+
+	cases := []struct {
+		name         string
+		initial      func(*expv1alpha1.Graph)
+		program      *compiler.Program
+		exec         *fakeExecutor
+		wantApplied  bool   // was the executor run this cycle?
+		wantField    string // status field named in the condition message
+		wantCount    int    // entry count named in the condition message
+		wantManaged  int    // persisted managedResources length after reconcile
+		wantContribs int    // persisted contributions length after reconcile
+	}{
+		{
+			// previous holds exactly the cap; the template intends one more.
+			name: "managed-resource write-ahead over the cap refuses to apply",
+			initial: func(g *expv1alpha1.Graph) {
+				g.Status.ManagedResources = manyManagedResources("cms", limit)
+			},
+			program:     templateProgram("widget", "example.com/v1", "Widget", "default", "w"),
+			exec:        &fakeExecutor{},
+			wantApplied: false,
+			wantField:   "managedResources",
+			wantCount:   limit + 1,
+			wantManaged: limit,
+		},
+		{
+			// prior ledger holds exactly the cap; the patch intends one more target.
+			name: "contribution write-ahead over the cap refuses to apply",
+			initial: func(g *expv1alpha1.Graph) {
+				g.SetUID("uid-contrib-cap")
+				g.Status.Contributions = toAPIContributions(manyContributions("kro-graphengine.patch.prior.x", limit))
+			},
+			program:      patchProgram("p", "v1", "ConfigMap", "default", "target"),
+			exec:         &fakeExecutor{},
+			wantApplied:  false,
+			wantField:    "contributions",
+			wantCount:    limit + 1,
+			wantContribs: limit,
+		},
+		{
+			// No write-ahead (payload-less node); apply reports cap+1 identities
+			// the projection could not see. Condition set, no prune, server
+			// inventory unchanged.
+			name:    "post-apply applied set over the cap surfaces InventoryTooLarge",
+			program: emptyNodeProgram("cms"),
+			exec: &fakeExecutor{applyResult: executor.ApplyResult{
+				Applied: manyManagedResources("cms", limit+1),
+			}},
+			wantApplied: true,
+			wantField:   "managedResources",
+			wantCount:   limit + 1,
+			wantManaged: 0,
+		},
+		{
+			// Same for contributions observed after apply.
+			name:    "post-apply contribution set over the cap surfaces InventoryTooLarge",
+			program: emptyNodeProgram("p"),
+			exec: &fakeExecutor{applyResult: executor.ApplyResult{
+				Contributions: manyContributions("kro-graphengine.patch.abc.def", limit+1),
+			}},
+			wantApplied:  true,
+			wantField:    "contributions",
+			wantCount:    limit + 1,
+			wantContribs: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := graph("g", withFinalizer)
+			if tc.initial != nil {
+				tc.initial(g)
+			}
+			cl := newClient(t, g)
+			r := &Reconciler{Client: cl, Compiler: &fakeCompiler{program: tc.program}, Registry: registry.New(), Executor: tc.exec}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+			require.Error(t, err, "an over-cap inventory must be returned as an error so the Graph is retried")
+			var tooLarge *inventoryTooLargeError
+			require.ErrorAs(t, err, &tooLarge, "the error must be the typed cap error, not a raw apiserver rejection")
+			assert.Equal(t, tc.wantApplied, tc.exec.applyCalls > 0, "executor run")
+			assert.Empty(t, tc.exec.deleteCalls, "no prune may run on a cycle whose bookkeeping cannot be persisted")
+
+			got := &expv1alpha1.Graph{}
+			require.NoError(t, cl.Get(context.Background(), key, got))
+			rc := requireConverged(t, got, metav1.ConditionFalse, "InventoryTooLarge")
+			require.NotNil(t, rc.Message)
+			assert.Contains(t, *rc.Message, "status."+tc.wantField)
+			assert.Contains(t, *rc.Message, fmt.Sprintf("%d entries", tc.wantCount))
+			assert.Contains(t, *rc.Message, fmt.Sprintf("cap of %d", limit))
+			// The message says whether anything reached the cluster.
+			if tc.wantApplied {
+				assert.Contains(t, *rc.Message, "applied resources exceed the trackable inventory")
+			} else {
+				assert.Contains(t, *rc.Message, "refusing to apply")
+			}
+			acc := findCondition(got.Status.Conditions, GraphAccepted)
+			require.NotNil(t, acc)
+			assert.Equal(t, metav1.ConditionTrue, acc.Status, "the Graph still compiled")
+			assert.Len(t, got.Status.ManagedResources, tc.wantManaged, "server-side inventory must not grow past what it held")
+			assert.Len(t, got.Status.Contributions, tc.wantContribs, "server-side ledger must not grow past what it held")
+		})
+	}
+}
+
+// TestReconcile_PostApplyOverCapKeepsWriteAheadUIDs: when the applied set is
+// over the cap the inventory stays at the write-ahead union but adopts the
+// observed UIDs, since Delete skips UID-free entries.
+func TestReconcile_PostApplyOverCapKeepsWriteAheadUIDs(t *testing.T) {
+	t.Parallel()
+	limit := expv1alpha1.GraphInventoryMaxItems
+	key := types.NamespacedName{Namespace: "default", Name: "g"}
+
+	g := graph("g", withFinalizer)
+	cl := newClient(t, g)
+
+	// Write-ahead projects "w" UID-free; apply reports it with a UID plus cap
+	// more identities the projection never saw.
+	applied := append([]expv1alpha1.ManagedResource{{
+		NodeID: "widget", APIVersion: "example.com/v1", Kind: "Widget", Namespace: "default", Name: "w", UID: "uid-w",
+	}}, manyManagedResources("cms", limit)...)
+	exec := &fakeExecutor{applyResult: executor.ApplyResult{Applied: applied}}
+	fc := &fakeCompiler{program: templateProgram("widget", "example.com/v1", "Widget", "default", "w")}
+	r := &Reconciler{Client: cl, Compiler: fc, Registry: registry.New(), Executor: exec}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	var tooLarge *inventoryTooLargeError
+	require.ErrorAs(t, err, &tooLarge)
+
+	got := &expv1alpha1.Graph{}
+	require.NoError(t, cl.Get(context.Background(), key, got))
+	requireConverged(t, got, metav1.ConditionFalse, "InventoryTooLarge")
+	require.Len(t, got.Status.ManagedResources, 1, "the inventory stays at the write-ahead union, never the over-cap applied set")
+	assert.Equal(t, "w", got.Status.ManagedResources[0].Name)
+	assert.Equal(t, "uid-w", got.Status.ManagedResources[0].UID,
+		"the write-ahead entry must adopt the observed UID so teardown can still delete it")
 }

--- a/pkg/controller/graph/tracking.go
+++ b/pkg/controller/graph/tracking.go
@@ -254,8 +254,10 @@ func childRuntime(rt *krotruntime.Runtime, n *krotruntime.Node) *krotruntime.Run
 // write-ahead entry would never correlate with the later Release. Both derive it
 // from the shared executor.PatchFieldManager(graphUID, qualifiedNodeID), so they
 // cannot drift — which is why subgraphs are recursed here (to reproduce the
-// executor's prefix-qualified path). Intentionally lossy: unresolvable, ignored,
-// or dynamic-GVK-no-namespace patch nodes are skipped.
+// executor's prefix-qualified path). A forEach patch node projects one entry per
+// target, as the executor records one Contribution per target. Intentionally
+// lossy: unresolvable, ignored, or dynamic-GVK-no-namespace patch nodes are
+// skipped.
 func intendedContributions(rt *krotruntime.Runtime) []executor.Contribution {
 	if rt == nil {
 		return nil
@@ -299,38 +301,43 @@ func projectContributions(
 			continue
 		}
 		desired, err := n.Resolve()
-		if err != nil || len(desired) != 1 {
+		if err != nil {
 			continue
 		}
-		obj := desired[0]
-		gvk := obj.GroupVersionKind()
-		if gvk.Kind == "" || obj.GetName() == "" {
-			continue
+		// One entry per rendered target (a forEach patch fans out over all of
+		// them), all under the node's single field manager; contribKeyOf includes
+		// the target identity, so the rows stay distinct.
+		fieldManager := executor.PatchFieldManager(graphUID, prefix+n.ID())
+		for _, obj := range desired {
+			gvk := obj.GroupVersionKind()
+			if gvk.Kind == "" || obj.GetName() == "" {
+				continue
+			}
+			ns := obj.GetNamespace()
+			if ns == "" && n.Namespaced() {
+				ns = rt.Graph().GetNamespace()
+			}
+			// Same dynamic-GVK-no-namespace ambiguity as intendedManagedResources:
+			// the scope isn't known until apply resolves it from the RESTMapper, so a
+			// ns="" entry would never correlate. Skip it.
+			if ns == "" && n.DynamicGVK() {
+				continue
+			}
+			c := executor.Contribution{
+				APIVersion:   gvk.GroupVersion().String(),
+				Kind:         gvk.Kind,
+				Namespace:    ns,
+				Name:         obj.GetName(),
+				Subresource:  n.Subresource(),
+				FieldManager: fieldManager,
+			}
+			k := contribKeyOf(c)
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			*out = append(*out, c)
 		}
-		ns := obj.GetNamespace()
-		if ns == "" && n.Namespaced() {
-			ns = rt.Graph().GetNamespace()
-		}
-		// Same dynamic-GVK-no-namespace ambiguity as intendedManagedResources:
-		// the scope isn't known until apply resolves it from the RESTMapper, so a
-		// ns="" entry would never correlate. Skip it.
-		if ns == "" && n.DynamicGVK() {
-			continue
-		}
-		c := executor.Contribution{
-			APIVersion:   gvk.GroupVersion().String(),
-			Kind:         gvk.Kind,
-			Namespace:    ns,
-			Name:         obj.GetName(),
-			Subresource:  n.Subresource(),
-			FieldManager: executor.PatchFieldManager(graphUID, prefix+n.ID()),
-		}
-		k := contribKeyOf(c)
-		if _, dup := seen[k]; dup {
-			continue
-		}
-		seen[k] = struct{}{}
-		*out = append(*out, c)
 	}
 }
 
@@ -371,6 +378,58 @@ func unionManagedResources(
 		add(r)
 	}
 	return out
+}
+
+// adoptUIDs returns a copy of base with UIDs taken from matching applied entries,
+// never adding an identity. An over-cap cycle keeps its inventory at the
+// write-ahead union but must still record UIDs: Delete skips UID-free entries.
+func adoptUIDs(base, applied []expv1alpha1.ManagedResource) []expv1alpha1.ManagedResource {
+	if len(base) == 0 {
+		return base
+	}
+	uids := make(map[resourceKey]string, len(applied))
+	for _, r := range applied {
+		if r.UID != "" {
+			uids[keyOf(r)] = r.UID
+		}
+	}
+	out := make([]expv1alpha1.ManagedResource, len(base))
+	copy(out, base)
+	for i := range out {
+		if uid, ok := uids[keyOf(out[i])]; ok {
+			out[i].UID = uid
+		}
+	}
+	return out
+}
+
+// inventoryTooLargeError reports a status inventory over the CRD's MaxItems cap.
+// A distinct type so reconcileGraph can surface it as InventoryTooLarge.
+type inventoryTooLargeError struct {
+	field string // "managedResources" or "contributions"
+	count int
+}
+
+func (e *inventoryTooLargeError) Error() string {
+	return fmt.Sprintf(
+		"status.%s would hold %d entries, exceeding the cap of %d; the count includes "+
+			"entries still tracked from the previous spec (the inventory never shrinks before "+
+			"apply), so shrink or remove nodes before renaming them, reduce the forEach fan-out, "+
+			"or split the Graph",
+		e.field, e.count, expv1alpha1.GraphInventoryMaxItems)
+}
+
+// checkInventoryCaps returns an inventoryTooLargeError when either count exceeds
+// expv1alpha1.GraphInventoryMaxItems. Run before any status write (so the cap
+// surfaces as a condition, not an apiserver rejection) and before Apply.
+func checkInventoryCaps(managed, contributions int) error {
+	if managed > expv1alpha1.GraphInventoryMaxItems {
+		return &inventoryTooLargeError{field: "managedResources", count: managed}
+	}
+	if contributions > expv1alpha1.GraphInventoryMaxItems {
+		return &inventoryTooLargeError{field: "contributions", count: contributions}
+	}
+	return nil
 }
 
 // contribKey is the identity tuple for a patch contribution. The field

--- a/pkg/controller/graph/tracking_test.go
+++ b/pkg/controller/graph/tracking_test.go
@@ -438,3 +438,33 @@ func TestContributionsAPIRoundTrip(t *testing.T) {
 		assert.Equal(t, in, fromAPIContributions(api), "round-trip must be lossless")
 	})
 }
+
+// TestCheckInventoryCaps: exactly the cap fits, one more does not, the error
+// names the field, count and cap, and managedResources is reported first.
+func TestCheckInventoryCaps(t *testing.T) {
+	t.Parallel()
+	limit := expv1alpha1.GraphInventoryMaxItems
+
+	require.NoError(t, checkInventoryCaps(0, 0))
+	require.NoError(t, checkInventoryCaps(limit, limit), "exactly the cap must be accepted")
+
+	err := checkInventoryCaps(limit+1, 0)
+	require.Error(t, err)
+	var tooLarge *inventoryTooLargeError
+	require.ErrorAs(t, err, &tooLarge)
+	assert.Equal(t, "managedResources", tooLarge.field)
+	assert.Equal(t, limit+1, tooLarge.count)
+	assert.Contains(t, err.Error(), "status.managedResources")
+	assert.Contains(t, err.Error(), "5001")
+	assert.Contains(t, err.Error(), "5000")
+
+	err = checkInventoryCaps(0, limit+7)
+	require.ErrorAs(t, err, &tooLarge)
+	assert.Equal(t, "contributions", tooLarge.field)
+	assert.Equal(t, limit+7, tooLarge.count)
+	assert.Contains(t, err.Error(), "status.contributions")
+
+	err = checkInventoryCaps(limit+1, limit+1)
+	require.ErrorAs(t, err, &tooLarge)
+	assert.Equal(t, "managedResources", tooLarge.field, "managed resources are reported first")
+}

--- a/test/integration/suites/core/graph_patch_test.go
+++ b/test/integration/suites/core/graph_patch_test.go
@@ -300,4 +300,127 @@ var _ = Describe("Graph Patch", func() {
 			return nil
 		}, 15*time.Second)
 	})
+
+	// A forEach patch node records one ledger row per target under one field
+	// manager, and deleting the Graph releases every row.
+	It("records one contribution per forEach target and releases them all on delete", func() {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+
+		cmGVK := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+		targets := []string{"claim-a", "claim-b", "claim-c"}
+
+		ctx := env.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		// Pre-existing targets, each with its own data so an over-reaching release
+		// would be visible.
+		for _, name := range targets {
+			target := &unstructured.Unstructured{}
+			target.SetGroupVersionKind(cmGVK)
+			target.SetNamespace(ns)
+			target.SetName(name)
+			if err := unstructured.SetNestedStringMap(target.Object, map[string]string{"orig": name}, "data"); err != nil {
+				t.Fatalf("set target data: %v", err)
+			}
+			if err := env.Client.Create(ctx, target); err != nil {
+				t.Fatalf("create target ConfigMap %s: %v", name, err)
+			}
+		}
+
+		g := &expv1alpha1.Graph{
+			ObjectMeta: metav1.ObjectMeta{Name: "fanout-patcher", Namespace: ns},
+			Spec: expv1alpha1.GraphSpec{
+				Nodes: []expv1alpha1.Node{
+					{
+						ID:  "src",
+						Def: environment.RawExt(t, map[string]any{"names": targets}),
+					},
+					{
+						ID:      "p",
+						ForEach: []expv1alpha1.ForEachDimension{{"n": "${src.names}"}},
+						Patch: environment.RawExt(t, map[string]any{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata":   map[string]any{"name": "${n}"},
+							"data":       map[string]any{"patched": "yes"},
+						}),
+					},
+				},
+			},
+		}
+		env.CreateGraph(t, g)
+
+		gKey := types.NamespacedName{Namespace: ns, Name: "fanout-patcher"}
+		env.AwaitCondition(t, gKey, expv1alpha1.GraphConditionTypeReady, metav1.ConditionTrue, 15*time.Second)
+
+		// Every target got the fanned-out field and kept its own.
+		for _, name := range targets {
+			env.AwaitObject(t, cmGVK, types.NamespacedName{Namespace: ns, Name: name}, func(u *unstructured.Unstructured) error {
+				data, _, _ := unstructured.NestedStringMap(u.Object, "data")
+				if data["patched"] != "yes" {
+					return fmt.Errorf("%s data.patched: want=yes got=%q", name, data["patched"])
+				}
+				if data["orig"] != name {
+					return fmt.Errorf("%s data.orig: want=%s got=%q", name, name, data["orig"])
+				}
+				return nil
+			}, 15*time.Second)
+		}
+
+		// One row per target under one field manager; a patch owns nothing.
+		var fieldManager string
+		environment.Eventually(t, 10*time.Second, 200*time.Millisecond, func() error {
+			cur := env.GetGraph(t, gKey)
+			if len(cur.Status.Contributions) != len(targets) {
+				return fmt.Errorf("status.contributions len=%d want %d: %+v", len(cur.Status.Contributions), len(targets), cur.Status.Contributions)
+			}
+			seen := map[string]bool{}
+			for _, c := range cur.Status.Contributions {
+				if c.Kind != "ConfigMap" || c.Namespace != ns {
+					return fmt.Errorf("unexpected contribution target %s/%s in %s", c.Kind, c.Name, c.Namespace)
+				}
+				if fieldManager == "" {
+					fieldManager = c.FieldManager
+				} else if c.FieldManager != fieldManager {
+					return fmt.Errorf("contributions of one patch node must share a field manager: %q vs %q", c.FieldManager, fieldManager)
+				}
+				seen[c.Name] = true
+			}
+			for _, name := range targets {
+				if !seen[name] {
+					return fmt.Errorf("no contribution row for target %q", name)
+				}
+			}
+			if len(cur.Status.ManagedResources) != 0 {
+				return fmt.Errorf("a patch node must not be tracked as an owned resource: %+v", cur.Status.ManagedResources)
+			}
+			return nil
+		})
+
+		// Teardown releases every row: targets survive and lose only the
+		// contributed field.
+		if err := env.Client.Delete(ctx, env.GetGraph(t, gKey)); err != nil {
+			t.Fatalf("delete graph: %v", err)
+		}
+		env.AwaitGraphGone(t, gKey, 15*time.Second)
+		for _, name := range targets {
+			env.AwaitObject(t, cmGVK, types.NamespacedName{Namespace: ns, Name: name}, func(u *unstructured.Unstructured) error {
+				data, _, _ := unstructured.NestedStringMap(u.Object, "data")
+				if _, ok := data["patched"]; ok {
+					return fmt.Errorf("%s data.patched still present after Graph deletion", name)
+				}
+				if data["orig"] != name {
+					return fmt.Errorf("%s data.orig lost during release: got=%q", name, data["orig"])
+				}
+				for _, mf := range u.GetManagedFields() {
+					if mf.Manager == fieldManager {
+						return fmt.Errorf("%s still lists the Graph's patch field manager %q after release", name, fieldManager)
+					}
+				}
+				return nil
+			}, 15*time.Second)
+		}
+	})
 })

--- a/test/integration/suites/core/graph_serviceaccount_test.go
+++ b/test/integration/suites/core/graph_serviceaccount_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+)
+
+// graphWithServiceAccountName builds a Graph as an unstructured object so the
+// serviceAccountName value is sent verbatim (the typed struct's omitempty would
+// drop an empty string).
+func graphWithServiceAccountName(ns, name, sa string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": expv1alpha1.GroupVersion.String(),
+		"kind":       "Graph",
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+		"spec": map[string]any{
+			"serviceAccountName": sa,
+			"nodes": []any{map[string]any{
+				"id": "cm",
+				"template": map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]any{"name": name + "-cm"},
+					"data":       map[string]any{"hello": "world"},
+				},
+			}},
+		},
+	}}
+}
+
+var _ = Describe("Graph ServiceAccount", func() {
+	// An explicit serviceAccountName: "" (what Helm/Kustomize render for an unset
+	// value) must be admitted and behave like an omitted field.
+	It("admits an explicit empty serviceAccountName and applies as the namespace default", func() {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+		ctx := env.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		u := graphWithServiceAccountName(ns, "empty-sa", "")
+		if err := env.Client.Create(ctx, u); err != nil {
+			t.Fatalf("create Graph with serviceAccountName \"\": %v (the CRD pattern must admit the explicit empty value)", err)
+		}
+		key := types.NamespacedName{Namespace: ns, Name: "empty-sa"}
+		t.Cleanup(func() {
+			cur := &expv1alpha1.Graph{}
+			if err := env.Client.Get(context.Background(), key, cur); err == nil {
+				_ = env.Client.Delete(context.Background(), cur)
+			}
+		})
+
+		env.AwaitCondition(t, key, expv1alpha1.GraphConditionTypeReady, metav1.ConditionTrue, 15*time.Second)
+		env.AwaitObject(t, configMapGVK, types.NamespacedName{Namespace: ns, Name: "empty-sa-cm"}, nil, 15*time.Second)
+
+		// The empty value resolved to the namespace default ServiceAccount.
+		got := env.GetGraph(t, key)
+		want := fmt.Sprintf("system:serviceaccount:%s:default", ns)
+		if got.Status.AppliedServiceAccount != want {
+			t.Fatalf("status.appliedServiceAccount=%q want %q", got.Status.AppliedServiceAccount, want)
+		}
+	})
+})


### PR DESCRIPTION
## Problem

The standalone Graph controller (`GraphKind` gate) keeps two status inventories, `status.managedResources` and `status.contributions`, and tears a Graph down from them. Three status-write failures around those inventories were invisible or misreported. When the post-apply write of the contribution ledger was refused (a dozen `forEach` patch nodes over a thousand targets exceed etcd's request size), the error was returned but `ResourcesConverged`/`Ready` stayed `True` with an empty ledger, so deleting the Graph left every contributed field and field manager on its targets. When the pre-apply write-ahead was refused (six 1000-item collection nodes exceed the `managedResources` cap of 5000), no condition was set and the in-memory Graph still held the refused list, so the conditions write was refused for the same reason: a fresh Graph had no `status` at all and a blank `READY` column. `status.contributions` also had no `maxItems`, so nothing bounded the ledger.

Separately, the write-ahead contribution projection only handled singleton patches (`len(desired) != 1` was skipped), so a `forEach` patch node had zero write-ahead rows while the executor recorded one contribution per target. And `spec.serviceAccountName` documented "empty means the namespace default" but its pattern rejected the explicit `""` that Helm and Kustomize render for an unset value.

## Fix

- `api/v1alpha1/graph_types.go`: new `GraphInventoryMaxItems = 5000`; `status.contributions` gains `MaxItems=5000` like `managedResources`; the `serviceAccountName` pattern admits the empty string (`^$|…`). `helm/crds/kro.run_graphs.yaml` regenerated. `TestGraphCRD_MarkersMatchConstants` asserts the generated CRD agrees with the constant and the regex under test.
- `tracking.go`: `projectContributions` emits one write-ahead `Contribution` per rendered patch target under the node's field manager; new `checkInventoryCaps` (typed `inventoryTooLargeError`) and `adoptUIDs` (copies observed UIDs onto write-ahead entries without adding identities).
- `controller.go` `writeAheadIntent`: checks both inventories against the cap before writing or applying (fail closed), and on a refused managed-resource write restores `g.Status.ManagedResources` to what the server holds so the conditions write is not refused too.
- `controller.go` `reconcileGraph`: a refused write-ahead sets `ResourcesConverged=False` with reason `InventoryTooLarge` or `WriteAheadFailed`; a post-apply cap check (the executor can apply identities the projection cannot see) sets `InventoryTooLarge`, keeps the write-ahead union with observed UIDs adopted, skips prune/release and returns the cap error joined with a hard apply error; a refused clean-path ledger write sets `StatusWriteFailed`. The error branches persist `ledgerUnion` (the ledger the write-ahead left on the server plus the observed rows) instead of `prior ∪ observed`, so a patch whose target does not exist yet no longer has its write-ahead rows written and erased on every reconcile, each status write re-enqueuing the Graph. `TestReconcile_SoftPathKeepsWriteAheadLedger` pins one ledger write per Graph and no shrink for forEach and singleton patches over absent targets.
- `docs/design/proposals/graph.md`: the three new condition reasons; `""` documented as unset.

## Behaviour changes

- New `ResourcesConverged=False` reasons: `WriteAheadFailed` (pre-apply inventory write refused, nothing applied), `StatusWriteFailed` (clean apply but the contribution ledger did not persist), `InventoryTooLarge` (an inventory would exceed 5000 entries; the controller fails closed and names the field, count and cap). `Ready` follows.
- `status.contributions` is now capped at 5000 entries like `managedResources`. Because the pre-apply inventory is `previous ∪ intended`, a `forEach` patch set whose union exceeds the cap — for example renaming or retargeting more than 2500 contribution rows in one step — is now refused with `InventoryTooLarge` where it previously succeeded; rename such nodes incrementally. For `managedResources` the same shape already failed with a raw 422.
- A patch node whose target does not exist yet now holds a stable write-ahead ledger and `WaitingForReadiness` until the target appears; before, a singleton patch in that state rewrote the ledger twice per reconcile and hot-looped.
- `spec.serviceAccountName: ""` is admitted and behaves exactly like an omitted field (impersonates `system:serviceaccount:<ns>:default`); malformed values are still rejected.
- `api/v1alpha1/graph_types_test.go`: the `"empty rejected"` row is flipped to allowed, since it pinned the rejected-empty-string behaviour this PR removes.
