### PR TITLE
fix(graphengine): report patch field conflicts as FieldManagerConflict; reject readyWhen on patch nodes

### DIFF
--- a/docs/design/proposals/graph.md
+++ b/docs/design/proposals/graph.md
@@ -1,6 +1,6 @@
 # KREP-024: Graph
 
-> **Implementation status (as of v1alpha1):** This proposal document has been partially reconciled with the shipped implementation in `pkg/graphengine/` and `pkg/controller/graph/`. Key architectural differences from earlier drafts — including unified `ref:` for collections (superseding `watch:`), explicit `graph:` subgraph nodes, the raw-manifest `patch:` API (a `Patch *runtime.RawExtension` field authored exactly like `template:` — no `PatchSpec` wrapper, no `subresource`/`body` fields, no `forEach`; the target endpoint is derived from field presence, see `api/v1alpha1/graph_types.go:208`), collection expansion caps (`MaxCollectionSize`), and the `Accepted`/`ResourcesConverged`/`Ready` condition model — are reflected below. Note also that RGD is no longer a sibling engine: the RGD controller now unconditionally routes through the graph engine (it issues `GraphRevision` objects and serves compiled graphs through the shared runtime; see `pkg/controller/resourcegraphdefinition/controller_reconcile.go`). Features marked as "Planned" or "Not yet implemented" (such as KREP-006 `propagateWhen` and lifecycle signals) remain future work. Remaining design claims may still drift.
+> **Implementation status (as of v1alpha1):** This proposal document has been partially reconciled with the shipped implementation in `pkg/graphengine/` and `pkg/controller/graph/`. Key architectural differences from earlier drafts — including unified `ref:` for collections (superseding `watch:`), explicit `graph:` subgraph nodes, the raw-manifest `patch:` API (a `Patch *runtime.RawExtension` field authored exactly like `template:` — no `PatchSpec` wrapper, no `subresource`/`body` fields; `forEach` and `includeWhen` are supported, `readyWhen` is not; the target endpoint is derived from field presence, see `api/v1alpha1/graph_types.go:208`), collection expansion caps (`MaxCollectionSize`), and the `Accepted`/`ResourcesConverged`/`Ready` condition model — are reflected below. Note also that RGD is no longer a sibling engine: the RGD controller now unconditionally routes through the graph engine (it issues `GraphRevision` objects and serves compiled graphs through the shared runtime; see `pkg/controller/resourcegraphdefinition/controller_reconcile.go`). Features marked as "Planned" or "Not yet implemented" (such as KREP-006 `propagateWhen` and lifecycle signals) remain future work. Remaining design claims may still drift.
 
 ## Summary
 
@@ -159,7 +159,17 @@ presence**:
   endpoints. If a resource needs both, split into two patch nodes.
 - The scale subresource is not supported.
 
