### PR TITLE
fix(graph): make Graph teardown safe against gone CRDs, UID-free entries and partial applies

### DIFF
--- a/pkg/controller/graph/controller.go
+++ b/pkg/controller/graph/controller.go
@@ -248,7 +248,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, logger logr.Logger, re
 	}
 
 	if len(g.Status.ManagedResources) > 0 {
-		if err := ex.Delete(ctx, g.Status.ManagedResources); err != nil {
+		if err := ex.Delete(ctx, g.GetUID(), g.Status.ManagedResources); err != nil {
 			return teardownFailed(err, "executor delete", "failed to persist teardown delete-failure condition")
 		}
 	}
@@ -374,12 +374,17 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 		marker.ResourcesApplyFailed(applyErr.Error())
 	}
 
-	// Record the identity that applied under, but ONLY when the apply reached
-	// the cluster (clean or soft not-ready) — never on a hard failure, which
-	// must preserve the last-good identity so teardown can still see resources a
-	// prior identity applied. Empty when impersonation is inactive (the base
-	// controller identity), in which case teardown falls back to the spec.
-	reachedCluster := applyErr == nil || errors.Is(applyErr, executor.ErrNotReady)
+	// Record the identity the apply ran under whenever anything reached the
+	// cluster, including a hard failure that still landed some resources or
+	// patch contributions: those entries are persisted below and teardown must
+	// delete them as this identity, not as whatever the spec says later. A hard
+	// failure that applied nothing keeps the last-good identity. Empty when
+	// impersonation is inactive (teardown then falls back to the spec).
+	// Limitation: the scalar cannot represent a mixed-identity inventory (SA
+	// changed mid-life, or an SSA whose response was lost and so is absent from
+	// result.Applied).
+	reachedCluster := applyErr == nil || errors.Is(applyErr, executor.ErrNotReady) ||
+		len(result.Applied) > 0 || len(result.Contributions) > 0
 	if reachedCluster {
 		if user := r.appliedIdentity(g); user != "" {
 			g.Status.AppliedServiceAccount = user
@@ -409,7 +414,7 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 	}
 	if !hardErr {
 		if len(pruneCandidates) > 0 {
-			if err := ex.Delete(ctx, pruneCandidates); err != nil {
+			if err := ex.Delete(ctx, g.GetUID(), pruneCandidates); err != nil {
 				// A retired resource could not be deleted (e.g. the impersonated
 				// SA lacks delete RBAC). The Graph has NOT converged; surface it
 				// and keep the union so teardown still sees the un-deleted entry.

--- a/pkg/controller/graph/controller_test.go
+++ b/pkg/controller/graph/controller_test.go
@@ -53,6 +53,7 @@ type fakeExecutor struct {
 	applyResult  executor.ApplyResult
 	deleteErr    error
 	deleteCalls  [][]expv1alpha1.ManagedResource // captures every Delete invocation in order
+	deleteOwners []types.UID                     // captures the ownerUID passed to each Delete, in order
 	releaseErr   error
 	releaseCalls [][]executor.Contribution // captures every Release invocation in order
 }
@@ -60,8 +61,9 @@ type fakeExecutor struct {
 func (f *fakeExecutor) Apply(context.Context, *krotruntime.Runtime, watchrouter.Watcher) (executor.ApplyResult, error) {
 	return f.applyResult, f.applyErr
 }
-func (f *fakeExecutor) Delete(_ context.Context, resources []expv1alpha1.ManagedResource) error {
+func (f *fakeExecutor) Delete(_ context.Context, ownerUID types.UID, resources []expv1alpha1.ManagedResource) error {
 	f.deleteCalls = append(f.deleteCalls, resources)
+	f.deleteOwners = append(f.deleteOwners, ownerUID)
 	return f.deleteErr
 }
 func (f *fakeExecutor) Release(_ context.Context, contributions []executor.Contribution) error {

--- a/pkg/controller/graph/impersonation.go
+++ b/pkg/controller/graph/impersonation.go
@@ -93,7 +93,8 @@ func (r *Reconciler) executorFor(g *expv1alpha1.Graph) (executor.Interface, erro
 
 // appliedIdentity returns the impersonation username the Graph applies under
 // this cycle, or "" when impersonation is inactive (the base controller
-// identity). Recorded in Status.AppliedServiceAccount on a successful apply so
+// identity). Recorded in Status.AppliedServiceAccount whenever an apply reached
+// the cluster — including a hard failure that landed some resources — so
 // teardown can resolve the same identity; empty leaves teardown to fall back to
 // the current spec.
 func (r *Reconciler) appliedIdentity(g *expv1alpha1.Graph) string {

--- a/pkg/controller/graph/teardown_identity_test.go
+++ b/pkg/controller/graph/teardown_identity_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/executor"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/registry"
+)
+
+// fakeImpersonation resolves every identity to exec and records the identities
+// asked for, so a test can observe which one a reconcile ran under.
+func fakeImpersonation(exec executor.Interface) (*impersonationCache, *[]string) {
+	var built []string
+	return &impersonationCache{
+		newExec: func(user string) (executor.Interface, error) {
+			built = append(built, user)
+			return exec, nil
+		},
+	}, &built
+}
+
+func withServiceAccount(sa string) func(*expv1alpha1.Graph) {
+	return func(g *expv1alpha1.Graph) { g.Spec.ServiceAccountName = sa }
+}
+
+func withAppliedIdentity(user string) func(*expv1alpha1.Graph) {
+	return func(g *expv1alpha1.Graph) { g.Status.AppliedServiceAccount = user }
+}
+
+func withUID(uid string) func(*expv1alpha1.Graph) {
+	return func(g *expv1alpha1.Graph) { g.UID = types.UID(uid) }
+}
+
+// TestReconcile_AppliedIdentityOnHardFailure pins that the applying identity is
+// recorded when a hard failure still landed resources or contributions (the
+// inventory persists them, so teardown needs the identity), and left untouched
+// when nothing landed.
+func TestReconcile_AppliedIdentityOnHardFailure(t *testing.T) {
+	t.Parallel()
+
+	partial := []expv1alpha1.ManagedResource{{
+		NodeID: "cm", APIVersion: "v1", Kind: "ConfigMap", Namespace: "default", Name: "landed", UID: "uid-landed",
+	}}
+	hard := errors.New(`clusterroles.rbac.authorization.k8s.io "cr" is forbidden`)
+
+	cases := []struct {
+		name         string
+		graph        *expv1alpha1.Graph
+		exec         *fakeExecutor
+		wantIdentity string
+	}{
+		{
+			name:  "hard failure with a partial Applied set records the identity",
+			graph: graph("g", withFinalizer, withServiceAccount("deployer")),
+			exec: &fakeExecutor{
+				applyErr:    hard,
+				applyResult: executor.ApplyResult{Applied: partial},
+			},
+			wantIdentity: "system:serviceaccount:default:deployer",
+		},
+		{
+			name:  "hard failure that landed only patch contributions records the identity",
+			graph: graph("g", withFinalizer, withServiceAccount("deployer")),
+			exec: &fakeExecutor{
+				applyErr: hard,
+				applyResult: executor.ApplyResult{Contributions: []executor.Contribution{{
+					APIVersion: "v1", Kind: "ConfigMap", Namespace: "default", Name: "target",
+					FieldManager: executor.PatchFieldManager("uid", "p"),
+				}}},
+			},
+			wantIdentity: "system:serviceaccount:default:deployer",
+		},
+		{
+			name: "hard failure that applied nothing preserves the last-good identity",
+			graph: graph("g", withFinalizer, withServiceAccount("new-sa"),
+				withAppliedIdentity("system:serviceaccount:default:old-sa")),
+			exec:         &fakeExecutor{applyErr: hard},
+			wantIdentity: "system:serviceaccount:default:old-sa",
+		},
+		{
+			name:         "hard failure that applied nothing on a never-applied Graph records nothing",
+			graph:        graph("g", withFinalizer, withServiceAccount("deployer")),
+			exec:         &fakeExecutor{applyErr: hard},
+			wantIdentity: "",
+		},
+		{
+			name:  "partial Applied under a NEW identity moves the recorded identity to it",
+			graph: graph("g", withFinalizer, withServiceAccount("new-sa"), withAppliedIdentity("system:serviceaccount:default:old-sa")),
+			exec: &fakeExecutor{
+				applyErr:    hard,
+				applyResult: executor.ApplyResult{Applied: partial},
+			},
+			// The scalar cannot represent a mixed-identity inventory; the latest wins.
+			wantIdentity: "system:serviceaccount:default:new-sa",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cl := newClient(t, tc.graph)
+			imp, _ := fakeImpersonation(tc.exec)
+			r := &Reconciler{
+				Client:        cl,
+				Compiler:      &fakeCompiler{program: emptyNodeProgram("cm")},
+				Registry:      registry.New(),
+				Executor:      tc.exec,
+				Impersonation: imp,
+			}
+			key := types.NamespacedName{Namespace: "default", Name: "g"}
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+			require.Error(t, err, "a hard apply failure is surfaced")
+
+			got := &expv1alpha1.Graph{}
+			require.NoError(t, cl.Get(context.Background(), key, got))
+			assert.Equal(t, tc.wantIdentity, got.Status.AppliedServiceAccount)
+			for _, mr := range tc.exec.applyResult.Applied {
+				assert.Contains(t, got.Status.ManagedResources, mr,
+					"the partially-applied resource is in the persisted inventory, so teardown needs its identity")
+			}
+		})
+	}
+}
+
+// TestReconcileDelete_RecordedIdentityAndGraphUID pins that teardown runs under
+// Status.AppliedServiceAccount (not the current spec) and hands Delete the
+// Graph's UID.
+func TestReconcileDelete_RecordedIdentityAndGraphUID(t *testing.T) {
+	t.Parallel()
+
+	g := graph("g", withFinalizer, withDeletionTimestamp, withManagedResource,
+		withUID("graph-uid-123"),
+		withServiceAccount("rights-less-sa"),
+		withAppliedIdentity("system:serviceaccount:default:deployer"))
+	cl := newClient(t, g)
+	exec := &fakeExecutor{}
+	imp, built := fakeImpersonation(exec)
+	r := &Reconciler{
+		Client:        cl,
+		Compiler:      &fakeCompiler{err: errors.New("delete never compiles")},
+		Registry:      registry.New(),
+		Executor:      exec,
+		Impersonation: imp,
+	}
+	key := types.NamespacedName{Namespace: "default", Name: "g"}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"system:serviceaccount:default:deployer"}, *built,
+		"teardown must impersonate the recorded applied identity, never the current spec")
+	require.Len(t, exec.deleteCalls, 1)
+	assert.Equal(t, g.Status.ManagedResources, exec.deleteCalls[0])
+	assert.Equal(t, []types.UID{"graph-uid-123"}, exec.deleteOwners)
+
+	err = cl.Get(context.Background(), key, &expv1alpha1.Graph{})
+	assert.True(t, apierrors.IsNotFound(err), "finalizer released after teardown")
+}

--- a/pkg/controller/graph/tracking.go
+++ b/pkg/controller/graph/tracking.go
@@ -116,7 +116,7 @@ func diffManagedResources(
 // UID so post-apply entries dedup against their intent entry. Subgraph nodes are
 // recursed to arbitrary depth, qualifying child NodeIDs with the subgraph prefix
 // exactly as the executor's applySubgraph does so intent and post-apply entries
-// dedup on identity.
+// dedup on identity (and render the kro.run/node-id token Delete verifies).
 func intendedManagedResources(rt *krotruntime.Runtime) []expv1alpha1.ManagedResource {
 	if rt == nil {
 		return nil
@@ -343,8 +343,9 @@ func projectContributions(
 // dedups against its applied counterpart), but on a key collision the surviving
 // entry keeps whichever side's UID is set, and a later UID overrides an earlier
 // one. Every caller passes the UID-free previous/intent set first, so plain
-// first-wins would strand a resource in status with no UID — which Simple.Delete
-// then refuses to delete, leaking it on teardown.
+// first-wins would leave a resource in status with no UID; Simple.Delete can
+// still verify and delete such an entry, but the recorded UID is the stricter
+// precondition, so the inventory must never lose one it has.
 func unionManagedResources(
 	previous []expv1alpha1.ManagedResource,
 	applied []expv1alpha1.ManagedResource,

--- a/pkg/controller/graph/wiring_coverage_test.go
+++ b/pkg/controller/graph/wiring_coverage_test.go
@@ -162,7 +162,7 @@ func TestReconcilePrunesStaleResources(t *testing.T) {
 	stale := r("n", "ConfigMap", "old")
 	fresh := r("n", "ConfigMap", "new")
 
-	g := graph("g", withFinalizer)
+	g := graph("g", withFinalizer, withUID("graph-uid-456"))
 	g.Status.ManagedResources = []expv1alpha1.ManagedResource{stale}
 	cl := newClient(t, g)
 
@@ -179,9 +179,10 @@ func TestReconcilePrunesStaleResources(t *testing.T) {
 	_, err := r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
 
-	// The stale resource must have been handed to Delete.
+	// The stale resource must have been handed to Delete, with the Graph's UID.
 	require.Len(t, exec.deleteCalls, 1)
 	assert.Equal(t, []expv1alpha1.ManagedResource{stale}, exec.deleteCalls[0])
+	assert.Equal(t, []types.UID{"graph-uid-456"}, exec.deleteOwners)
 
 	got := &expv1alpha1.Graph{}
 	require.NoError(t, cl.Get(context.Background(), req.NamespacedName, got))

--- a/pkg/graphengine/executor/coverage_test.go
+++ b/pkg/graphengine/executor/coverage_test.go
@@ -16,10 +16,12 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	memory "k8s.io/client-go/discovery/cached/memory"
@@ -151,33 +153,78 @@ func TestRefName(t *testing.T) {
 	}
 }
 
-// TestDelete_UIDPrecondition exercises the UID-precondition and empty-UID skip:
-// a resource carrying a UID calls Client.Delete with a DeleteOptions UID precondition,
-// while a resource without a UID is skipped without calling Client.Delete.
+// TestDelete_UIDPrecondition pins the UID each Delete call is preconditioned
+// on (the recorded UID, or the LIVE UID for a verified UID-free entry) and the
+// UID-free GET outcomes that produce no Delete call: absent, Forbidden (skipped
+// without error), and a server error (surfaced for retry).
 func TestDelete_UIDPrecondition(t *testing.T) {
 	t.Parallel()
+	liveWithManager := func(manager string) *unstructured.Unstructured {
+		live := obj("cm")
+		live.SetNamespace("default")
+		live.SetUID("live-uid-42")
+		return withManagedFields(live, manager)
+	}
 	cases := []struct {
 		name       string
 		uid        string
+		live       *unstructured.Unstructured // canned live object returned by Get (nil → NotFound)
+		getErr     error                      // when set, Get fails with this error instead
+		wantErr    string
 		wantCalls  int
-		wantPrecon bool
+		wantPrecon string // UID expected in the Delete precondition
 	}{
-		{name: "with UID adds a precondition and calls delete", uid: "abc-123", wantCalls: 1, wantPrecon: true},
-		{name: "without UID skips delete call completely", uid: "", wantCalls: 0, wantPrecon: false},
+		{
+			name:       "with UID adds that UID as precondition and calls delete",
+			uid:        "abc-123",
+			wantCalls:  1,
+			wantPrecon: "abc-123",
+		},
+		{
+			name:       "without UID and live object owned by this Graph deletes with the LIVE uid precondition",
+			uid:        "",
+			live:       liveWithManager(templateFieldManager(testOwnerUID)),
+			wantCalls:  1,
+			wantPrecon: "live-uid-42",
+		},
+		{
+			name:      "without UID and no live object skips delete",
+			uid:       "",
+			live:      nil,
+			wantCalls: 0,
+		},
+		{
+			name:      "without UID and a Forbidden GET skips delete without error",
+			uid:       "",
+			getErr:    apierrors.NewForbidden(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}, "cm", fmt.Errorf("denied")),
+			wantCalls: 0,
+		},
+		{
+			name:      "without UID and a server-error GET is surfaced for retry",
+			uid:       "",
+			getErr:    apierrors.NewInternalError(fmt.Errorf("etcd unavailable")),
+			wantErr:   "get live object for UID-free inventory entry",
+			wantCalls: 0,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			rec := &recordingDeleteClient{}
+			rec := &recordingDeleteClient{live: tc.live, getErr: tc.getErr}
 			ex := NewSimple(rec)
-			err := ex.Delete(context.Background(), []expv1alpha1.ManagedResource{{
+			err := ex.Delete(context.Background(), testOwnerUID, []expv1alpha1.ManagedResource{{
 				NodeID: "n", APIVersion: "v1", Kind: "ConfigMap",
 				Namespace: "default", Name: "cm", UID: tc.uid,
 			}})
-			require.NoError(t, err)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Len(t, rec.opts, tc.wantCalls)
 			if tc.wantCalls > 0 {
-				assert.Equal(t, tc.wantPrecon, rec.hasPrecondition(0))
+				assert.Equal(t, tc.wantPrecon, rec.preconditionUID(0))
 			}
 		})
 	}
@@ -367,11 +414,15 @@ func nodeFromSpec(id string, spec *compiler.Node) *krotruntime.Node {
 	return rt.Node(id)
 }
 
-// recordingDeleteClient captures the DeleteOptions passed to each Delete so
-// the UID-precondition branch can be asserted without an envtest server.
+// recordingDeleteClient captures the DeleteOptions passed to each Delete. Get
+// serves the canned live object (NotFound when nil, or getErr when set) so the
+// UID-free path can be driven with hand-built managedFields, which the fake
+// client would strip.
 type recordingDeleteClient struct {
 	clientStub
-	opts [][]client.DeleteOption
+	live   *unstructured.Unstructured
+	getErr error
+	opts   [][]client.DeleteOption
 }
 
 func (r *recordingDeleteClient) Delete(_ context.Context, _ client.Object, opts ...client.DeleteOption) error {
@@ -379,16 +430,31 @@ func (r *recordingDeleteClient) Delete(_ context.Context, _ client.Object, opts 
 	return nil
 }
 
-// hasPrecondition reports whether the i-th captured Delete carried a UID
-// precondition.
-func (r *recordingDeleteClient) hasPrecondition(i int) bool {
+func (r *recordingDeleteClient) Get(_ context.Context, key client.ObjectKey, out client.Object, _ ...client.GetOption) error {
+	if r.getErr != nil {
+		return r.getErr
+	}
+	if r.live == nil {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
+	}
+	u, ok := out.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("recordingDeleteClient.Get: want *unstructured.Unstructured, got %T", out)
+	}
+	r.live.DeepCopyInto(u)
+	return nil
+}
+
+// preconditionUID returns the UID carried by the i-th captured Delete's
+// precondition, or "" when it carried none.
+func (r *recordingDeleteClient) preconditionUID(i int) string {
 	for _, o := range r.opts[i] {
 		do, ok := o.(*client.DeleteOptions)
 		if ok && do.Preconditions != nil && do.Preconditions.UID != nil {
-			return true
+			return string(*do.Preconditions.UID)
 		}
 	}
-	return false
+	return ""
 }
 
 // clientStub satisfies client.Client; only Delete is overridden by the

--- a/pkg/graphengine/executor/delete_teardown_test.go
+++ b/pkg/graphengine/executor/delete_teardown_test.go
@@ -1,0 +1,486 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
+)
+
+// resettableMapper is a meta.ResettableRESTMapper whose Reset is observable,
+// standing in for a deferred-discovery mapper.
+type resettableMapper struct {
+	meta.RESTMapper
+	resets int
+	// onReset is invoked on every Reset so the wrapping client can "heal".
+	onReset func()
+}
+
+func (m *resettableMapper) Reset() {
+	m.resets++
+	if m.onReset != nil {
+		m.onReset()
+	}
+}
+
+// noMatchClient fails Get/Delete with a raw *meta.NoKindMatchError until healed;
+// with healOnReset the mapper's Reset heals it (a stale mapper predating a
+// re-created CRD), otherwise the NoMatch persists (the CRD is gone).
+type noMatchClient struct {
+	client.Client
+	mapper      *resettableMapper
+	healOnReset bool
+	healed      bool
+	deletes     int
+	gets        int
+	// deleteErr, when set, replaces the NoMatch on Delete (any error class).
+	deleteErr error
+}
+
+func newNoMatchClient(t *testing.T, healOnReset bool) *noMatchClient {
+	t.Helper()
+	inner := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	c := &noMatchClient{Client: inner, healOnReset: healOnReset}
+	c.mapper = &resettableMapper{RESTMapper: inner.RESTMapper(), onReset: func() {
+		if c.healOnReset {
+			c.healed = true
+		}
+	}}
+	return c
+}
+
+func (c *noMatchClient) RESTMapper() meta.RESTMapper { return c.mapper }
+
+func (c *noMatchClient) noMatch(obj client.Object) error {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	return &meta.NoKindMatchError{GroupKind: gvk.GroupKind(), SearchedVersions: []string{gvk.Version}}
+}
+
+func (c *noMatchClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	c.deletes++
+	if c.deleteErr != nil {
+		return c.deleteErr
+	}
+	if !c.healed {
+		return c.noMatch(obj)
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func (c *noMatchClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.gets++
+	if !c.healed {
+		return c.noMatch(obj)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+// TestSimple_Delete_NoMatch pins the NoMatch handling: one mapper reset and one
+// retry, then a persistent NoMatch is "already gone" while a healed one deletes.
+func TestSimple_Delete_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	entryWithUID := func(name string) expv1alpha1.ManagedResource {
+		return expv1alpha1.ManagedResource{
+			NodeID: "w", APIVersion: "e2.test/v1", Kind: "Widget",
+			Namespace: "default", Name: name, UID: "uid-" + name,
+		}
+	}
+	entryNoUID := func(name string) expv1alpha1.ManagedResource {
+		mr := entryWithUID(name)
+		mr.UID = ""
+		return mr
+	}
+	seedLabelledCM := func(t *testing.T, c client.Client, name string) expv1alpha1.ManagedResource {
+		cm := &unstructured.Unstructured{}
+		cm.SetGroupVersionKind(configMapGVK)
+		cm.SetNamespace("default")
+		cm.SetName(name)
+		cm.SetUID(types.UID("uid-" + name))
+		cm.SetLabels(map[string]string{
+			metadata.InstanceIDLabel: string(testOwnerUID),
+			metadata.NodeIDLabel:     nodeIDTokenForPath("items"),
+		})
+		require.NoError(t, c.Create(context.Background(), cm))
+		return expv1alpha1.ManagedResource{
+			NodeID: "items", APIVersion: "v1", Kind: "ConfigMap",
+			Namespace: "default", Name: name,
+		}
+	}
+
+	cases := []struct {
+		name        string
+		healOnReset bool
+		deleteErr   error
+		seed        func(t *testing.T, c client.Client) []expv1alpha1.ManagedResource
+		wantErr     string
+		wantResets  int
+		wantDeletes int
+		wantGets    int
+		after       func(t *testing.T, c client.Client)
+	}{
+		{
+			name:        "persistent NoMatch on a UID entry is tolerated after one mapper refresh",
+			healOnReset: false,
+			seed: func(*testing.T, client.Client) []expv1alpha1.ManagedResource {
+				return []expv1alpha1.ManagedResource{entryWithUID("gone")}
+			},
+			wantResets:  1,
+			wantDeletes: 2, // first attempt + the post-refresh retry
+		},
+		{
+			name:        "NoMatch that heals after the mapper refresh is retried and deletes",
+			healOnReset: true,
+			seed: func(t *testing.T, c client.Client) []expv1alpha1.ManagedResource {
+				return []expv1alpha1.ManagedResource{newSeededCM(t, c, "revived", "default")}
+			},
+			wantResets:  1,
+			wantDeletes: 2,
+			after: func(t *testing.T, c client.Client) {
+				assertCMGone(t, c, "revived", "default")
+			},
+		},
+		{
+			name:        "persistent NoMatch on a UID-free entry's GET is tolerated without any delete",
+			healOnReset: false,
+			seed: func(*testing.T, client.Client) []expv1alpha1.ManagedResource {
+				return []expv1alpha1.ManagedResource{entryNoUID("gone")}
+			},
+			wantResets:  1,
+			wantGets:    2,
+			wantDeletes: 0,
+		},
+		{
+			name:        "NoMatch on a UID-free entry's GET that heals proceeds to verify and delete",
+			healOnReset: true,
+			seed: func(t *testing.T, c client.Client) []expv1alpha1.ManagedResource {
+				return []expv1alpha1.ManagedResource{seedLabelledCM(t, c, "member")}
+			},
+			wantResets:  1,
+			wantGets:    2,
+			wantDeletes: 1,
+			after: func(t *testing.T, c client.Client) {
+				assertCMGone(t, c, "member", "default")
+			},
+		},
+		{
+			name:      "a non-NoMatch error is neither retried nor tolerated, and later entries are still visited",
+			deleteErr: apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "cm", fmt.Errorf("denied")),
+			seed: func(*testing.T, client.Client) []expv1alpha1.ManagedResource {
+				return []expv1alpha1.ManagedResource{entryWithUID("first"), entryWithUID("second")}
+			},
+			wantErr:     "forbidden",
+			wantResets:  0,
+			wantDeletes: 2, // both entries attempted exactly once each, no retry
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cl := newNoMatchClient(t, tc.healOnReset)
+			cl.deleteErr = tc.deleteErr
+			resources := tc.seed(t, cl.Client)
+
+			err := NewSimple(cl).Delete(context.Background(), testOwnerUID, resources)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantResets, cl.mapper.resets, "mapper resets")
+			assert.Equal(t, tc.wantDeletes, cl.deletes, "Delete calls")
+			if tc.wantGets > 0 {
+				assert.Equal(t, tc.wantGets, cl.gets, "Get calls")
+			}
+			if tc.after != nil {
+				tc.after(t, cl.Client)
+			}
+		})
+	}
+}
+
+// TestOwnedByGraph pins the marker matrix a UID-free entry is verified against.
+func TestOwnedByGraph(t *testing.T) {
+	t.Parallel()
+	self := types.UID("graph-self")
+	peer := types.UID("graph-peer")
+	newCM := func(labels map[string]string, managers ...string) *unstructured.Unstructured {
+		o := obj("cm")
+		o.SetNamespace("default")
+		if labels != nil {
+			o.SetLabels(labels)
+		}
+		return withManagedFields(o, managers...)
+	}
+	memberLabels := func(uid types.UID, nodePath string) map[string]string {
+		return map[string]string{
+			metadata.InstanceIDLabel: string(uid),
+			metadata.NodeIDLabel:     nodeIDTokenForPath(nodePath),
+		}
+	}
+	legacyPerNode := templateFieldManagerPrefix + graphManagerSegment(self) + ".deadbeef"
+
+	cases := []struct {
+		name   string
+		live   *unstructured.Unstructured
+		owner  types.UID
+		nodeID string
+		want   bool
+	}{
+		{name: "nil object is never owned", live: nil, owner: self, nodeID: "n"},
+		{name: "empty owner UID verifies nothing", live: newCM(nil, templateFieldManager(self)), owner: "", nodeID: "n"},
+		{name: "no markers at all", live: newCM(nil), owner: self, nodeID: "n"},
+		{name: "own template manager", live: newCM(nil, templateFieldManager(self)), owner: self, nodeID: "n", want: true},
+		{name: "own template manager among other managers", live: newCM(nil, "kubectl-client-side-apply", FieldManager, templateFieldManager(self)), owner: self, nodeID: "n", want: true},
+		{name: "legacy per-node manager of the same Graph", live: newCM(nil, legacyPerNode), owner: self, nodeID: "n", want: true},
+		{name: "peer Graph's template manager", live: newCM(nil, templateFieldManager(peer)), owner: self, nodeID: "n"},
+		{name: "shared RGD field manager is not Graph ownership", live: newCM(nil, FieldManager), owner: self, nodeID: "n"},
+		{name: "non-kro manager", live: newCM(nil, "kubectl-client-side-apply"), owner: self, nodeID: "n"},
+		{name: "collection member labels match", live: newCM(memberLabels(self, "sub/items")), owner: self, nodeID: "sub/items", want: true},
+		{name: "collection member of a peer Graph", live: newCM(memberLabels(peer, "sub/items")), owner: self, nodeID: "sub/items"},
+		{name: "collection member of another node", live: newCM(memberLabels(self, "sub/other")), owner: self, nodeID: "sub/items"},
+		{name: "instance-id alone without node-id is not enough", live: newCM(map[string]string{metadata.InstanceIDLabel: string(self)}), owner: self, nodeID: "items"},
+		{name: "an entry without a node ID never matches an unlabelled node-id", live: newCM(map[string]string{metadata.InstanceIDLabel: string(self)}), owner: self, nodeID: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, ownedByGraph(tc.live, tc.owner, tc.nodeID))
+		})
+	}
+}
+
+// TestNodeIDTokenForPath_MatchesNodeIDToken pins that the token teardown derives
+// from a persisted NodeID equals the one the executor stamps through its frame.
+func TestNodeIDTokenForPath_MatchesNodeIDToken(t *testing.T) {
+	t.Parallel()
+	root := &Simple{}
+	child := &Simple{nodePrefix: "subA/subB/"}
+	assert.Equal(t, root.nodeIDToken("res"), nodeIDTokenForPath("res"))
+	assert.Equal(t, child.nodeIDToken("res"), nodeIDTokenForPath("subA/subB/res"))
+	long := &Simple{nodePrefix: "aVeryLongSubgraphNameThatKeepsGoing/andAnotherEquallyLongNestedFrame/"}
+	assert.Equal(t, long.nodeIDToken("someLeafNodeWithALongIdentifier"),
+		nodeIDTokenForPath("aVeryLongSubgraphNameThatKeepsGoing/andAnotherEquallyLongNestedFrame/someLeafNodeWithALongIdentifier"),
+		"the hashed fallback must agree too")
+}
+
+// TestSimple_Delete_UIDFreeEntries tears down an inventory of UID-free entries
+// against a real apiserver (real SSA managedFields, real UID preconditions):
+// objects this Graph applied are deleted, everything else named survives.
+func TestSimple_Delete_UIDFreeEntries(t *testing.T) {
+	cl := patchEnvClient(t)
+	ctx := context.Background()
+	ns := "default"
+	self := types.UID("uid-graph-teardown-self")
+	peer := types.UID("uid-graph-teardown-peer")
+
+	ssaCM := func(name, manager string) {
+		cm := &unstructured.Unstructured{}
+		cm.SetGroupVersionKind(configMapGVK)
+		cm.SetNamespace(ns)
+		cm.SetName(name)
+		require.NoError(t, unstructured.SetNestedField(cm.Object, "v", "data", "k"))
+		require.NoError(t, cl.Patch(ctx, cm, client.Apply, client.FieldOwner(manager)))
+	}
+	createCM := func(name string, labels map[string]string) {
+		cm := &unstructured.Unstructured{}
+		cm.SetGroupVersionKind(configMapGVK)
+		cm.SetNamespace(ns)
+		cm.SetName(name)
+		if labels != nil {
+			cm.SetLabels(labels)
+		}
+		require.NoError(t, cl.Create(ctx, cm))
+	}
+	memberLabels := func(uid types.UID, nodePath string) map[string]string {
+		return map[string]string{
+			metadata.InstanceIDLabel: string(uid),
+			metadata.NodeIDLabel:     nodeIDTokenForPath(nodePath),
+		}
+	}
+	entry := func(name, nodeID, uid string) expv1alpha1.ManagedResource {
+		return expv1alpha1.ManagedResource{
+			NodeID: nodeID, APIVersion: "v1", Kind: "ConfigMap",
+			Namespace: ns, Name: name, UID: uid,
+		}
+	}
+	exists := func(name string) bool {
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(configMapGVK)
+		err := cl.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, got)
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		require.NoError(t, err)
+		return true
+	}
+
+	// Objects this Graph applied: template manager, legacy per-node manager,
+	// stamped collection member.
+	ssaCM("wa-owned", TemplateFieldManager(self))
+	ssaCM("wa-legacy-owned", templateFieldManagerPrefix+graphManagerSegment(self)+".abcdef")
+	createCM("wa-member", memberLabels(self, "sub/items"))
+	// Objects this Graph must NOT touch.
+	createCM("wa-control", nil)
+	ssaCM("wa-peer", TemplateFieldManager(peer))
+	createCM("wa-peer-member", memberLabels(peer, "sub/items"))
+	createCM("wa-other-node-member", memberLabels(self, "sub/other"))
+	createCM("wa-impostor", nil)
+	require.True(t, hasFieldManager(getConfigMap(t, cl, ns, "wa-owned"), TemplateFieldManager(self)),
+		"precondition: SSA landed the Graph's template field manager")
+
+	err := NewSimple(cl).Delete(ctx, self, []expv1alpha1.ManagedResource{
+		entry("wa-owned", "owned", ""),
+		entry("wa-legacy-owned", "owned2", ""),
+		entry("wa-member", "sub/items", ""),
+		entry("wa-control", "owned", ""),
+		entry("wa-peer", "owned", ""),
+		entry("wa-peer-member", "sub/items", ""),
+		entry("wa-other-node-member", "sub/items", ""),
+		entry("wa-never-landed", "owned", ""),
+		// A stale recorded UID: the apiserver rejects the precondition (Conflict).
+		entry("wa-impostor", "owned", "00000000-stale-uid-0000"),
+	})
+	require.NoError(t, err, "no entry in this inventory is an error condition")
+
+	assert.False(t, exists("wa-owned"), "object under this Graph's template manager must be deleted")
+	assert.False(t, exists("wa-legacy-owned"), "object under this Graph's legacy per-node manager must be deleted")
+	assert.False(t, exists("wa-member"), "this Graph's collection member must be deleted")
+
+	assert.True(t, exists("wa-control"), "an unmarked object named by a UID-free entry must survive")
+	assert.True(t, exists("wa-peer"), "a peer Graph's object must survive")
+	assert.True(t, exists("wa-peer-member"), "a peer Graph's collection member must survive")
+	assert.True(t, exists("wa-other-node-member"), "another node's collection member must survive")
+	assert.True(t, exists("wa-impostor"), "a UID precondition mismatch must leave the live object alone")
+}
+
+// TestSimple_Delete_ColdMapperTreatsMissingTypeAsGone deletes the CRD behind an
+// inventory entry and tears down with a fresh client (cold lazy mapper), which
+// surfaces the missing mapping as a raw NoMatch; Delete must treat it as gone.
+func TestSimple_Delete_ColdMapperTreatsMissingTypeAsGone(t *testing.T) {
+	cl := patchEnvClient(t)
+	ctx := context.Background()
+	ns := "default"
+
+	const group = "teardown.test.kro.run"
+	gizmoGVK := schema.GroupVersionKind{Group: group, Version: "v1", Kind: "Gizmo"}
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "gizmos." + group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind: "Gizmo", ListKind: "GizmoList", Plural: "gizmos", Singular: "gizmo",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name: "v1", Served: true, Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec": {Type: "object", XPreserveUnknownFields: new(true)},
+						},
+					},
+				},
+			}},
+		},
+	}
+	require.NoError(t, cl.Create(ctx, crd))
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (bool, error) {
+		got := &apiextensionsv1.CustomResourceDefinition{}
+		if err := cl.Get(ctx, types.NamespacedName{Name: crd.Name}, got); err != nil {
+			return false, nil
+		}
+		for _, c := range got.Status.Conditions {
+			if c.Type == apiextensionsv1.Established && c.Status == apiextensionsv1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	}), "CRD must become Established")
+
+	gizmo := &unstructured.Unstructured{}
+	gizmo.SetGroupVersionKind(gizmoGVK)
+	gizmo.SetNamespace(ns)
+	gizmo.SetName("g1")
+	gizmo.Object["spec"] = map[string]any{"field": "val"}
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (bool, error) {
+		// Discovery of a freshly established CRD can lag by a moment.
+		err := cl.Create(ctx, gizmo)
+		return err == nil, nil
+	}), "Gizmo instance must be creatable once the CRD is served")
+	require.NotEmpty(t, gizmo.GetUID())
+	inventory := []expv1alpha1.ManagedResource{
+		{
+			NodeID: "gizmo", APIVersion: group + "/v1", Kind: "Gizmo",
+			Namespace: ns, Name: "g1", UID: string(gizmo.GetUID()),
+		},
+		{
+			NodeID: "gizmo", APIVersion: group + "/v1", Kind: "Gizmo",
+			Namespace: ns, Name: "g2",
+		},
+	}
+
+	require.NoError(t, cl.Delete(ctx, crd))
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := cl.Get(ctx, types.NamespacedName{Name: crd.Name}, &apiextensionsv1.CustomResourceDefinition{})
+		return apierrors.IsNotFound(err), nil
+	}), "CRD must be fully removed")
+
+	// A fresh client whose lazy mapper has never seen the group; poll until a
+	// direct Delete surfaces the raw NoMatch (discovery of the removal can lag).
+	scheme := k8sruntime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	var cold client.Client
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		fresh, err := client.New(patchEnvCfg, client.Options{Scheme: scheme})
+		if err != nil {
+			return false, err
+		}
+		probe := &unstructured.Unstructured{}
+		probe.SetGroupVersionKind(gizmoGVK)
+		probe.SetNamespace(ns)
+		probe.SetName("g1")
+		if err := fresh.Delete(ctx, probe); meta.IsNoMatchError(err) {
+			cold = fresh
+			return true, nil
+		}
+		return false, nil
+	}), "a cold mapper must report the removed type as NoMatch")
+
+	err := NewSimple(cold).Delete(ctx, types.UID("uid-graph-cold-mapper"), inventory)
+	require.NoError(t, err, "a resource type the cluster no longer serves must not wedge teardown")
+}

