### PR TITLE
fix(graphengine): type dynamic-GVK collections as list(dyn), not any

### DIFF
--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -36,7 +36,7 @@ type EnvOption func(*envOptions)
 // envOptions holds all the configuration for the CEL environment.
 type envOptions struct {
 	// resourceIDs will be converted to CEL variable declarations
-	// of type 'any'.
+	// of type 'dyn'.
 	resourceIDs []string
 	// typedResources maps resource names to their OpenAPI schemas.
 	// These will be converted to typed CEL variables with field-level
@@ -72,7 +72,10 @@ func WithRuntimeLibrary(enabled bool) EnvOption {
 	}
 }
 
-// WithResourceIDs adds resource ids that will be declared as CEL variables.
+// WithResourceIDs adds resource ids that will be declared as untyped (`dyn`)
+// CEL variables. They must be `dyn`, not `any`: the checker treats both as
+// wildcards for assignability and field access, but rejects `any` as a
+// comprehension range, so `x.map(...)` over an `any` identifier fails to compile.
 func WithResourceIDs(ids []string) EnvOption {
 	return func(opts *envOptions) {
 		opts.resourceIDs = append(opts.resourceIDs, ids...)
@@ -98,9 +101,9 @@ func WithTypedResources(schemas map[string]*spec.Schema) EnvOption {
 	}
 }
 
-// WithListVariables adds list-typed variable declarations to the CEL environment.
-// Used for collection resources so they support list operations/macros like all()
-// exists(), filter(), and map() etc...
+// WithListVariables adds list(dyn) variable declarations to the CEL environment.
+// Used for collection resources without an element schema so they support list
+// operations/macros like all(), exists(), filter(), and map().
 func WithListVariables(names []string) EnvOption {
 	return func(opts *envOptions) {
 		for _, name := range names {
@@ -270,7 +273,7 @@ func defaultEnvironment(options ...EnvOption) (*cel.Env, *DeclTypeProvider, erro
 	}
 
 	for _, name := range opts.resourceIDs {
-		declarations = append(declarations, cel.Variable(name, cel.AnyType))
+		declarations = append(declarations, cel.Variable(name, cel.DynType))
 	}
 
 	env, err := base.Extend(declarations...)
@@ -300,7 +303,8 @@ func TypedEnvironmentWithProvider(schemas map[string]*spec.Schema, options ...En
 // TypedEnvironmentWithIDsAndProvider builds the typed CEL environment with
 // the supplied typed resources, additionally declaring the given identifiers
 // as untyped (dyn) variables. Useful when some identifiers carry no schema
-// but must still resolve at type-check time.
+// but must still resolve at type-check time. Schemaless collections should be
+// passed via WithListVariables instead so they type as list(dyn).
 func TypedEnvironmentWithIDsAndProvider(schemas map[string]*spec.Schema, dynIDs []string, options ...EnvOption) (*cel.Env, *DeclTypeProvider, error) {
 	opts := append([]EnvOption{WithTypedResources(schemas), WithResourceIDs(dynIDs)}, options...)
 	return defaultEnvironment(opts...)

--- a/pkg/cel/environment_test.go
+++ b/pkg/cel/environment_test.go
@@ -341,6 +341,57 @@ func TestTypedEnvironmentWithIDsAndProvider(t *testing.T) {
 	assert.Error(t, issues.Err())
 }
 
+// TestWithResourceIDs_DeclaresDyn pins that WithResourceIDs declares dyn, not
+// any: the checker rejects any as a comprehension range, so x.map(...) over an
+// any-declared identifier would not compile even when the runtime value is a list.
+func TestWithResourceIDs_DeclaresDyn(t *testing.T) {
+	env, err := DefaultEnvironment(WithResourceIDs([]string{"x"}), WithRuntimeLibrary(false))
+	require.NoError(t, err)
+
+	checked, issues := env.Compile("x")
+	require.NoError(t, issues.Err())
+	assert.True(t, checked.OutputType().IsExactType(cel.DynType), "got %s", checked.OutputType())
+
+	for _, expr := range []string{
+		"x.map(i, i.name)",
+		"x.filter(i, i.enabled).size()",
+		"x.all(i, has(i.name))",
+		"x.exists(i, i == 'a')",
+		"x.metadata.name",
+		"x[0].name",
+		"size(x)",
+	} {
+		t.Run(expr, func(t *testing.T) {
+			_, issues := env.Compile(expr)
+			assert.NoError(t, issues.Err())
+		})
+	}
+
+	ast, issues := env.Compile("x.map(i, i.name).join(',')")
+	require.NoError(t, issues.Err())
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+	out, _, err := prg.Eval(map[string]any{"x": []any{
+		map[string]any{"name": "a"},
+		map[string]any{"name": "b"},
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, "a,b", out.Value())
+
+	t.Run("any is rejected as a comprehension range", func(t *testing.T) {
+		anyEnv, err := DefaultEnvironment(
+			WithCustomDeclarations([]cel.EnvOption{cel.Variable("y", cel.AnyType)}),
+			WithRuntimeLibrary(false),
+		)
+		require.NoError(t, err)
+		_, issues := anyEnv.Compile("y.metadata.name")
+		require.NoError(t, issues.Err())
+		_, issues = anyEnv.Compile("y.map(i, i.name)")
+		require.Error(t, issues.Err())
+		assert.Contains(t, issues.Err().Error(), "cannot be range of a comprehension")
+	})
+}
+
 func TestBaseEnv_Extend_PreservesLibraries(t *testing.T) {
 	// Verify that extending the cached base env still has all libraries available
 	env, err := DefaultEnvironment(

--- a/pkg/graphengine/compiler/compiler.go
+++ b/pkg/graphengine/compiler/compiler.go
@@ -374,24 +374,15 @@ func (ctx *CompilationContext) compileFrame(apiNodes []expv1alpha1.Node, isRoot 
 
 	// Def nodes contribute inferred schemas to celSchemas (set in buildNode),
 	// so the typed env knows `${naming.prefix}` down to its field type.
-	//
-	// Three kinds of identifier are declared dyn rather than typed: dynamic-
-	// GVK templates and subgraph nodes (local, no published schema), plus all
-	// captured ancestor IDs (the cross-frame seam). Within-frame typed
-	// references stay fully checked; the rest type-check permissively.
-	dynIDs := make([]string, 0, len(ancestors)+len(nodes))
-	dynIDs = append(dynIDs, ancestors...)
-	for id, n := range nodes {
-		if n.Kind == NodeKindPatch {
-			continue
-		}
-		if _, ok := celSchemas[id]; !ok {
-			dynIDs = append(dynIDs, id)
-		}
-	}
+	// Schemaless identifiers (dynamic-GVK nodes, subgraph nodes, captured
+	// ancestors) are declared dyn or list(dyn); see schemalessIdentifiers.
+	// Within-frame typed references stay fully checked; the rest type-check
+	// permissively.
+	dynIDs, dynListIDs := schemalessIdentifiers(nodes, celSchemas, ancestors)
 	typedEnv, typeProvider, err := krocel.TypedEnvironmentWithIDsAndProvider(
 		celSchemas,
 		dynIDs,
+		krocel.WithListVariables(dynListIDs),
 		krocel.WithRuntimeLibrary(false),
 	)
 	if err != nil {
@@ -426,6 +417,28 @@ func (ctx *CompilationContext) compileFrame(apiNodes []expv1alpha1.Node, isRoot 
 	emitSchemaDependencies(prog)
 	captured = dedupe(captured)
 	return prog, captured, nil
+}
+
+// schemalessIdentifiers partitions the identifiers with no celSchemas entry:
+// collections are declared list(dyn) (the []any the executor publishes, so forEach
+// and comprehensions type-check); ancestors and other nodes dyn. Patches are skipped.
+func schemalessIdentifiers(nodes map[string]*Node, celSchemas map[string]*spec.Schema, ancestors []string) (dynIDs, dynListIDs []string) {
+	dynIDs = make([]string, 0, len(ancestors)+len(nodes))
+	dynIDs = append(dynIDs, ancestors...)
+	for id, n := range nodes {
+		if n.Kind == NodeKindPatch {
+			continue
+		}
+		if _, typed := celSchemas[id]; typed {
+			continue
+		}
+		if n.IsCollection() {
+			dynListIDs = append(dynListIDs, id)
+			continue
+		}
+		dynIDs = append(dynIDs, id)
+	}
+	return dynIDs, dynListIDs
 }
 
 // buildSubgraphNode compiles a nested Graph node. The child compiles in a

--- a/pkg/graphengine/compiler/compiler_test.go
+++ b/pkg/graphengine/compiler/compiler_test.go
@@ -1178,6 +1178,196 @@ func TestCompile_DynamicRef(t *testing.T) {
 	})
 }
 
+// TestCompile_DynamicRefCollectionTyping pins the CEL types of schemaless
+// identifiers: a dynamic-GVK collection is list(dyn) and a dynamic single ref
+// is dyn, so forEach, comprehensions and bare references compile as documented.
+func TestCompile_DynamicRefCollectionTyping(t *testing.T) {
+	t.Parallel()
+
+	// A static ref to a CRD object plus a dynamic selector ref over that CRD's
+	// instances (the fake CRD schema exposes spec.version, not spec.versions[]).
+	withCRDAndInstances := func(extra ...generator.GraphOption) *expv1alpha1.Graph {
+		return generator.NewGraph("g", append([]generator.GraphOption{
+			generator.WithNamespace("default"),
+			generator.WithRef("crd", &expv1alpha1.ExternalRef{
+				APIVersion: "apiextensions.k8s.io/v1",
+				Kind:       "CustomResourceDefinition",
+				Metadata:   expv1alpha1.ExternalRefMetadata{Name: "widgets.example.com"},
+			}),
+			generator.WithRef("insts", &expv1alpha1.ExternalRef{
+				APIVersion: "${crd.spec.group + '/' + crd.spec.version}",
+				Kind:       "${crd.spec.names.kind}",
+				Metadata: expv1alpha1.ExternalRefMetadata{
+					Selector: runtime.RawExtension{Raw: []byte(`{}`)},
+				},
+			}),
+		}, extra...)...)
+	}
+
+	t.Run("forEach over a dynamic collection ref compiles", func(t *testing.T) {
+		t.Parallel()
+		g := withCRDAndInstances(
+			generator.WithTemplate("cms", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${w.metadata.name}-x"},
+				"data":     map[string]any{"kind": "${w.kind}"},
+			}, generator.ForEachDim("w", "${insts}")),
+		)
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+		cms := prog.Nodes["cms"]
+		require.NotNil(t, cms)
+		assert.Contains(t, cms.HardDepIDs(), "insts")
+		require.Len(t, cms.ForEach, 1)
+		assert.NotNil(t, cms.ForEach[0].Expression.Program)
+	})
+
+	t.Run("comprehensions over a dynamic collection ref compile", func(t *testing.T) {
+		t.Parallel()
+		g := withCRDAndInstances(
+			generator.WithTemplate("summary", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "summary"},
+				"data": map[string]any{
+					"names":    "${insts.map(x, x.metadata.name).join(',')}",
+					"labelled": "${string(insts.filter(x, has(x.metadata.labels)).size())}",
+					"allNamed": "${string(insts.all(x, has(x.metadata.name)))}",
+					"anyReady": "${string(insts.exists(x, x.status.ready == true))}",
+				},
+			}),
+			generator.WithDef("derived", map[string]any{
+				"names": "${insts.map(x, x.metadata.name)}",
+				"count": "${insts.filter(x, has(x.metadata.labels)).size()}",
+			}),
+		)
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+		assert.Contains(t, prog.Nodes["summary"].HardDepIDs(), "insts")
+		assert.Contains(t, prog.Nodes["derived"].HardDepIDs(), "insts")
+	})
+
+	t.Run("size, indexing and dyn() wrapping keep working", func(t *testing.T) {
+		t.Parallel()
+		g := withCRDAndInstances(
+			generator.WithTemplate("cms", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${w.metadata.name}-x"},
+			}, generator.ForEachDim("w", "${dyn(insts)}")),
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "cm"},
+				"data": map[string]any{
+					"count": "${string(size(insts))}",
+					"first": "${insts[0].metadata.name}",
+					"names": "${dyn(insts).map(x, x.metadata.name).join(',')}",
+				},
+			}),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+	})
+
+	t.Run("a dynamic collection is a list, not a bool or a string", func(t *testing.T) {
+		t.Parallel()
+		_, err := newTestCompiler(t).Compile(withCRDAndInstances(
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "cm"},
+			}),
+			generator.WithIncludeWhen("${insts}"),
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must return bool, got list(dyn)")
+
+		_, err = newTestCompiler(t).Compile(withCRDAndInstances(
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "cm"},
+				"data":     map[string]any{"bad": "${insts}"},
+			}),
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `returns "list(dyn)" but expected "string"`)
+	})
+
+	t.Run("a dynamic non-collection ref is dyn: bare reference and field access compile", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithNamespace("default"),
+			generator.WithDef("crd", map[string]any{"group": "example.com"}),
+			generator.WithRef("target", &expv1alpha1.ExternalRef{
+				APIVersion: "${crd.group}/v1",
+				Kind:       "Widget",
+				Metadata:   expv1alpha1.ExternalRefMetadata{Name: "w"},
+			}),
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${target.metadata.name}-cm"},
+				"data": map[string]any{
+					"whole": "${target}",
+					"items": "${target.spec.items.map(i, i.name).join(',')}",
+					"ns":    "${has(target.metadata.namespace) ? target.metadata.namespace : 'none'}",
+				},
+			}),
+			// A bare dyn is accepted where a bool is expected (checked at runtime).
+			generator.WithIncludeWhen("${target}"),
+			generator.WithTemplate("per", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${target.metadata.name}-${i.name}"},
+			}, generator.ForEachDim("i", "${target.spec.items}")),
+		)
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+		assert.False(t, prog.Nodes["target"].IsCollection())
+		assert.Contains(t, prog.Nodes["cm"].HardDepIDs(), "target")
+		assert.Contains(t, prog.Nodes["per"].HardDepIDs(), "target")
+	})
+
+	t.Run("a dynamic forEach template is list(dyn) for downstream nodes", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithNamespace("default"),
+			generator.WithDef("cfg", map[string]any{"group": "example.com/v1", "names": []any{"a", "b"}}),
+			generator.WithTemplate("widgets", map[string]any{
+				"apiVersion": "${cfg.group}",
+				"kind":       "Widget",
+				"metadata":   map[string]any{"name": "${n}"},
+			}, generator.ForEachDim("n", "${cfg.names}")),
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "cm"},
+				"data":     map[string]any{"names": "${widgets.map(w, w.metadata.name).join(',')}"},
+			}),
+		)
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+		assert.True(t, prog.Nodes["widgets"].DynamicGVK)
+		assert.Contains(t, prog.Nodes["cm"].HardDepIDs(), "widgets")
+	})
+
+	t.Run("a subgraph forEach over a captured parent collection compiles", func(t *testing.T) {
+		t.Parallel()
+		child := generator.NewGraph("child",
+			generator.WithTemplate("cm", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${w.metadata.name}-child"},
+			}, generator.ForEachDim("w", "${insts}")),
+			generator.WithDef("names", map[string]any{
+				"all": "${insts.map(x, x.metadata.name)}",
+			}),
+		)
+		g := withCRDAndInstances(generator.WithSubgraph("sub", child))
+		prog, err := newTestCompiler(t).Compile(g)
+		require.NoError(t, err)
+		sub := prog.Nodes["sub"]
+		require.NotNil(t, sub)
+		require.NotNil(t, sub.SubProgram)
+		assert.Contains(t, sub.HardDepIDs(), "insts")
+		require.NotNil(t, sub.SubProgram.Nodes["cm"])
+		require.Len(t, sub.SubProgram.Nodes["cm"].ForEach, 1)
+	})
+}
+
 func TestCompile_WithSoftDependencies(t *testing.T) {
 	t.Parallel()
 	g := generator.NewGraph("g",

--- a/pkg/graphengine/compiler/context.go
+++ b/pkg/graphengine/compiler/context.go
@@ -435,14 +435,14 @@ func validatePatchPayload(payload map[string]any) error {
 	return nil
 }
 
-// buildDynamicNode compiles a Template or Patch whose apiVersion or kind is
-// a CEL expression. There is no compile-time GVK, so we skip schema
+// buildDynamicNode compiles a Template, Ref, or Patch whose apiVersion or kind
+// is a CEL expression. There is no compile-time GVK, so we skip schema
 // resolution and REST mapping, parse the payload schemaless, and mark the
 // node dynamic. metadata is still required (payloads are authored) and
 // apiVersion/kind must be non-empty strings, but the version segment isn't
 // validated — it isn't a literal version yet. The node publishes no schema
-// (nil), so downstream references see it as dyn until the executor pins the
-// GVK.
+// (nil), so downstream references see it as dyn (list(dyn) for a collection)
+// until the executor pins the GVK.
 func (ctx *CompilationContext) buildDynamicNode(
 	n *expv1alpha1.Node,
 	order int,

--- a/pkg/graphengine/executor/dynamic_ref_test.go
+++ b/pkg/graphengine/executor/dynamic_ref_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	memory "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -166,5 +167,71 @@ func TestSimple_Apply_DynamicRef(t *testing.T) {
 		assert.ErrorIs(t, err, errSchemaNotReady)
 		assert.Contains(t, res.Unresolved, "coll")
 		assert.Empty(t, res.Applied)
+	})
+
+	t.Run("dynamic selector ref feeds a forEach template and comprehensions", func(t *testing.T) {
+		t.Parallel()
+		// The collection is declared list(dyn) at compile time and published as
+		// a []any at runtime, so forEach fans out per matched object and
+		// coll.map(...) / size(coll) evaluate against the same list.
+		g := generator.NewGraph("g",
+			generator.WithNamespace("default"),
+			generator.WithDef("crd", map[string]any{"kind": "ConfigMap"}),
+			generator.WithRef("coll", &expv1alpha1.ExternalRef{
+				APIVersion: "v1",
+				Kind:       "${crd.kind}",
+				Metadata: expv1alpha1.ExternalRefMetadata{
+					Namespace: "default",
+					Selector:  runtime.RawExtension{Raw: []byte(`{"matchLabels":{"tier":"db"}}`)},
+				},
+			}),
+			generator.WithTemplate("fanout", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${w.metadata.name}-copy"},
+				"data":     map[string]any{"from": "${w.data.k}"},
+			}, generator.ForEachDim("w", "${coll}")),
+			generator.WithTemplate("summary", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "summary"},
+				"data": map[string]any{
+					"names": "${coll.map(c, c.metadata.name).join(',')}",
+					"count": "${string(size(coll))}",
+				},
+			}),
+		)
+		rt := compileAndBuild(t, g)
+		cl := fake.NewClientBuilder().WithScheme(newScheme(t)).WithRESTMapper(rm).
+			WithObjects(seedCM("db-a", "db"), seedCM("db-b", "db"), seedCM("web", "web")).Build()
+
+		res, err := NewSimple(cl).Apply(context.Background(), rt, watchrouter.NoopWatcher{})
+		require.NoError(t, err)
+		assert.Empty(t, res.Unresolved)
+
+		// One copy per matched object (the web ConfigMap is not selected) plus
+		// the summary — and nothing for the read-only collection itself.
+		applied := map[string]bool{}
+		for _, mr := range res.Applied {
+			applied[mr.NodeID+"/"+mr.Name] = true
+		}
+		assert.Equal(t, map[string]bool{
+			"fanout/db-a-copy": true,
+			"fanout/db-b-copy": true,
+			"summary/summary":  true,
+		}, applied)
+
+		get := func(name string) *unstructured.Unstructured {
+			t.Helper()
+			obj := &unstructured.Unstructured{}
+			obj.SetAPIVersion("v1")
+			obj.SetKind("ConfigMap")
+			require.NoError(t, cl.Get(context.Background(),
+				types.NamespacedName{Namespace: "default", Name: name}, obj), "missing %q", name)
+			return obj
+		}
+		assert.Equal(t, "db-a", get("db-a-copy").Object["data"].(map[string]any)["from"])
+		assert.Equal(t, "db-b", get("db-b-copy").Object["data"].(map[string]any)["from"])
+		summary := get("summary").Object["data"].(map[string]any)
+		assert.Equal(t, "db-a,db-b", summary["names"])
+		assert.Equal(t, "2", summary["count"])
 	})
 }