-Note that `forEach` is not supported on patch nodes.
+`forEach` is supported on patch nodes: the same contribution is fanned out across every rendered
+target, and every iterator must appear in the rendered `metadata.name`. `includeWhen` is supported.
+`readyWhen` is **not** supported on patch nodes and is rejected at compile time (`Accepted=False`): a
+patch publishes no value into scope, so there is nothing for a readyWhen to evaluate against. To wait
+for the target's state, add a `ref:` node for the target and put the `readyWhen` on that node.
+
+A main-resource patch is cooperative (see [Application & Field Management](#evaluation-model-and-compilation-cache)):
+when a contributed field is owned by another field manager — a human using `kubectl`, another
+controller, or a peer Graph — the contribution is refused rather than force-stolen, and the Graph
+reports `ResourcesConverged=False` with reason `FieldManagerConflict` naming the target and the
+contending manager. The contested field keeps the other owner's value until that owner releases it.
 
 ```yaml
 - id: instanceStatus
@@ -242,13 +252,13 @@ Node modifiers provide conditional logic, health checking, and repetition. In th
 
 - `forEach`: Supported on `template`, `def`, and `patch` nodes. On `template`/`def` it stamps one instance per element (or cartesian product across multiple dimensions); on `patch` it fans the same contribution out across every rendered target (each must resolve to a distinct name). Explicitly rejected on `graph` and `ref` nodes.
 - `includeWhen`: Supported on `template`, `ref`, `def`, and `patch` nodes. When false, the node is skipped (and template resources are pruned). The skip is contagious — nodes depending on a skipped node are skipped too, rather than erroring on the missing reference. Rejected on `graph` nodes.
-- `readyWhen`: Supported on `template`, `ref`, `def`, and `patch` nodes. Evaluated against scope to determine whether the node is ready. Rejected on `graph` nodes.
+- `readyWhen`: Supported on `template`, `ref`, and `def` nodes. Evaluated against scope to determine whether the node is ready. Rejected on `graph` nodes and on `patch` nodes (a patch publishes no value into scope, so there is nothing for readyWhen to evaluate; wait on the target's state through a `ref` node carrying the readyWhen instead).
 - `propagateWhen`: Planned / Not yet implemented (deferred to KREP-006).
 
 | Modifier        | Supported Node Types             | Question it answers       | When false                           | Status / Defined in  |
 | --------------- | -------------------------------- | ------------------------- | ------------------------------------ | -------------------- |
 | `includeWhen`   | `template`, `ref`, `def`, `patch`| Should this node exist?   | Prune — resource deleted / skipped   | Shipped (KREP-008)   |
-| `readyWhen`     | `template`, `ref`, `def`, `patch`| Is this node healthy?     | Signal only — Graph not Ready        | Shipped (from RGD)   |
+| `readyWhen`     | `template`, `ref`, `def`         | Is this node healthy?     | Signal only — Graph not Ready        | Shipped (from RGD)   |
 | `forEach`       | `template`, `def`, `patch`       | How many instances?       | N/A (expands node)                   | Shipped (KREP-002)   |
 | `propagateWhen` | (Planned)                        | May this node mutate now? | Freeze — last-applied state persists | Planned (KREP-006)   |
 
@@ -312,9 +322,9 @@ Reconciliation proceeds in topological order derived from hard dependency edges:
 2. **Evaluation & Scope:** A node evaluates as soon as its hard dependencies are in scope — meaning they have been applied and their observed state is available from the cluster. Nodes do not wait for upstream dependencies to pass `readyWhen`.
 3. **Application & Field Management:**
    - `template:` nodes apply their desired manifest via Server-Side Apply (SSA). On the RGD/instance path the shared field manager `kro.run/applyset` is used with force ownership. On the standalone Graph path a **per-Graph** field manager `kro-graphengine.tmpl.<graphSegment>` (e.g. `kro-graphengine.tmpl.d2ba416cfd76`, where `<graphSegment>` is derived from the Graph UID) is used **without** force so the API server reports a field-level conflict. Note the manager is keyed on the Graph UID **only**, not the node: every node of one Graph shares a single template manager, so ownership stays stable across a node rename (SSA narrows the manager's field set instead of orphaning the retired node's fields). The peer-vs-drift decision reads the 409's own conflict causes: a field owned by a _peer Graph's_ template manager is never stolen (the node is held soft not-ready), while external drift (a human or another controller) is reclaimed with force. Two nodes of the same Graph can never legitimately co-own one object — the identity-claim guard rejects that before any write — so there is no same-Graph self-conflict case.
-   - `patch:` nodes apply contributed fields under a dedicated per-node field manager (`kro-graphengine.patch.<graph>.<node>`). Force behavior **differs by target endpoint** (`pkg/graphengine/executor/simple.go:1495` `contributeApply`):
-     - A **status-subresource** patch (a top-level `status:` field) always applies **with** force ownership (`client.ForceOwnership`, `simple.go:1497`). Status writeback must reclaim status fields from a legacy `Update`-manager takeover (the pre-SSA controller wrote status via `Update`, which leaves fields owned by the `before-first-apply`/manager-update identity); without force the first status apply would 409 forever. SSA scopes the force to only the fields this manager sets.
-     - A **main-resource** patch (`spec:`, `data:`, `metadata.labels`/`annotations`, etc.) applies **without** force (`simple.go:1499`), so the API server reports a field-level 409 rather than silently stealing a field owned by a human, another controller, or a peer Graph — the caller surfaces that as soft not-ready. The one exception is a conflict with this Graph's own stale patch identity (a re-keyed node, or a legacy pre-segment manager), which is force-reclaimed since unforced it would deadlock forever.
+   - `patch:` nodes apply contributed fields under a dedicated per-node field manager (`kro-graphengine.patch.<graph>.<node>`). Force behavior **differs by target endpoint** (`contributeApply` in `pkg/graphengine/executor/simple.go`):
+     - A **status-subresource** patch (a top-level `status:` field) always applies **with** force ownership (`client.ForceOwnership`). Status writeback must reclaim status fields from a legacy `Update`-manager takeover (the pre-SSA controller wrote status via `Update`, which leaves fields owned by the `before-first-apply`/manager-update identity); without force the first status apply would 409 forever. SSA scopes the force to only the fields this manager sets.
+     - A **main-resource** patch (`spec:`, `data:`, `metadata.labels`/`annotations`, etc.) applies **without** force, so the API server reports a field-level 409 rather than silently stealing a field owned by a human, another controller, or a peer Graph — the caller surfaces that as soft not-ready under the distinct `FieldManagerConflict` reason (not `WaitingForReadiness`: nothing was applied, and nothing will be until the other owner releases the field). The one exception is a conflict with this Graph's own stale patch identity (a re-keyed node, or a legacy pre-segment manager), which is force-reclaimed since unforced it would deadlock forever.
    - The ownership implication: a status patch will _take over_ status fields another manager currently owns, while a main-resource patch is cooperative and will not. On delete or prune, releasing a contribution applies an empty object under that manager to relinquish field ownership without deleting the target object.
 4. **Reconciliation Parallelism:** Within a single Graph, nodes evaluate serially in topological order; collection instances evaluate in bounded parallel (default ApplyConcurrency=20). Across Graphs, reconciliation is fully parallel via controller-runtime's work queue.
 
@@ -401,6 +411,7 @@ A Graph object exposes three standard conditions managed by the controller:
   - Status `True` with reason `Applied` ("all nodes applied and ready").
   - Status `False` with reason `WaitingForReadiness` when apply succeeded but `readyWhen` expressions evaluate false.
   - Status `False` with reason `DataPending` when a node's CEL expression references data the cluster has not surfaced yet (e.g. pending status fields).
+  - Status `False` with reason `FieldManagerConflict` when a field a node wants to write is owned by another field manager that kro refuses to steal: a main-resource `patch:` contribution whose target field is owned by a human (`kubectl`), another controller, or a peer Graph, or a `template:` object owned by a peer Graph's template manager. Nothing was applied to the contested field; the message names the target and the contending manager. This reason takes precedence over `WaitingForReadiness`/`DataPending` from other nodes. The Graph is requeued with backoff and converges once the other owner releases the field.
   - Status `False` with reason `ApplyFailed` when the executor encounters a hard error applying resources.
 - **`Ready`** (`kro.run/v1alpha1` `GraphConditionTypeReady`): Root aggregate condition rolled up from `Accepted` and `ResourcesConverged`.
   - Status `True` when both `Accepted` and `ResourcesConverged` are `True`.
@@ -414,6 +425,7 @@ A Graph object exposes three standard conditions managed by the controller:
 | `ResourcesConverged` | True    | `Applied`            | All nodes applied and ready                  |
 | `ResourcesConverged` | False   | `WaitingForReadiness`| Applied, but readyWhen conditions not yet met|
 | `ResourcesConverged` | False   | `DataPending`        | Waiting for upstream cluster data in scope   |
+| `ResourcesConverged` | False   | `FieldManagerConflict`| A patch/template field is owned by another manager; not applied |
 | `ResourcesConverged` | False   | `ApplyFailed`        | Hard failure during resource apply           |
 | `Ready`              | True    | `Ready`              | All dependent conditions True (graph ready)  |
 | `Ready`              | False   | _(from dependent)_   | Spec invalid or apply failed                 |
@@ -487,7 +499,7 @@ scoping — e.g. short-lived/bound tokens and caller-credential propagation — 
 | KREP                            | Relationship                                                                                                                                                             |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | KREP-001 (Status Conditions)    | System conditions (`Accepted`, `ResourcesConverged`, `Ready`) exist on Graph objects — never on user resources. Users define their own status via `patch:` nodes.       |
-| KREP-002 (Collections)          | Adopted with safety limits (`MaxCollectionSize = 1000`, `MaxCollectionDimensions = 10`). Supported on `template` and `def` nodes.                                      |
+| KREP-002 (Collections)          | Adopted with safety limits (`MaxCollectionSize = 1000`, `MaxCollectionDimensions = 10`). Supported on `template`, `def`, and `patch` nodes.                              |
 | KREP-003 (Decorators)           | A Decorator is naturally a Graph with `ref:` (selector) + `forEach`. No special runtime support needed.                                                                  |
 | KREP-006 (Propagation Control)  | Planned / Not yet implemented: `propagateWhen` gating and lifecycle signals (`.ready()`, `.updated()`) are deferred to KREP-006 and not yet implemented in the engine. |
 | KREP-008 (includeWhen)          | Graph implements `includeWhen` as a first-class modifier across `template`, `ref`, `def`, and `patch` nodes. Dependency inference works naturally.                      |

--- a/pkg/controller/graph/controller.go
+++ b/pkg/controller/graph/controller.go
@@ -361,12 +361,14 @@ func (r *Reconciler) reconcileGraph(ctx context.Context, g *expv1alpha1.Graph) e
 		marker.ResourcesConverged()
 	case errors.Is(applyErr, executor.ErrNotReady):
 		watcher.Done(true)
-		// Distinguish the two not-ready flavors so principals can tell
-		// "apply succeeded, cluster still settling" from "upstream data
-		// isn't visible yet, can't even resolve dependents."
-		if errors.Is(applyErr, krotruntime.ErrDataPending) {
+		// Distinguish the not-ready flavors: an ownership conflict (nothing
+		// applied), missing upstream data, or apply succeeded but still settling.
+		switch {
+		case errors.Is(applyErr, executor.ErrFieldManagerConflict):
+			marker.ResourcesFieldManagerConflict(applyErr.Error())
+		case errors.Is(applyErr, krotruntime.ErrDataPending):
 			marker.ResourcesDataPending(applyErr.Error())
-		} else {
+		default:
 			marker.ResourcesNotReady(applyErr.Error())
 		}
 	default:
@@ -852,6 +854,14 @@ func (m *ConditionsMarker) ResourcesNotReady(msg string) {
 // resolution gap.
 func (m *ConditionsMarker) ResourcesDataPending(msg string) {
 	m.cs.SetFalse(ResourcesConverged, "DataPending", msg)
+}
+
+// ResourcesFieldManagerConflict marks ResourcesConverged=False with reason
+// "FieldManagerConflict" — a field a node wants to write is owned by another
+// field manager that kro refuses to steal. Distinct from WaitingForReadiness
+// because nothing was applied and nothing will be until that owner releases it.
+func (m *ConditionsMarker) ResourcesFieldManagerConflict(msg string) {
+	m.cs.SetFalse(ResourcesConverged, "FieldManagerConflict", msg)
 }
 
 // ResourcesApplyFailed marks ResourcesConverged=False with reason

--- a/pkg/controller/graph/controller_test.go
+++ b/pkg/controller/graph/controller_test.go
@@ -692,6 +692,17 @@ func TestConditionsMarker(t *testing.T) {
 			wantReason:  "Compiled",
 			msgContains: "1",
 		},
+		{
+			name: "ResourcesFieldManagerConflict drives Ready false even with Accepted true",
+			apply: func(m *ConditionsMarker) {
+				m.GraphCompiled(1)
+				m.ResourcesFieldManagerConflict("field owned by kubectl")
+			},
+			wantAcc:     metav1.ConditionTrue,
+			wantReady:   metav1.ConditionFalse,
+			wantReason:  "Compiled",
+			msgContains: "1",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/controller/graph/coverage_test.go
+++ b/pkg/controller/graph/coverage_test.go
@@ -20,6 +20,7 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -92,10 +93,11 @@ func TestUpdateStatusGenerationGuard(t *testing.T) {
 }
 
 // TestReconcileResourcesDataPendingCondition asserts the reconciler
-// distinguishes the two soft-error flavors via reason — DataPending
-// for unresolved CEL refs, WaitingForReadiness for readyWhen=false.
+// distinguishes the soft-error flavors via reason — DataPending for
+// unresolved CEL refs, WaitingForReadiness for readyWhen=false,
+// FieldManagerConflict for a field owned by another manager.
 // The error message reaching the marker decides which reason fires;
-// errors.Is must traverse the fmt.Errorf wrapping chain.
+// errors.Is must traverse the fmt.Errorf (and errors.Join) wrapping chain.
 func TestReconcileResourcesDataPendingCondition(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -111,6 +113,17 @@ func TestReconcileResourcesDataPendingCondition(t *testing.T) {
 			name:       "waiting-for-readiness-routes-to-WaitingForReadiness",
 			applyErr:   fmt.Errorf("apply %q: %w (%w)", "n", krotruntime.ErrWaitingForReadiness, executor.ErrNotReady),
 			wantReason: "WaitingForReadiness",
+		},
+		{
+			// A forEach patch joins per-target soft errors; one conflicting target
+			// is enough for the dedicated reason.
+			name: "field-manager-conflict-routes-to-FieldManagerConflict",
+			applyErr: fmt.Errorf("apply %q (patch): %w", "p", errors.Join(
+				fmt.Errorf("patch target ConfigMap %q not found: %w", "default/a", executor.ErrNotReady),
+				fmt.Errorf("patch field conflict on ConfigMap %q: conflict with %q: .data.k (%w) (%w)",
+					"default/b", "kubectl", executor.ErrFieldManagerConflict, executor.ErrNotReady),
+			)),
+			wantReason: "FieldManagerConflict",
 		},
 	}
 

--- a/pkg/controller/instance/controller_graph_engine.go
+++ b/pkg/controller/instance/controller_graph_engine.go
@@ -221,6 +221,10 @@ func (c *Controller) reconcileViaGraphEngine(
 		} else {
 			mark.ResourcesDeleting("%v", applyErr)
 		}
+	case errors.Is(applyErr, executor.ErrNotReady) && errors.Is(applyErr, executor.ErrFieldManagerConflict):
+		// Soft like any not-ready node, but the message must say the field is
+		// owned by another manager (the instance markers have no dedicated reason).
+		mark.ResourcesNotReady("field manager conflict: %v", applyErr)
 	case errors.Is(applyErr, executor.ErrNotReady):
 		// Soft: a node is waiting on data/readiness. State stays InProgress;
 		// child watch events (and the requeue below) drive the next cycle.

--- a/pkg/controller/instance/controller_graph_engine_test.go
+++ b/pkg/controller/instance/controller_graph_engine_test.go
@@ -223,6 +223,21 @@ func (e *errorClient) Get(ctx context.Context, key client.ObjectKey, obj client.
 	return e.Client.Get(ctx, key, obj, opts...)
 }
 
+// managedFieldsInjectingClient stamps a managedFields entry under `manager`
+// onto every object it GETs (the fake client strips managedFields).
+type managedFieldsInjectingClient struct {
+	client.Client
+	manager string
+}
+
+func (m *managedFieldsInjectingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := m.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	obj.SetManagedFields([]metav1.ManagedFieldsEntry{{Manager: m.manager, Operation: metav1.ManagedFieldsOperationApply}})
+	return nil
+}
+
 // -----------------------------------------------------------------------------
 // 1. orphanApplyOrder Tests
 // -----------------------------------------------------------------------------
@@ -941,6 +956,44 @@ func TestReconcileViaGraphEngine_SoftErrors(t *testing.T) {
 		assert.Equal(t, "NotReady", *cond.Reason)
 		require.NotNil(t, cond.Message)
 		assert.Contains(t, *cond.Message, "waiting for unresolved resource")
+
+		status, _, _ := unstructured.NestedMap(stored.Object, "status")
+		require.NotNil(t, status)
+		assert.Equal(t, string(v1alpha1.InstanceStateInProgress), status["state"])
+	})
+
+	// A field-manager conflict (here the cross-engine guard refusing a template
+	// object owned by a standalone Graph) stays soft, but the message must say so
+	// instead of the generic "waiting for unresolved resource".
+	t.Run("Executor returns field-manager conflict -> ResourcesReady False (NotReady) with a field-manager-conflict message, state InProgress", func(t *testing.T) {
+		inst := newInstanceObject("demo", "default")
+		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+		existing := newConfigMapObject("app-config", "default")
+		fakeRuntimeCl := &managedFieldsInjectingClient{
+			Client: newFakeRuntimeClient(t, existing),
+			// A standalone Graph's template manager: "kro-graphengine.tmpl.<graphSegment>".
+			manager: "kro-graphengine.tmpl.d2ba416cfd76",
+		}
+		spec := testRGDSpecWithConfigMap("app-config", "")
+		c, _ := newGraphEngineControllerUnderTest(t, raw, spec, revisions.RevisionStateActive, comp, fakeRuntimeCl)
+
+		watcher := &fakeInstanceWatcher{}
+		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
+		require.Error(t, err)
+		assert.True(t, requeue.IsRequeueError(err), "a field-manager conflict stays a soft requeue")
+		assert.True(t, errors.Is(err, executor.ErrNotReady))
+		assert.True(t, errors.Is(err, executor.ErrFieldManagerConflict))
+
+		stored := getStoredParentObject(t, raw)
+		cond := conditionByType(t, stored, ResourcesReady)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		require.NotNil(t, cond.Reason)
+		assert.Equal(t, "NotReady", *cond.Reason)
+		require.NotNil(t, cond.Message)
+		assert.Contains(t, *cond.Message, "field manager conflict:",
+			"the message must identify the contention instead of the generic readiness wait")
+		assert.NotContains(t, *cond.Message, "waiting for unresolved resource")
+		assert.Contains(t, *cond.Message, "owned by a foreign kro Graph", "the executor's detail is preserved")
 
 		status, _, _ := unstructured.NestedMap(stored.Object, "status")
 		require.NotNil(t, status)

--- a/pkg/graphengine/compiler/patch_test.go
+++ b/pkg/graphengine/compiler/patch_test.go
@@ -163,6 +163,73 @@ func TestCompilePatch_ReferencingPatchNodeRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), `patch node "p" does not publish a value into scope and cannot be referenced in CEL expressions`)
 }
 
+// TestCompilePatch_ReadyWhenRejected verifies readyWhen on a patch node is
+// rejected up front with an actionable message, whatever the expression
+// references (another node, the patch itself, nothing, or `each` on a forEach
+// patch), rather than failing later in CEL analysis or evaluating against the
+// rendered contribution.
+func TestCompilePatch_ReadyWhenRejected(t *testing.T) {
+	t.Parallel()
+
+	for _, expr := range []string{"${w.status.phase == 'Ready'}", "${p.data.k == 'v'}", "${true}"} {
+		t.Run(expr, func(t *testing.T) {
+			t.Parallel()
+			g := generator.NewGraph("g",
+				generator.WithTemplate("w", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "w"},
+					"data":     map[string]any{"k": "v"},
+				}),
+				generator.WithPatch("p", "v1", "ConfigMap", "existing", map[string]any{
+					"data": map[string]any{"k": "${w.data.k}"},
+				}),
+				generator.WithReadyWhen(expr),
+			)
+
+			_, err := newTestCompiler(t).Compile(g)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `node "p"`)
+			assert.Contains(t, err.Error(), "readyWhen is not supported on patch nodes")
+			assert.Contains(t, err.Error(), "add a ref node for the target and put readyWhen on it")
+		})
+	}
+
+	t.Run("forEach patch with each-based readyWhen", func(t *testing.T) {
+		t.Parallel()
+		g := generator.NewGraph("g",
+			generator.WithDef("src", map[string]any{"names": []any{"a", "b"}}),
+			generator.WithPatchManifest("p", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${n}"},
+				"data":     map[string]any{"k": "v"},
+			}),
+			generator.WithReadyWhen("${each.data.k == 'v'}"),
+		)
+		g.Spec.Nodes[len(g.Spec.Nodes)-1].ForEach = []expv1alpha1.ForEachDimension{{"n": "${src.names}"}}
+		_, err := newTestCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "readyWhen is not supported on patch nodes")
+	})
+
+	// The same rule applies to a patch node inside a nested subgraph frame.
+	t.Run("nested subgraph", func(t *testing.T) {
+		t.Parallel()
+		child := generator.NewGraph("child",
+			generator.WithPatch("cp", "v1", "ConfigMap", "existing", map[string]any{
+				"data": map[string]any{"k": "v"},
+			}),
+			generator.WithReadyWhen("${true}"),
+		)
+		g := generator.NewGraph("g",
+			generator.WithDef("seed", map[string]any{"x": "y"}),
+			generator.WithSubgraph("sub", child),
+		)
+		_, err := newTestCompiler(t).Compile(g)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "readyWhen is not supported on patch nodes")
+	})
+}
+
 // TestCompilePatch_LabelsOnlyTargetsMainResource verifies a patch that only
 // contributes metadata.labels (no status) derives to the main-resource
 // endpoint (empty Subresource), not the status subresource.

--- a/pkg/graphengine/compiler/validation.go
+++ b/pkg/graphengine/compiler/validation.go
@@ -97,7 +97,8 @@ func validateFrameNodes(nodes []expv1alpha1.Node) error {
 // don't render or read; the per-node modifiers have no defined semantics on
 // them yet, so they're rejected explicitly rather than silently ignored.
 // patch nodes MAY carry forEach — the contribution fans out across every
-// rendered target (each must be nameable and resolve to a distinct name).
+// rendered target (each must be nameable and resolve to a distinct name) —
+// and includeWhen, but not readyWhen (a patch publishes nothing into scope).
 func validateKindCompatibility(n *expv1alpha1.Node) error {
 	if n.Graph != nil {
 		switch {
@@ -111,13 +112,17 @@ func validateKindCompatibility(n *expv1alpha1.Node) error {
 		return nil
 	}
 	if n.Patch != nil {
+		// Rejected here, with an actionable message, rather than deep in CEL
+		// analysis where every readyWhen on a patch fails for a confusing reason.
+		if len(n.ReadyWhen) > 0 {
+			return fmt.Errorf("readyWhen is not supported on patch nodes: a patch contributes fields to its target and publishes no value into scope, so there is nothing for readyWhen to evaluate; to wait for the target's state, add a ref node for the target and put readyWhen on it")
+		}
 		// A patch contributes fields to EXISTING targets. forEach is allowed: it
 		// fans the same contribution out across every rendered target (e.g. a
 		// status writeback to each claimant CR). Name-required and endpoint
 		// derivation are enforced later against the unmarshalled payload
 		// (derivePatchEndpoint); iterator→identity coverage (each rendered patch
-		// must resolve to a distinct name) is enforced in analyzeVariables so a
-		// forEach patch can't silently patch one target N times.
+		// must resolve to a distinct name) is enforced in analyzeVariables.
 		return nil
 	}
 	if len(n.ForEach) == 0 {

--- a/pkg/graphengine/executor/patch_envtest_test.go
+++ b/pkg/graphengine/executor/patch_envtest_test.go
@@ -667,6 +667,9 @@ func TestPatch_StatusSubresourceLegacyUpdateConflictResolution(t *testing.T) {
 // an SSA field-manager conflict with a pre-existing manager, it is treated as a soft error
 // (ErrNotReady): the patch node is marked Unresolved, the error message mentions the
 // contending manager, and the topological walk continues to apply downstream nodes.
+// The error also carries ErrFieldManagerConflict so the controllers can report it under
+// its own reason, and it is returned even though an upstream node is soft not-ready
+// earlier in the walk.
 func TestPatch_FieldManagerConflictSoftRequeue(t *testing.T) {
 	cl := patchEnvClient(t)
 	ns := "default"
@@ -679,12 +682,19 @@ func TestPatch_FieldManagerConflictSoftRequeue(t *testing.T) {
 	require.NoError(t, cl.Patch(context.Background(), cm, client.Apply, client.FieldOwner("foreign-manager")))
 
 	// 2. Build graph with:
+	// - template node 'upstream' whose readyWhen is never satisfied (a plain soft not-ready that precedes 'p')
 	// - patch node 'p' patching contendedKey without ForceOwnership (which will conflict with foreign-manager)
 	// - downstream template node 'downstream' creating 'downstream-cm'
 	g := generator.NewGraph("g",
 		generator.WithNamespace(ns),
+		generator.WithTemplate("upstream", map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]any{"name": "upstream-cm"},
+			"data":     map[string]any{"k": "patch-value"},
+		}),
+		generator.WithReadyWhen("${upstream.data.k == 'never'}"),
 		generator.WithPatch("p", "v1", "ConfigMap", targetName, map[string]any{
-			"data": map[string]any{"contendedKey": "patch-value"},
+			"data": map[string]any{"contendedKey": "${upstream.data.k}"},
 		}),
 		generator.WithTemplate("downstream", map[string]any{
 			"apiVersion": "v1", "kind": "ConfigMap",
@@ -697,15 +707,24 @@ func TestPatch_FieldManagerConflictSoftRequeue(t *testing.T) {
 	rt := compileAndBuildEnv(t, patchEnvCfg, g)
 	res, err := NewSimple(cl).Apply(context.Background(), rt, watchrouter.NoopWatcher{})
 
-	// 3. Error must be soft (ErrNotReady), node 'p' is Unresolved, and contending manager is in message.
+	// 3. Error must be soft (ErrNotReady) AND distinguishable (ErrFieldManagerConflict) even
+	// though 'upstream' was not ready first; node 'p' is Unresolved, and the contending
+	// manager + target are in the message.
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrNotReady), "field-manager conflict on patch must be soft ErrNotReady, got %v", err)
+	assert.True(t, errors.Is(err, ErrFieldManagerConflict), "field-manager conflict must win over the earlier plain not-ready, got %v", err)
 	assert.Contains(t, res.Unresolved, "p", "conflicting patch node must be recorded as Unresolved")
 	assert.Contains(t, err.Error(), "foreign-manager", "error message must include the contending field manager name")
+	assert.Contains(t, err.Error(), targetName, "error message must name the patch target")
+	assert.Empty(t, res.Contributions, "a refused contribution must not be recorded as landed")
 
-	// 4. Topological walk must NOT have aborted: downstream node was applied!
-	require.Len(t, res.Applied, 1, "downstream node must be applied despite patch conflict")
-	assert.Equal(t, "downstream-cm", res.Applied[0].Name)
+	// The foreign manager keeps its value: the patch is cooperative and did not steal the field.
+	assert.Equal(t, "initial-value", getConfigMap(t, cl, ns, targetName).Object["data"].(map[string]any)["contendedKey"])
+
+	// 4. Topological walk must NOT have aborted: upstream and downstream were applied.
+	require.Len(t, res.Applied, 2, "upstream and downstream nodes must be applied despite patch conflict")
+	assert.Equal(t, "upstream-cm", res.Applied[0].Name)
+	assert.Equal(t, "downstream-cm", res.Applied[1].Name)
 	downstreamCM := getConfigMap(t, cl, ns, "downstream-cm")
 	data, _, _ := unstructured.NestedStringMap(downstreamCM.Object, "data")
 	assert.Equal(t, "v", data["k"])

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -224,8 +224,10 @@ var _ Interface = (*Simple)(nil)
 // authoritative — bailing early on a not-ready upstream node would
 // leave downstream nodes' watches missing, and the next reconcile
 // would lose drift events on them. Soft errors are remembered and the
-// first one is returned at the end wrapped in ErrNotReady. Hard errors
-// (apply failure, type errors, etc.) still abort immediately.
+// first one is returned at the end wrapped in ErrNotReady, except that a
+// field-manager conflict takes precedence so it is never hidden behind a
+// node that is merely still converging. Hard errors (apply failure, type
+// errors, etc.) still abort immediately.
 //
 // Dependency-readiness gating: a node is applied only once every node it
 // depends on is ready this cycle (readyWhen satisfied). A dependency that
@@ -250,7 +252,7 @@ func (s *Simple) Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.W
 	var result ApplyResult
 	var firstSoft error
 	recordSoft := func(err error) {
-		if firstSoft == nil {
+		if firstSoft == nil || (errors.Is(err, ErrFieldManagerConflict) && !errors.Is(firstSoft, ErrFieldManagerConflict)) {
 			firstSoft = err
 		}
 	}
@@ -467,9 +469,8 @@ func (s *Simple) applyNodeByKind(
 			}
 			return nil, fmt.Errorf("apply %q (patch): %w", n.ID(), err)
 		}
-		// A patch publishes no value into scope; record observed so an
-		// optional readyWhen can still evaluate against the node.
-		n.SetObserved(desired, desired)
+		// A patch publishes no value into scope and the compiler rejects
+		// readyWhen on it, so there is no observed state to record.
 	default:
 		return nil, fmt.Errorf("apply %q: unknown kind %v", n.ID(), n.Kind())
 	}
@@ -1737,7 +1738,13 @@ func (s *Simple) applyPatchOne(ctx context.Context, rt *runtime.Runtime, w watch
 	subresource := n.Subresource()
 	if err := s.contributeApply(ctx, obj, fieldManager, subresource); err != nil {
 		if apierrors.IsConflict(err) {
-			return Contribution{}, fmt.Errorf("patch field conflict on %s %q: %w (%w)",
+			// Soft either way; an ownership conflict additionally carries
+			// ErrFieldManagerConflict so the controllers can report it distinctly.
+			if hasFieldManagerConflictCause(err) {
+				return Contribution{}, fmt.Errorf("patch field conflict on %s %q: %w (%w) (%w)",
+					obj.GetKind(), client.ObjectKeyFromObject(obj), err, ErrFieldManagerConflict, ErrNotReady)
+			}
+			return Contribution{}, fmt.Errorf("patch conflict on %s %q: %w (%w)",
 				obj.GetKind(), client.ObjectKeyFromObject(obj), err, ErrNotReady)
 		}
 		return Contribution{}, err
@@ -1961,6 +1968,22 @@ func isReclaimableStalePatchManager(manager, self, selfGraph string) bool {
 	return seg == "" || (selfGraph != "" && seg == selfGraph)
 }
 
+// hasFieldManagerConflictCause reports whether a 409 carries a FieldManagerConflict
+// cause (a server-side-apply ownership conflict) rather than, e.g., an
+// optimistic-concurrency precondition failure.
+func hasFieldManagerConflictCause(err error) bool {
+	status := apierrors.APIStatus(nil)
+	if !errors.As(err, &status) || status.Status().Details == nil {
+		return false
+	}
+	for _, cause := range status.Status().Details.Causes {
+		if cause.Type == metav1.CauseTypeFieldManagerConflict {
+			return true
+		}
+	}
+	return false
+}
+
 // conflictCauseManager extracts the field-manager name from an SSA conflict
 // cause message. The apiserver formats these as `conflict with "<manager>"`
 // optionally followed by ` using <version>[ at <time>]` or ` with subresource
@@ -1995,12 +2018,13 @@ func graphManagerSegment(parentUID types.UID) string {
 	return hex.EncodeToString(sum[:6])
 }
 
-// ErrFieldManagerConflict is the sentinel returned when a Template object's
-// field is already owned by a DIFFERENT kro Graph's template field manager.
-// kro refuses to force-steal a peer Graph's field, so the node is held soft
-// not-ready and the reconcile backs off instead of flip-flopping the field
-// between the two Graphs forever. It always also satisfies
-// errors.Is(err, ErrNotReady) at the call site (wrapped alongside it).
+// ErrFieldManagerConflict is the sentinel returned when a field this Graph
+// wants to write is owned by another field manager that kro refuses to steal:
+// a Template object owned by a DIFFERENT kro Graph's template manager, or a
+// main-resource patch contribution whose field is owned by anyone else. The
+// node is held soft not-ready (the call site also wraps ErrNotReady); the
+// controllers report it under its own reason because nothing was applied and
+// nothing will be until the other owner releases the field.
 var ErrFieldManagerConflict = errors.New("executor: field owned by a foreign field manager")
 
 // templateFieldManager derives a stable, PER-GRAPH field-manager identity for a

--- a/pkg/graphengine/executor/template_conflict_test.go
+++ b/pkg/graphengine/executor/template_conflict_test.go
@@ -17,6 +17,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -182,6 +184,40 @@ func TestAnyConflictOwnedByForeignGraphTemplate(t *testing.T) {
 		"an unparseable error is treated as foreign (never force-steal on ambiguity)")
 	assert.True(t, anyConflictOwnedByForeignGraphTemplate(conflictErr(""), self),
 		"a conflict cause with no readable manager is treated as foreign")
+}
+
+// TestHasFieldManagerConflictCause pins the classifier that tells an SSA
+// ownership conflict apart from any other 409.
+func TestHasFieldManagerConflictCause(t *testing.T) {
+	t.Parallel()
+
+	fieldConflict := &apierrors.StatusError{ErrStatus: metav1.Status{
+		Status: metav1.StatusFailure,
+		Reason: metav1.StatusReasonConflict,
+		Details: &metav1.StatusDetails{Causes: []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldManagerConflict,
+			Message: `conflict with "kubectl-client-side-apply"`,
+			Field:   ".data.logLevel",
+		}}},
+	}}
+	assert.True(t, hasFieldManagerConflictCause(fieldConflict), "an SSA 409 with a FieldManagerConflict cause")
+	assert.True(t, hasFieldManagerConflictCause(fmt.Errorf("wrapped: %w", fieldConflict)),
+		"the classifier must see through fmt.Errorf wrapping")
+
+	// A 409 whose causes carry no field-manager conflict (e.g. an optimistic
+	// concurrency failure) is NOT a field-manager conflict.
+	assert.False(t, hasFieldManagerConflictCause(apierrors.NewConflict(
+		schema.GroupResource{Resource: "configmaps"}, "cm", errors.New("the object has been modified"))),
+		"a plain optimistic-concurrency 409 has no field-manager cause")
+	assert.False(t, hasFieldManagerConflictCause(&apierrors.StatusError{ErrStatus: metav1.Status{
+		Status: metav1.StatusFailure,
+		Reason: metav1.StatusReasonConflict,
+		Details: &metav1.StatusDetails{Causes: []metav1.StatusCause{{
+			Type: metav1.CauseTypeFieldValueInvalid, Field: ".data.x",
+		}}},
+	}}), "a 409 with only non-field-manager causes is not a field-manager conflict")
+	assert.False(t, hasFieldManagerConflictCause(errors.New("opaque")), "a non-API error is never a field-manager conflict")
+	assert.False(t, hasFieldManagerConflictCause(nil), "nil is never a field-manager conflict")
 }
 
 // contestedGraph builds and compiles a Graph that templates a single ConfigMap