--- a/pkg/graphengine/executor/executor.go
+++ b/pkg/graphengine/executor/executor.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/runtime"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/watchrouter"
@@ -176,16 +178,22 @@ type Interface interface {
 	Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.Watcher) (ApplyResult, error)
 
 	// Delete removes the supplied managed resources from the cluster in
-	// the reverse of the slice's order. UID precondition is applied per
-	// entry so we never remove an impostor that replaced our resource
-	// out of band. NotFound is tolerated. Safe to call repeatedly.
+	// the reverse of the slice's order, on behalf of the Graph ownerUID.
+	// An entry with a recorded UID is deleted preconditioned on it; a
+	// UID-free (write-ahead) entry only if the live object carries
+	// ownerUID's ownership markers (template field manager, or the
+	// instance-id + node-id labels of a collection member), so a status
+	// entry naming another Graph's or a non-kro object never deletes it.
+	// NotFound, a UID mismatch, a type the cluster no longer serves, and a
+	// UID-free object this identity may not read are all "nothing to do".
+	// Safe to call repeatedly.
 	//
 	// Unlike Apply, Delete does not consult the runtime — it operates
 	// purely from the persisted tracking record. This means a Graph
 	// whose spec was edited (template renamed, forEach shrunk, node
 	// removed) can still be deleted cleanly: the record knows what was
 	// applied, regardless of what the current spec would re-derive.