--- a/pkg/graphengine/rgdadapter/status.go
+++ b/pkg/graphengine/rgdadapter/status.go
@@ -296,10 +296,9 @@ func unmarshalStatusRaw(rgd *v1alpha1.ResourceGraphDefinition) (map[string]any, 
 // than a compile-time undeclared-reference error.
 //
 // Collection nodes (forEach templates, selector externalRefs) are declared
-// as list(dyn) rather than the scalar `any` type, so status
-// expressions that range over them — filter / map / sortBy — type-check
-// (CEL rejects `any` as a comprehension range; it must be list, map, or
-// dyn). Scalar nodes stay `any`, matching the schemaless projection contract.
+// as list(dyn) so status expressions that range over them — filter / map /
+// sortBy — type-check against a list. Scalar nodes are declared dyn,
+// matching the schemaless projection contract.
 func buildStatusEnvForNodes(rt *runtime.Runtime, includeRuntime bool) (*cel.Env, error) {
 	nodes := rt.Nodes()
 	scalarIDs := make([]string, 0, len(nodes))

--- a/test/integration/suites/core/graph_dynamic_collection_test.go
+++ b/test/integration/suites/core/graph_dynamic_collection_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/test/integration/environment"
+)
+
+// Graph Dynamic Collection covers the graph.md "Dynamic GVKs" pattern: a static
+// ref to a CRD object, a dynamic-GVK selector ref over that CRD's instances, and
+// a forEach template plus comprehensions over that schemaless collection.
+var _ = Describe("Graph Dynamic Collection", func() {
+	It("fans a forEach template out over a dynamic-GVK selector ref", func() {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+		ctx := env.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		// A CRD under a unique group so parallel specs never collide; the
+		// Graph discovers its instances' GVK from the CRD object itself.
+		group := fmt.Sprintf("dyncoll-%s.example.com", rand.String(5))
+		kind := fmt.Sprintf("Widget%s", rand.String(5))
+		crd := installCRD(t, env, group, kind, "dyncoll")
+		instanceGVK := schema.GroupVersionKind{Group: group, Version: "v1", Kind: kind}
+
+		createInstance := func(name, value string) {
+			t.Helper()
+			inst := &unstructured.Unstructured{}
+			inst.SetGroupVersionKind(instanceGVK)
+			inst.SetName(name)
+			inst.SetNamespace(ns)
+			if err := unstructured.SetNestedField(inst.Object, value, "spec", "value"); err != nil {
+				t.Fatalf("set spec.value on %s: %v", name, err)
+			}
+			if err := env.Client.Create(ctx, inst); err != nil {
+				t.Fatalf("create %s instance %s: %v", kind, name, err)
+			}
+			t.Cleanup(func() { _ = env.Client.Delete(context.Background(), inst) })
+		}
+		createInstance("alpha", "one")
+		createInstance("beta", "two")
+
+		g := &expv1alpha1.Graph{
+			ObjectMeta: metav1.ObjectMeta{Name: "dyncoll", Namespace: ns},
+			Spec: expv1alpha1.GraphSpec{
+				Nodes: []expv1alpha1.Node{
+					{
+						// Static ref: the CRD object, typed against the
+						// apiextensions.k8s.io/v1 schema.
+						ID: "crd",
+						Ref: &expv1alpha1.ExternalRef{
+							APIVersion: "apiextensions.k8s.io/v1",
+							Kind:       "CustomResourceDefinition",
+							Metadata:   expv1alpha1.ExternalRefMetadata{Name: crd.Name},
+						},
+					},
+					{
+						// Dynamic-GVK selector ref: a read-only collection of the
+						// CRD's instances whose GVK is only known at reconcile time.
+						ID: "insts",
+						Ref: &expv1alpha1.ExternalRef{
+							APIVersion: "${crd.spec.group + '/' + crd.spec.versions[0].name}",
+							Kind:       "${crd.spec.names.kind}",
+							Metadata: expv1alpha1.ExternalRefMetadata{
+								Namespace: ns,
+								Selector:  runtime.RawExtension{Raw: []byte(`{}`)},
+							},
+						},
+					},
+					{
+						// forEach directly over the dynamic collection: one
+						// ConfigMap per instance, reading the instance's fields.
+						ID:      "cms",
+						ForEach: []expv1alpha1.ForEachDimension{{"w": "${insts}"}},
+						Template: environment.RawExt(t, map[string]any{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata":   map[string]any{"name": "${w.metadata.name}-cm"},
+							"data":       map[string]any{"value": "${w.spec.value}"},
+						}),
+					},
+					{
+						// Comprehensions and size() over the same collection.
+						ID: "summary",
+						Template: environment.RawExt(t, map[string]any{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata":   map[string]any{"name": "summary"},
+							"data": map[string]any{
+								"count": "${string(size(insts))}",
+								"names": "${insts.map(x, x.metadata.name).join(',')}",
+								"twos":  "${string(insts.filter(x, x.spec.value == 'two').size())}",
+							},
+						}),
+					},
+				},
+			},
+		}
+		env.CreateGraph(t, g)
+
+		graphKey := types.NamespacedName{Namespace: ns, Name: "dyncoll"}
+		env.AwaitCondition(t, graphKey, expv1alpha1.GraphConditionTypeAccepted, metav1.ConditionTrue, 20*time.Second)
+		env.AwaitCondition(t, graphKey, expv1alpha1.GraphConditionTypeReady, metav1.ConditionTrue, 30*time.Second)
+
+		awaitConfigMaps := func(want []string) {
+			t.Helper()
+			environment.Eventually(t, 20*time.Second, 200*time.Millisecond, func() error {
+				got, err := listConfigMapNames(env, ns)
+				if err != nil {
+					return err
+				}
+				if !sliceEqual(got, want) {
+					return fmt.Errorf("ConfigMap names=%v want %v", got, want)
+				}
+				return nil
+			})
+		}
+		awaitConfigMaps([]string{"alpha-cm", "beta-cm", "summary"})
+
+		// Per-instance fan-out read the instance's own spec.
+		env.AwaitObject(t, configMapGVK, types.NamespacedName{Namespace: ns, Name: "alpha-cm"}, func(u *unstructured.Unstructured) error {
+			if v, _, _ := unstructured.NestedString(u.Object, "data", "value"); v != "one" {
+				return fmt.Errorf("alpha-cm.data.value=%q want one", v)
+			}
+			return nil
+		}, 10*time.Second)
+		env.AwaitObject(t, configMapGVK, types.NamespacedName{Namespace: ns, Name: "beta-cm"}, func(u *unstructured.Unstructured) error {
+			if v, _, _ := unstructured.NestedString(u.Object, "data", "value"); v != "two" {
+				return fmt.Errorf("beta-cm.data.value=%q want two", v)
+			}
+			return nil
+		}, 10*time.Second)
+
+		// The comprehensions ranged over the listed instances.
+		env.AwaitObject(t, configMapGVK, types.NamespacedName{Namespace: ns, Name: "summary"}, func(u *unstructured.Unstructured) error {
+			count, _, _ := unstructured.NestedString(u.Object, "data", "count")
+			names, _, _ := unstructured.NestedString(u.Object, "data", "names")
+			twos, _, _ := unstructured.NestedString(u.Object, "data", "twos")
+			gotNames := strings.Split(names, ",")
+			sort.Strings(gotNames)
+			if count != "2" || twos != "1" || !sliceEqual(gotNames, []string{"alpha", "beta"}) {
+				return fmt.Errorf("summary data count=%q twos=%q names=%q", count, twos, names)
+			}
+			return nil
+		}, 10*time.Second)
+
+		// A new matching instance re-enqueues the Graph and extends the fan-out.
+		createInstance("gamma", "three")
+		awaitConfigMaps([]string{"alpha-cm", "beta-cm", "gamma-cm", "summary"})
+		env.AwaitObject(t, configMapGVK, types.NamespacedName{Namespace: ns, Name: "summary"}, func(u *unstructured.Unstructured) error {
+			if count, _, _ := unstructured.NestedString(u.Object, "data", "count"); count != "3" {
+				return fmt.Errorf("summary.data.count=%q want 3", count)
+			}
+			return nil
+		}, 20*time.Second)
+	})
+})


### PR DESCRIPTION
## Problem

A Graph `ref:` whose `apiVersion`/`kind` is a CEL expression and that carries `metadata.selector` (the graph.md "Dynamic GVKs" collection pattern) has no compile-time schema, so the compiler declared it through `krocel.WithResourceIDs`, which emitted an opaque `any` (`google.protobuf.Any`) variable despite its doc promising `dyn`. cel-go treats `any` like `dyn` for field selection, indexing and assignability but rejects it as a comprehension range, and kro's forEach check accepts only a list or `dyn`. So `forEach: [{w: ${insts}}]` failed with `Accepted=False: forEach "w" must return a list, got "google.protobuf.Any"` and `${insts.map(...)}` / `.filter` / `.all` / `.exists` with `expression of type 'any' cannot be range of a comprehension`, while `size(insts)`, `insts[0].metadata.name` and the `${dyn(insts)}` workaround compiled. Captured ancestor IDs got the same declaration, so a subgraph `forEach` over a parent collection was rejected too. `examples/graph/rgd.yaml`'s L1 Graph uses exactly this pattern, but it is a stamped child Graph that `TestExamplesGraphCompile` never compiles.

The pre-rewrite engine (`7458023`) is not a comparison point: `metadata.ExtractGVKFromUnstructured` and schema resolution rejected any `${` in `apiVersion`/`kind`, so dynamic GVKs did not exist, and `WithResourceIDs` only fed the parse-only inspector environment.

## Fix

- `pkg/cel/environment.go`: `WithResourceIDs` declares `cel.DynType` instead of `cel.AnyType`, as its doc already said. The compiler and legacy RGD-builder inspector environments only parse, so nothing changes there, and the legacy builder type-checks against `TypedEnvironmentWithProvider`, so the set of RGD expressions accepted at RGD validation is unchanged. The RGD adapter's per-reconcile `status.conditions` environment (`rgdadapter/status.go`) now lets a comprehension range over a bare scalar node id, but that is unreachable for any RGD that reaches `Active`: the legacy builder type-checks the same expressions against the typed environment first and rejects them.
- `pkg/graphengine/compiler/compiler.go`: `compileFrame` partitions schemaless identifiers via `schemalessIdentifiers`: dynamic-GVK collections (selector refs, forEach templates) are declared `list(dyn)` through `krocel.WithListVariables` — the `[]any` the executor publishes — while dynamic single templates/refs, subgraph nodes and captured ancestors stay `dyn`; Patch nodes are skipped as before. The helper is extracted because inlining it pushes `compileFrame` over the `gocyclo` limit. `TestCompile_DynamicRefCollectionTyping` pins forEach, comprehensions and subgraph captures over a dynamic collection, that a bare collection is still rejected where a bool or string is expected, and that a bare dynamic single ref compiles in `includeWhen` and in a typed field.
- Doc corrections in `compiler/context.go` (`buildDynamicNode` also compiles Refs; a collection is `list(dyn)`) and `rgdadapter/status.go` (scalar nodes are `dyn`).
- New executor test (dynamic selector ref feeding a forEach template and comprehensions against a fake client) and envtest Graph spec (static CRD ref → dynamic selector ref → forEach ConfigMaps + summary, then a third instance appears).

## Behaviour changes

- Graphs (including RGD-adapter Graphs) that reference a dynamic-GVK collection in `forEach` or in a comprehension now compile and converge; previously `Accepted=False`. `${dyn(insts)}` keeps working.
- A bare dynamic collection reference is precisely typed: `includeWhen: ["${insts}"]` is rejected with `must return bool, got list(dyn)` and `${insts}` in a string field with `returns "list(dyn)" but expected "string"` (same outcome as before, clearer message).
- A bare dynamic non-collection identifier (single dynamic ref/template, subgraph node, captured ancestor) is `dyn`: `includeWhen: ["${target}"]` now passes compilation and fails at runtime with `includeWhen "target" returned map[string]interface {}, want bool` where it used to fail compilation, and `${target}` into a typed field passes the structural check. This is the documented intent of the cross-frame `dyn` seam.
- No RGD-validation change; no existing test was modified or removed.