--- a/test/integration/suites/core/graph_multigraph_test.go
+++ b/test/integration/suites/core/graph_multigraph_test.go
@@ -212,10 +212,25 @@ var _ = Describe("Graph Multi-Graph Isolation", func() {
 		}, 15*time.Second)
 
 		// owner-b contends for the same field. It must NOT reach Ready=True
-		// (its apply is refused as a field-manager conflict).
+		// (its apply is refused as a field-manager conflict), and the refusal is
+		// reported under its own reason, FieldManagerConflict.
 		env.CreateGraph(t, mkGraph("owner-b", "b"))
 		keyB := types.NamespacedName{Namespace: ns, Name: "owner-b"}
 		env.AwaitCondition(t, keyB, expv1alpha1.GraphConditionTypeReady, metav1.ConditionFalse, 20*time.Second)
+		environment.Eventually(t, 10*time.Second, 200*time.Millisecond, func() error {
+			cur := env.GetGraph(t, keyB)
+			for i := range cur.Status.Conditions {
+				c := &cur.Status.Conditions[i]
+				if string(c.Type) != "ResourcesConverged" {
+					continue
+				}
+				if c.Status != metav1.ConditionFalse || c.Reason == nil || *c.Reason != "FieldManagerConflict" {
+					return fmt.Errorf("owner-b ResourcesConverged: want False/FieldManagerConflict, got %+v", c)
+				}
+				return nil
+			}
+			return fmt.Errorf("owner-b has no ResourcesConverged condition yet")
+		})
 
 		// The value must stay "a" and never flip to "b": no flip-flop, and the
 		// resourceVersion is not churning between the two owners.