-	Delete(ctx context.Context, resources []expv1alpha1.ManagedResource) error
+	Delete(ctx context.Context, ownerUID types.UID, resources []expv1alpha1.ManagedResource) error
 
 	// Release relinquishes the fields each Contribution's field manager
 	// owns on its target by server-side applying an object that carries

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -524,25 +524,15 @@ func publishScope(rt *runtime.Runtime, n *runtime.Node, objs []*unstructured.Uns
 	rt.Set(n.ID(), objs[0].Object)
 }
 
-// Delete removes resources in reverse of the supplied slice order so
-// dependents go before dependencies. Identity comes from the persisted
-// ManagedResources list — no re-resolve of the current spec, so a
-// Graph whose templates were renamed or whose forEach shrunk between
-// apply and delete still gets every prior resource removed.
-//
-// Legitimate managed resources always carry a UID captured from SSA.
-// Refuse to delete any entry with an empty UID to close the forged/UID-less
-// prune vector where a user-forged status entry could delete arbitrary resources.
-// NotFound and "already deleted by something else" are tolerated.
-func (s *Simple) Delete(ctx context.Context, resources []expv1alpha1.ManagedResource) error {
+// Delete implements Interface.Delete from the persisted ManagedResources list
+// alone (no re-resolve of the current spec), in reverse slice order so
+// dependents go before dependencies. A UID-free entry is resolved against the
+// live object first (verifyUIDFreeEntry). Failures other than the tolerated
+// "nothing to do" cases are aggregated and returned after the whole inventory
+// has been visited, so one denied delete does not strand the remaining entries.
+func (s *Simple) Delete(ctx context.Context, ownerUID types.UID, resources []expv1alpha1.ManagedResource) error {
 	var errs []error
 	for _, r := range slices.Backward(resources) {
-		// Legitimate managed resources always carry a UID captured from SSA.
-		// Refuse to delete any resource without a UID to close the forged/UID-less prune vector.
-		if r.UID == "" {
-			continue
-		}
-
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion(r.APIVersion)
 		obj.SetKind(r.Kind)
@@ -550,22 +540,19 @@ func (s *Simple) Delete(ctx context.Context, resources []expv1alpha1.ManagedReso
 		obj.SetName(r.Name)
 
 		uid := types.UID(r.UID)
-		opts := []client.DeleteOption{
-			&client.DeleteOptions{
-				Preconditions: &metav1.Preconditions{UID: &uid},
-			},
+		if uid == "" {
+			liveUID, owned, err := s.verifyUIDFreeEntry(ctx, ownerUID, r, obj)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("delete %s/%s %s: %w", r.APIVersion, r.Kind, refName(r), err))
+				continue
+			}
+			if !owned {
+				continue
+			}
+			uid = liveUID
 		}
 
-		if err := s.Client.Delete(ctx, obj, opts...); err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			// UID-precondition mismatch surfaces as Conflict — the
-			// resource we tracked is gone and a different object now
-			// occupies its identity. Not our problem; skip.
-			if apierrors.IsConflict(err) {
-				continue
-			}
+		if err := s.deletePreconditioned(ctx, obj, uid); err != nil {
 			// Accumulate and keep going: one denied/failed delete (e.g. an
 			// impersonated SA lacking delete RBAC on a single target) must not
 			// strand every remaining managed resource in the inventory. The
@@ -574,6 +561,106 @@ func (s *Simple) Delete(ctx context.Context, resources []expv1alpha1.ManagedReso
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// deletePreconditioned deletes obj preconditioned on uid. NotFound, Conflict
+// (the UID no longer matches: not ours to delete) and a NoMatch that survives a
+// mapper refresh (the type is gone, and its objects with it) return nil.
+func (s *Simple) deletePreconditioned(ctx context.Context, obj *unstructured.Unstructured, uid types.UID) error {
+	opts := []client.DeleteOption{
+		&client.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &uid},
+		},
+	}
+	err := s.retryOnNoMatch(func() error { return s.Client.Delete(ctx, obj, opts...) })
+	switch {
+	case err == nil, apierrors.IsNotFound(err), apierrors.IsConflict(err):
+		return nil
+	case meta.IsNoMatchError(err):
+		log.FromContext(ctx).V(1).Info("resource type is no longer served; treating managed resource as already deleted",
+			"gvk", obj.GroupVersionKind().String(), "object", client.ObjectKeyFromObject(obj).String())
+		return nil
+	}
+	return err
+}
+
+// retryOnNoMatch runs op once more after meta.MaybeResetRESTMapper when it
+// fails with a NoMatch, so a client with a resettable (deferred discovery)
+// mapper that predates a re-created CRD gets a fresh look instead of a
+// tolerated no-op. controller-runtime's lazy mapper has no Reset and already
+// reloads on the first NoMatch, so for it the retry is a no-op.
+func (s *Simple) retryOnNoMatch(op func() error) error {
+	err := op()
+	if err == nil || !meta.IsNoMatchError(err) {
+		return err
+	}
+	meta.MaybeResetRESTMapper(s.Client.RESTMapper())
+	return op()
+}
+
+// verifyUIDFreeEntry resolves a write-ahead (UID-free) entry against the live
+// object and returns its UID and whether this Graph may delete it
+// (ownedByGraph). An absent object, a type no longer served, an unmarked
+// object, or a Forbidden GET — an identity that cannot read a type cannot have
+// applied it — are "nothing to do" (false, nil); any other GET failure is
+// returned so the caller retries instead of dropping the entry.
+func (s *Simple) verifyUIDFreeEntry(ctx context.Context, ownerUID types.UID, r expv1alpha1.ManagedResource, obj *unstructured.Unstructured) (types.UID, bool, error) {
+	live := &unstructured.Unstructured{}
+	live.SetGroupVersionKind(obj.GroupVersionKind())
+	key := client.ObjectKeyFromObject(obj)
+	err := s.retryOnNoMatch(func() error { return s.Client.Get(ctx, key, live) })
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		if meta.IsNoMatchError(err) {
+			log.FromContext(ctx).V(1).Info("resource type is no longer served; treating UID-free managed-resource entry as already deleted",
+				"gvk", obj.GroupVersionKind().String(), "object", key.String())
+			return "", false, nil
+		}
+		if apierrors.IsForbidden(err) {
+			log.FromContext(ctx).Info("skipping UID-free managed-resource entry: identity may not read the live object, so it cannot have applied it",
+				"gvk", obj.GroupVersionKind().String(), "object", key.String(), "node", r.NodeID, "reason", err.Error())
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("get live object for UID-free inventory entry: %w", err)
+	}
+	if !ownedByGraph(live, ownerUID, r.NodeID) {
+		log.FromContext(ctx).Info("skipping UID-free managed-resource entry: live object carries no ownership marker of this Graph",
+			"gvk", obj.GroupVersionKind().String(), "object", key.String(), "node", r.NodeID)
+		return "", false, nil
+	}
+	// The live UID is the delete precondition that closes the check-then-delete race.
+	if live.GetUID() == "" {
+		log.FromContext(ctx).Info("skipping UID-free managed-resource entry: live object has no UID to precondition the delete on",
+			"gvk", obj.GroupVersionKind().String(), "object", key.String(), "node", r.NodeID)
+		return "", false, nil
+	}
+	return live.GetUID(), true, nil
+}
+
+// ownedByGraph reports whether live carries a marker this executor stamps when
+// the Graph ownerUID applies an object: a managedFields entry under the Graph's
+// template field manager (matched on the per-Graph segment so a legacy per-node
+// manager counts; the RGD path never writes one), or — for collection members —
+// the instance-id label equal to ownerUID plus the node-id label equal to the
+// entry's node token (stampKROMeta). An empty ownerUID or nodeID matches nothing.
+func ownedByGraph(live *unstructured.Unstructured, ownerUID types.UID, nodeID string) bool {
+	if live == nil || ownerUID == "" {
+		return false
+	}
+	selfGraph := graphManagerSegment(ownerUID)
+	for _, mf := range live.GetManagedFields() {
+		if seg := templateManagerGraphSegment(mf.Manager); seg != "" && seg == selfGraph {
+			return true
+		}
+	}
+	if nodeID == "" {
+		return false
+	}
+	labels := live.GetLabels()
+	return labels[metadata.InstanceIDLabel] == string(ownerUID) &&
+		labels[metadata.NodeIDLabel] == nodeIDTokenForPath(nodeID)
 }
 
 func refName(r expv1alpha1.ManagedResource) string {
@@ -1153,13 +1240,21 @@ func (s *Simple) qualifiedPath(id string) string {
 // costs debuggability. The selector is built from this same function, so it
 // matches the stamped label by construction.
 func (s *Simple) nodeIDToken(id string) string {
-	dotted := strings.ReplaceAll(s.qualifiedPath(id), "/", ".")
+	return nodeIDTokenForPath(s.qualifiedPath(id))
+}
+
+// nodeIDTokenForPath renders the kro.run/node-id label value for a qualified
+// node path (the '/'-form persisted in ManagedResource.NodeID). Teardown has no
+// executor frame, so ownedByGraph calls this directly; nodeIDToken delegates
+// here so the stamped label and the verified token cannot drift.
+func nodeIDTokenForPath(path string) string {
+	dotted := strings.ReplaceAll(path, "/", ".")
 	if len(dotted) <= validation.LabelValueMaxLength {
 		return dotted
 	}
 	// Fallback: "h-<40 hex>" of the '/'-form. The leading letter keeps the
 	// value a valid label (must start alphanumeric) and marks it as hashed.
-	sum := sha256.Sum256([]byte(s.qualifiedPath(id)))
+	sum := sha256.Sum256([]byte(path))
 	return "h-" + hex.EncodeToString(sum[:20])
 }
 
@@ -2021,6 +2116,13 @@ var ErrFieldManagerConflict = errors.New("executor: field owned by a foreign fie
 // silently reassigning ownership between Graphs.
 func templateFieldManager(parentUID types.UID) string {
 	return templateFieldManagerPrefix + graphManagerSegment(parentUID)
+}
+
+// TemplateFieldManager is the exported derivation of a Graph's template
+// field-manager identity (see templateFieldManager), for tests that stage
+// objects as this Graph would have applied them.
+func TemplateFieldManager(parentUID types.UID) string {
+	return templateFieldManager(parentUID)
 }
 
 // ownedByForeignGraphTemplate reports whether current carries a managedFields

--- a/pkg/graphengine/executor/simple_test.go
+++ b/pkg/graphengine/executor/simple_test.go
@@ -37,10 +37,14 @@ import (
 	krotruntime "github.com/kubernetes-sigs/kro/pkg/graphengine/runtime"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/watchrouter"
+	"github.com/kubernetes-sigs/kro/pkg/metadata"
 	testk8s "github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
 )
 
 var configMapGVK = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+
+// testOwnerUID is the Graph UID handed to Delete in tests.
+const testOwnerUID = types.UID("graph-uid-under-test")
 
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -359,7 +363,7 @@ func TestSimple_Delete(t *testing.T) {
 			},
 		},
 		{
-			name: "empty UID is skipped and does not delete pre-existing object",
+			name: "empty UID naming an unmarked object is skipped and does not delete it",
 			seed: func(t *testing.T, c client.Client) []expv1alpha1.ManagedResource {
 				cm := &unstructured.Unstructured{}
 				cm.SetGroupVersionKind(configMapGVK)
@@ -376,7 +380,32 @@ func TestSimple_Delete(t *testing.T) {
 				cm.SetGroupVersionKind(configMapGVK)
 				err := c.Get(context.Background(),
 					types.NamespacedName{Namespace: "default", Name: "victim"}, cm)
-				require.NoError(t, err, "victim must not be deleted when UID is empty")
+				require.NoError(t, err, "victim must not be deleted: UID-free entry, live object carries no ownership marker of this Graph")
+			},
+		},
+		{
+			// The fake client strips managedFields, so the collection-label
+			// marker is used here; the template-manager marker is covered by
+			// the envtest-backed TestSimple_Delete_UIDFreeEntries.
+			name: "empty UID naming an object stamped with this Graph's collection labels is deleted",
+			seed: func(t *testing.T, c client.Client) []expv1alpha1.ManagedResource {
+				cm := &unstructured.Unstructured{}
+				cm.SetGroupVersionKind(configMapGVK)
+				cm.SetName("write-ahead-item")
+				cm.SetNamespace("default")
+				cm.SetUID("uid-write-ahead-item") // the fake client assigns none; it is the delete precondition
+				cm.SetLabels(map[string]string{
+					metadata.InstanceIDLabel: string(testOwnerUID),
+					metadata.NodeIDLabel:     nodeIDTokenForPath("sub/items"),
+				})
+				require.NoError(t, c.Create(context.Background(), cm))
+				return []expv1alpha1.ManagedResource{{
+					NodeID: "sub/items", APIVersion: "v1", Kind: "ConfigMap",
+					Namespace: "default", Name: "write-ahead-item", UID: "",
+				}}
+			},
+			after: func(t *testing.T, c client.Client) {
+				assertCMGone(t, c, "write-ahead-item", "default")
 			},
 		},
 		{
@@ -400,7 +429,7 @@ func TestSimple_Delete(t *testing.T) {
 			cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
 			ex := NewSimple(cl)
 			resources := tc.seed(t, cl)
-			err := ex.Delete(context.Background(), resources)
+			err := ex.Delete(context.Background(), testOwnerUID, resources)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -462,7 +491,7 @@ func TestSimple_PropagatesClientError(t *testing.T) {
 				// Delete no longer needs the runtime; we hand it a
 				// single tracked entry so the underlying Client.Delete
 				// is actually called and surfaces the injected error.
-				return ex.Delete(context.Background(), []expv1alpha1.ManagedResource{{
+				return ex.Delete(context.Background(), testOwnerUID, []expv1alpha1.ManagedResource{{
 					NodeID: "n", APIVersion: "v1", Kind: "ConfigMap",
 					Namespace: "default", Name: "x", UID: "uid-x",
 				}})

--- a/test/integration/suites/core/graph_rgd_deletion_test.go
+++ b/test/integration/suites/core/graph_rgd_deletion_test.go
@@ -101,7 +101,6 @@ var _ = Describe("Graph RGD Deletion", func() {
 		if err != nil {
 			t.Fatalf("BuildRuntimeForInstance: %v", err)
 		}
-		_ = g
 
 		// ── 4. Apply ─────────────────────────────────────────────────────────────
 		exec := executor.NewSimple(env.Client)
@@ -199,7 +198,7 @@ var _ = Describe("Graph RGD Deletion", func() {
 		}
 
 		// ── 8. Execute Delete and verify both resources are gone from the cluster ─
-		if err := exec.Delete(ctx, applied); err != nil {
+		if err := exec.Delete(ctx, g.GetUID(), applied); err != nil {
 			t.Fatalf("executor.Delete: %v", err)
 		}
 

--- a/test/integration/suites/core/graph_teardown_test.go
+++ b/test/integration/suites/core/graph_teardown_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/executor"
+	"github.com/kubernetes-sigs/kro/test/integration/environment"
+)
+
+// Graph teardown must neither wedge on a resource type the cluster no longer
+// serves nor orphan children whose inventory entry never received a UID.
+var _ = Describe("Graph Teardown Safety", func() {
+	It("releases the finalizer after the CRD behind a managed resource was deleted", func(ctx SpecContext) {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+
+		group := fmt.Sprintf("teardown-%s.kro.run", rand.String(5))
+		kind := fmt.Sprintf("TdWidget%s", rand.String(5))
+		crd := installCRD(t, env, group, kind, "v0")
+		widgetGVK := schema.GroupVersionKind{Group: group, Version: "v1", Kind: kind}
+		widgetKey := types.NamespacedName{Namespace: ns, Name: "w"}
+
+		// The Widget reads an external ConfigMap ("gate"); deleting gate later
+		// makes the node Unresolved, so the inventory entry is preserved and the
+		// Widget is not re-created while its CRD is removed.
+		gate := &unstructured.Unstructured{}
+		gate.SetGroupVersionKind(configMapGVK)
+		gate.SetNamespace(ns)
+		gate.SetName("gate")
+		if err := unstructured.SetNestedField(gate.Object, "x", "data", "k"); err != nil {
+			t.Fatalf("set gate data: %v", err)
+		}
+		if err := env.Client.Create(ctx, gate); err != nil {
+			t.Fatalf("create gate: %v", err)
+		}
+
+		g := &expv1alpha1.Graph{
+			ObjectMeta: metav1.ObjectMeta{Name: "crd-gone", Namespace: ns},
+			Spec: expv1alpha1.GraphSpec{
+				Nodes: []expv1alpha1.Node{
+					{
+						ID: "gate",
+						Ref: &expv1alpha1.ExternalRef{
+							APIVersion: "v1",
+							Kind:       "ConfigMap",
+							Metadata:   expv1alpha1.ExternalRefMetadata{Name: "gate"},
+						},
+					},
+					{
+						ID: "w",
+						Template: environment.RawExt(t, map[string]any{
+							"apiVersion": group + "/v1",
+							"kind":       kind,
+							"metadata":   map[string]any{"name": "w"},
+							"spec":       map[string]any{"value": "${gate.data.k}"},
+						}),
+					},
+				},
+			},
+		}
+		env.CreateGraph(t, g)
+		graphKey := types.NamespacedName{Namespace: ns, Name: "crd-gone"}
+		env.AwaitCondition(t, graphKey, expv1alpha1.GraphConditionTypeReady, metav1.ConditionTrue, 30*time.Second)
+		env.AwaitObject(t, widgetGVK, widgetKey, nil, 15*time.Second)
+		environment.Eventually(t, 10*time.Second, 100*time.Millisecond, func() error {
+			got := env.GetGraph(t, graphKey)
+			if len(got.Status.ManagedResources) != 1 || got.Status.ManagedResources[0].UID == "" {
+				return fmt.Errorf("inventory not yet recorded with a UID: %+v", got.Status.ManagedResources)
+			}
+			return nil
+		})
+
+		if err := env.Client.Delete(ctx, gate); err != nil {
+			t.Fatalf("delete gate: %v", err)
+		}
+		env.AwaitCondition(t, graphKey, expv1alpha1.GraphConditionTypeReady, metav1.ConditionFalse, 30*time.Second)
+		if got := env.GetGraph(t, graphKey); len(got.Status.ManagedResources) != 1 {
+			t.Fatalf("inventory must be preserved while the node is unresolved, got %+v", got.Status.ManagedResources)
+		}
+
+		// Remove the CRD: delete the lone instance ourselves and drop the
+		// apiserver's cleanup finalizer, which starves under the shared control
+		// plane's CRD churn (as crd_test.go does).
+		w := &unstructured.Unstructured{}
+		w.SetGroupVersionKind(widgetGVK)
+		w.SetNamespace(ns)
+		w.SetName("w")
+		if err := env.Client.Delete(ctx, w); err != nil && !apierrors.IsNotFound(err) {
+			t.Fatalf("delete widget instance: %v", err)
+		}
+		env.AwaitDeleted(t, widgetGVK, widgetKey, 15*time.Second)
+		if err := env.Client.Delete(ctx, crd); err != nil {
+			t.Fatalf("delete CRD: %v", err)
+		}
+		unstickTerminatingCRD(ctx, crd.Name)
+		environment.Eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
+			err := env.Client.Get(ctx, types.NamespacedName{Name: crd.Name}, &apiextensionsv1.CustomResourceDefinition{})
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("CRD %s still present", crd.Name)
+		})
+
+		// The shared manager's mapper is warm, so the stale mapping 404s here; the
+		// cold-mapper NoMatch case is covered in the executor's envtest suite.
+		if err := env.Client.Delete(ctx, env.GetGraph(t, graphKey)); err != nil {
+			t.Fatalf("delete graph: %v", err)
+		}
+		env.AwaitGraphGone(t, graphKey, 30*time.Second)
+	})
+
+	It("tears down UID-free write-ahead entries only for objects it verifiably applied", func() {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+		ctx := env.Context()
+
+		// The template node reads a ConfigMap that never exists, so it stays
+		// Unresolved and the controller preserves staged inventory entries
+		// verbatim instead of repairing their UIDs.
+		g := &expv1alpha1.Graph{
+			ObjectMeta: metav1.ObjectMeta{Name: "write-ahead", Namespace: ns},
+			Spec: expv1alpha1.GraphSpec{
+				Nodes: []expv1alpha1.Node{
+					{
+						ID: "ext",
+						Ref: &expv1alpha1.ExternalRef{
+							APIVersion: "v1",
+							Kind:       "ConfigMap",
+							Metadata:   expv1alpha1.ExternalRefMetadata{Name: "never-created"},
+						},
+					},
+					{
+						ID: "owned",
+						Template: environment.RawExt(t, map[string]any{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata":   map[string]any{"name": "wa-owned"},
+							"data":       map[string]any{"v": "${ext.data.k}"},
+						}),
+					},
+				},
+			},
+		}
+		env.CreateGraph(t, g)
+		graphKey := types.NamespacedName{Namespace: ns, Name: "write-ahead"}
+		env.AwaitCondition(t, graphKey, expv1alpha1.GraphConditionTypeAccepted, metav1.ConditionTrue, 30*time.Second)
+		environment.Eventually(t, 15*time.Second, 100*time.Millisecond, func() error {
+			if got := env.GetGraph(t, graphKey); got.Status.AppliedServiceAccount == "" {
+				return fmt.Errorf("applied identity not yet recorded")
+			}
+			return nil
+		})
+		graphUID := env.GetGraph(t, graphKey).GetUID()
+
+		// Live objects: one under this Graph's template manager, one under a peer
+		// Graph's, one unmarked.
+		ssa := func(name, manager string) {
+			cm := &unstructured.Unstructured{}
+			cm.SetGroupVersionKind(configMapGVK)
+			cm.SetNamespace(ns)
+			cm.SetName(name)
+			if err := unstructured.SetNestedField(cm.Object, "v", "data", "k"); err != nil {
+				t.Fatalf("set data: %v", err)
+			}
+			if err := env.Client.Patch(ctx, cm, client.Apply, client.FieldOwner(manager)); err != nil {
+				t.Fatalf("ssa %s: %v", name, err)
+			}
+		}
+		ssa("wa-owned", executor.TemplateFieldManager(graphUID))
+		ssa("wa-peer", executor.TemplateFieldManager(types.UID("some-other-graph-uid")))
+		bystander := &unstructured.Unstructured{}
+		bystander.SetGroupVersionKind(configMapGVK)
+		bystander.SetNamespace(ns)
+		bystander.SetName("wa-bystander")
+		if err := env.Client.Create(ctx, bystander); err != nil {
+			t.Fatalf("create bystander: %v", err)
+		}
+
+		// UID-free entries for all three, under the Unresolved node's ID.
+		entry := func(name string) expv1alpha1.ManagedResource {
+			return expv1alpha1.ManagedResource{
+				NodeID: "owned", APIVersion: "v1", Kind: "ConfigMap", Namespace: ns, Name: name,
+			}
+		}
+		staged := []expv1alpha1.ManagedResource{entry("wa-owned"), entry("wa-peer"), entry("wa-bystander")}
+		stagedPersisted := func() error {
+			got := env.GetGraph(t, graphKey)
+			if len(got.Status.ManagedResources) != len(staged) {
+				return fmt.Errorf("staged inventory not in status: %+v", got.Status.ManagedResources)
+			}
+			for i, mr := range got.Status.ManagedResources {
+				if mr != staged[i] {
+					return fmt.Errorf("entry %d = %+v, want %+v", i, mr, staged[i])
+				}
+			}
+			return nil
+		}
+		// A reconcile in flight before the patch may overwrite it; re-stage until
+		// the entries survive a settling window.
+		environment.Eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
+			current := env.GetGraph(t, graphKey)
+			dc := current.DeepCopy()
+			dc.Status.ManagedResources = staged
+			if err := env.Client.Status().Patch(ctx, dc, client.MergeFrom(current)); err != nil {
+				return fmt.Errorf("stage status: %w", err)
+			}
+			deadline := time.Now().Add(1500 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				if err := stagedPersisted(); err != nil {
+					return err
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+			return nil
+		})
+
+		if err := env.Client.Delete(ctx, env.GetGraph(t, graphKey)); err != nil {
+			t.Fatalf("delete graph: %v", err)
+		}
+		env.AwaitGraphGone(t, graphKey, 30*time.Second)
+		env.AwaitDeleted(t, configMapGVK, types.NamespacedName{Namespace: ns, Name: "wa-owned"}, 15*time.Second)
+
+		for _, name := range []string{"wa-peer", "wa-bystander"} {
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"})
+			if err := env.Client.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, got); err != nil {
+				t.Fatalf("%s must survive teardown of a Graph that never applied it: %v", name, err)
+			}
+		}
+	})
+})

--- a/test/integration/suites/impersonation/confinement_test.go
+++ b/test/integration/suites/impersonation/confinement_test.go
@@ -56,8 +56,9 @@ import (
 // TestGraphImpersonationConfinement proves an impersonated ServiceAccount whose
 // RBAC forbids a write cannot apply the Graph's resource. It stands up its OWN
 // envtest (RBAC-enforcing), grants a limited SA read-only access to ConfigMaps,
-// then submits a Graph (as that SA) that tries to CREATE a ConfigMap. The apply
-// must be refused and the ConfigMap must never appear.
+// then submits a Graph (as that SA) that tries to CREATE a ConfigMap and a
+// Secret. The apply must be refused, the ConfigMap must never appear, and the
+// refused Graph must still be deletable under that same identity.
 func TestGraphImpersonationConfinement(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping envtest-backed confinement test in -short mode")
@@ -179,20 +180,32 @@ func TestGraphImpersonationConfinement(t *testing.T) {
 		t.Fatal("cache did not sync")
 	}
 
-	// A Graph naming the read-only SA that tries to CREATE a ConfigMap.
+	// A Graph naming the read-only SA that tries to CREATE a ConfigMap (a type
+	// the SA may read but not write) and a Secret (a type it may not even read).
 	g := &expv1alpha1.Graph{
 		ObjectMeta: metav1.ObjectMeta{Name: "confined", Namespace: ns},
 		Spec: expv1alpha1.GraphSpec{
 			ServiceAccountName: saName,
-			Nodes: []expv1alpha1.Node{{
-				ID: "cm",
-				Template: rawExt(t, map[string]any{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata":   map[string]any{"name": "forbidden-cm"},
-					"data":       map[string]any{"hello": "world"},
-				}),
-			}},
+			Nodes: []expv1alpha1.Node{
+				{
+					ID: "cm",
+					Template: rawExt(t, map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata":   map[string]any{"name": "forbidden-cm"},
+						"data":       map[string]any{"hello": "world"},
+					}),
+				},
+				{
+					ID: "secret",
+					Template: rawExt(t, map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]any{"name": "forbidden-secret"},
+						"stringData": map[string]any{"hello": "world"},
+					}),
+				},
+			},
 		},
 	}
 	if err := adminClient.Create(ctx, g); err != nil {
@@ -241,6 +254,36 @@ func TestGraphImpersonationConfinement(t *testing.T) {
 	}
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("unexpected error checking ConfigMap absence: %v", err)
+	}
+
+	// Teardown resolves the UID-free write-ahead entries as the SA: NotFound for
+	// the ConfigMap, Forbidden for the Secret. Neither may wedge the finalizer.
+	if err := adminClient.Delete(ctx, g); err != nil {
+		t.Fatalf("delete graph: %v", err)
+	}
+	deadline = time.Now().Add(30 * time.Second)
+	for {
+		err := adminClient.Get(ctx, key, &expv1alpha1.Graph{})
+		if apierrors.IsNotFound(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			got := &expv1alpha1.Graph{}
+			_ = adminClient.Get(ctx, key, got)
+			conds := make([]string, 0, len(got.Status.Conditions))
+			for _, c := range got.Status.Conditions {
+				reason, msg := "", ""
+				if c.Reason != nil {
+					reason = *c.Reason
+				}
+				if c.Message != nil {
+					msg = *c.Message
+				}
+				conds = append(conds, string(c.Type)+"="+string(c.Status)+"/"+reason+": "+msg)
+			}
+			t.Fatalf("Graph %s still present 30s after delete (finalizers=%v, conditions=%v)", key, got.Finalizers, conds)
+		}
+		time.Sleep(250 * time.Millisecond)
 	}
 
 	mgrCancel()


### PR DESCRIPTION
## Problem

Deleting a standalone Graph (`GraphKind`) runs `Simple.Delete` over `Status.ManagedResources` from the finalizer, and three cases went wrong there. A managed resource whose CRD had been removed wedged the finalizer forever once kro had restarted: the cold REST mapper surfaces the missing mapping as a raw `*meta.NoKindMatchError`, which `Delete` tolerated neither as NotFound nor as Conflict, so the Graph sat in `Terminating` with `DeleteFailed … no matches for kind` until the CRD was recreated.

The reconciler write-aheads UID-free inventory entries before Apply so a status write lost after Apply still leaves teardown something to delete — but `Delete` skipped every UID-free entry as an anti-forgery guard, so in exactly that crash window the finalizer came off and every child was orphaned (Graph children carry no `ownerReference`).

`Status.AppliedServiceAccount` was recorded only after a clean or soft not-ready apply. A hard failure that still created resources (a ConfigMap lands, a ClusterRole gets 403) persisted those entries with no identity, so after the user switched `spec.serviceAccountName` to a rights-less ServiceAccount and deleted, teardown ran as that ServiceAccount and wedged on `DeleteFailed … cannot delete resource "configmaps"`. The RGD/instance path never calls `executor.Delete` and is untouched.

## Fix

- `executor.Interface.Delete` gains an `ownerUID types.UID` parameter (the Graph UID); both controller call sites (teardown and prune) pass `g.GetUID()`.
- `Simple.Delete` / `deletePreconditioned`: a NoMatch that survives one mapper refresh (`retryOnNoMatch` — a no-op for controller-runtime's lazy mapper, which already reloads on the first miss; it matters for a resettable mapper) is treated as "already gone" alongside NotFound and Conflict, matching `Release`, `mappingFor` and the applyset prune path.
- `Simple.Delete` / `verifyUIDFreeEntry`: a UID-free entry is resolved against the live object and deleted, preconditioned on the live UID, only when `ownedByGraph` holds — the object's `managedFields` carry this Graph's template field manager (per-Graph segment, so a legacy per-node manager counts), or for collection members the `kro.run/instance-id` label equals the Graph UID and `kro.run/node-id` equals the entry's node token. An absent object, a type no longer served, an unmarked object, or a Forbidden GET (an identity that cannot read a type cannot have applied it) are skipped with an Info log; any other GET failure is returned so the reconcile retries. `TemplateFieldManager` is exported so tests can stage objects with the real marker.
- `reconcileGraph`: `Status.AppliedServiceAccount` is recorded whenever anything reached the cluster — clean, soft not-ready, or a hard failure with a non-empty `Applied`/`Contributions`; a hard failure that applied nothing keeps the last-good identity.
- Tests: executor unit and envtest tests for the NoMatch retry and the UID-free verification (real SSA `managedFields`, a cold lazy mapper against a deleted CRD); controller tests for the identity recording and the UID plumbing; two core integration specs (CRD removed then Graph deleted; staged UID-free inventory where only this Graph's child is deleted); the RBAC-enforcing impersonation suite now also deletes its refused Graph, whose inventory names a type the ServiceAccount may not read.

## Behaviour changes

- Teardown or prune of a managed resource whose CRD no longer exists releases the finalizer instead of reporting `DeleteFailed … no matches for kind` forever.
- A UID-free (write-ahead) inventory entry is deleted on teardown or prune when the live object verifiably belongs to the Graph; an entry naming an object without those markers, or one the Graph's ServiceAccount may not `get`, is still never deleted (now with an Info log). One GET per UID-free entry; entries with a recorded UID are unaffected.
- `Status.AppliedServiceAccount` is also written after a hard apply failure that landed at least one resource or patch contribution, so such a Graph is torn down under the identity that created its resources even if `spec.serviceAccountName` changed afterwards. The field remains a single scalar: after a mid-life ServiceAccount change the most recent identity that reached the cluster wins.
- Go API change, no CRD change: `executor.Interface.Delete(ctx, ownerUID, resources)`. The unit test "empty UID is skipped and does not delete pre-existing object" keeps its assertion under the name "empty UID naming an unmarked object is skipped and does not delete it"; `TestDelete_UIDPrecondition` now pins that a verified UID-free entry is deleted with the live UID as precondition instead of producing no Delete call.