--- a/test/integration/suites/core/graph_patch_test.go
+++ b/test/integration/suites/core/graph_patch_test.go
@@ -17,6 +17,7 @@ package core_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/test/integration/environment"
@@ -296,6 +298,121 @@ var _ = Describe("Graph Patch", func() {
 			}
 			if data["orig"] != "kept" {
 				return fmt.Errorf("data.orig lost during release: got=%q", data["orig"])
+			}
+			return nil
+		}, 15*time.Second)
+	})
+
+	// A main-resource patch is cooperative: a contributed field already owned by
+	// a foreign field manager is refused and reported as
+	// ResourcesConverged=False/FieldManagerConflict naming the target and the
+	// manager; the field keeps the foreign value until that manager releases it.
+	It("reports a patch field owned by a foreign manager as FieldManagerConflict and converges once released", func() {
+		t := GinkgoT()
+		ns := env.CreateNamespace(t)
+		ctx := env.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		cmGVK := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+		cmKey := types.NamespacedName{Namespace: ns, Name: "app-config"}
+		const foreignManager = "kubectl-client-side-apply"
+
+		// A kubectl-like manager owns data.logLevel via server-side apply.
+		foreignApply := func(data map[string]any) {
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": cmKey.Name, "namespace": ns},
+				"data":       data,
+			}}
+			if err := env.Client.Patch(ctx, obj, client.Apply, client.FieldOwner(foreignManager)); err != nil {
+				t.Fatalf("foreign manager apply: %v", err)
+			}
+		}
+		foreignApply(map[string]any{"logLevel": "info", "other": "kept"})
+
+		g := &expv1alpha1.Graph{
+			ObjectMeta: metav1.ObjectMeta{Name: "loglevel-patcher", Namespace: ns},
+			Spec: expv1alpha1.GraphSpec{
+				Nodes: []expv1alpha1.Node{{
+					ID: "p",
+					Patch: environment.RawExt(t, map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata":   map[string]any{"name": cmKey.Name},
+						"data":       map[string]any{"logLevel": "debug"},
+					}),
+				}},
+			},
+		}
+		env.CreateGraph(t, g)
+		gKey := types.NamespacedName{Namespace: ns, Name: "loglevel-patcher"}
+
+		// The Graph compiles (Accepted=True) but does not converge: the conflict
+		// is reported under its own reason, and Ready rolls up to False.
+		env.AwaitCondition(t, gKey, expv1alpha1.GraphConditionTypeAccepted, metav1.ConditionTrue, 20*time.Second)
+		environment.Eventually(t, 20*time.Second, 200*time.Millisecond, func() error {
+			cur := env.GetGraph(t, gKey)
+			var conv *expv1alpha1.Condition
+			for i := range cur.Status.Conditions {
+				if string(cur.Status.Conditions[i].Type) == "ResourcesConverged" {
+					conv = &cur.Status.Conditions[i]
+				}
+			}
+			if conv == nil || conv.Status != metav1.ConditionFalse {
+				return fmt.Errorf("ResourcesConverged not False yet: %+v", conv)
+			}
+			if conv.Reason == nil || *conv.Reason != "FieldManagerConflict" {
+				return fmt.Errorf("ResourcesConverged reason: want FieldManagerConflict, got %+v", conv)
+			}
+			msg := ""
+			if conv.Message != nil {
+				msg = *conv.Message
+			}
+			for _, want := range []string{cmKey.Name, foreignManager, "logLevel"} {
+				if !strings.Contains(msg, want) {
+					return fmt.Errorf("ResourcesConverged message %q does not name %q", msg, want)
+				}
+			}
+			return nil
+		})
+		env.AwaitCondition(t, gKey, expv1alpha1.GraphConditionTypeReady, metav1.ConditionFalse, 10*time.Second)
+
+		// The foreign owner's value is untouched: kro did not steal the field,
+		// and no kro patch manager appears on the object.
+		environment.Consistently(t, 2*time.Second, 200*time.Millisecond, func() error {
+			cur := &unstructured.Unstructured{}
+			cur.SetGroupVersionKind(cmGVK)
+			if err := env.Client.Get(ctx, cmKey, cur); err != nil {
+				return err
+			}
+			data, _, _ := unstructured.NestedStringMap(cur.Object, "data")
+			if data["logLevel"] != "info" {
+				return fmt.Errorf("data.logLevel=%q — the foreign owner's value was overwritten", data["logLevel"])
+			}
+			for _, mf := range cur.GetManagedFields() {
+				if strings.HasPrefix(mf.Manager, "kro-graphengine.patch.") {
+					return fmt.Errorf("a kro patch manager %q landed on the contested object", mf.Manager)
+				}
+			}
+			return nil
+		})
+
+		// The foreign manager lets go of data.logLevel (re-applies without it).
+		// SSA drops the field from that manager's set, and the Graph's next
+		// requeue lands the contribution and converges.
+		foreignApply(map[string]any{"other": "kept"})
+
+		env.AwaitCondition(t, gKey, expv1alpha1.GraphConditionTypeReady, metav1.ConditionTrue, 60*time.Second)
+		env.AwaitObject(t, cmGVK, cmKey, func(u *unstructured.Unstructured) error {
+			data, _, _ := unstructured.NestedStringMap(u.Object, "data")
+			if data["logLevel"] != "debug" {
+				return fmt.Errorf("data.logLevel: want=debug got=%q", data["logLevel"])
+			}
+			if data["other"] != "kept" {
+				return fmt.Errorf("data.other: want=kept got=%q", data["other"])
 			}
 			return nil
 		}, 15*time.Second)


### PR DESCRIPTION
## Problem

A main-resource `patch:` node applies its contribution with unforced server-side apply, so a field already owned by another manager (`kubectl`, another controller, a peer Graph) is refused with a field-level 409. The executor wrapped that 409 only in `ErrNotReady`, and the Graph controller reported it as `ResourcesConverged=False/WaitingForReadiness` — documented as "applied, but readyWhen not yet met" — although nothing was applied and, for a `kubectl`-owned field, never would be. The template path's peer-Graph refusal already carried `ErrFieldManagerConflict` but was reported as `WaitingForReadiness` too, and any other soft not-ready node earlier in the walk hid the conflict entirely.

`readyWhen` was documented as supported on `patch:` nodes, but a patch publishes no value into scope: referencing the patch itself or any other node is rejected, and the only expressions that compiled — identifier-free ones, or `each`-based ones on a forEach patch — were evaluated against the rendered contribution, never the target. A realistic `readyWhen: ["${w.status.phase == 'Ready'}"]` on a patch of `w` failed the whole Graph with a misleading error.

## Fix

- `executor.applyPatchOne`: a 409 carrying `FieldManagerConflict` causes is wrapped with both `ErrFieldManagerConflict` and `ErrNotReady` (still a soft requeue, now distinguishable); a 409 without such causes (e.g. an optimistic-concurrency precondition) stays plain soft not-ready. New helper `hasFieldManagerConflictCause`.
- `executor.Simple.Apply`: among several soft not-ready nodes, a field-manager conflict takes precedence as the returned error, so it is reported even while an upstream node is still converging (`TestPatch_FieldManagerConflictSoftRequeue` places a never-ready template ahead of the conflicting patch).
- Graph controller: new marker `ResourcesFieldManagerConflict` ⇒ `ResourcesConverged=False`, reason `FieldManagerConflict`, selected before `DataPending`/`WaitingForReadiness` inside the `ErrNotReady` branch, so requeue/backoff and inventory handling are unchanged. The template peer-Graph conflict gets the same reason.
- Instance controller: the same conflict (cross-engine `ownedByGraphTemplate` guard) keeps reason `NotReady` — the instance markers have no custom reasons — but its message is prefixed `field manager conflict:` instead of `waiting for unresolved resource:`.
- `compiler.validateKindCompatibility`: `readyWhen` on a `patch` node is rejected at compile time with an actionable message (put the `readyWhen` on a `ref:` node for the target). `forEach` and `includeWhen` stay supported. The executor's `SetObserved` for patch nodes is removed (nothing evaluates it any more).
- `docs/design/proposals/graph.md`: `FieldManagerConflict` added to the `ResourcesConverged` reasons; the patch section, banner and KREP-002 row now say `forEach`/`includeWhen` are supported on patch nodes and `readyWhen` is not.

## Behaviour changes

- New `ResourcesConverged` reason `FieldManagerConflict` on Graph objects, for a refused main-resource patch contribution and for a template object owned by a peer Graph; anything keying on `WaitingForReadiness` for those cases will now see `FieldManagerConflict`. It wins over `WaitingForReadiness`/`DataPending` from other nodes. `Ready=False` roll-up, requeue and backoff are unchanged.
- Instance path: reason stays `NotReady`; only the message prefix changes to `field manager conflict:`.
- Upgrade caveat: a Graph whose `patch:` node carries a `readyWhen` — including a forEach patch with an `each`-based expression, which compiled and reached `Ready=True` before — now fails compilation (`Accepted=False/InvalidGraph`) until the `readyWhen` is removed; its existing contributions stay in place meanwhile. No shipped example or test fixture had such a node, and the RGD adapter's synthesized status patch never carries one.
- Executor error text: a causeless patch 409 now reads `patch conflict on …` instead of `patch field conflict on …` (still `ErrNotReady`).
- `TestPatch_FieldManagerConflictSoftRequeue` now expects two applied resources (an upstream template was added ahead of the patch node); no other existing assertion changed.
