### PR TITLE
Retry collection member updates after transient API rejections

### DIFF
--- a/pkg/graphengine/executor/apply_template_test.go
+++ b/pkg/graphengine/executor/apply_template_test.go
@@ -201,33 +201,25 @@ func TestSimple_ApplyTemplate_WatchRegistrationFailureIsSoftFail(t *testing.T) {
 	})
 }
 
-// Collection per-item apply tolerance. The two failure shapes are treated
-// differently on purpose, and the distinction is what keeps a collection from
-// wedging on one bad member.
+// Validation rejections are tolerated only on existing items; other failures
+// must retry without losing live identities.
 func TestSimple_ApplyTemplate_CollectionApplyTolerance(t *testing.T) {
 	t.Parallel()
 
-	t.Run("a rejected update conflict on an existing object records the live identity", func(t *testing.T) {
+	t.Run("an update conflict retains live identities and retries", func(t *testing.T) {
 		t.Parallel()
-		// Both members already exist, so every SSA is an update. A rejected
-		// update due to field-manager conflict must not block the node forever:
-		// the objects are in the cluster, so their identities are recorded and
-		// the node converges.
+		// This is an ordinary optimistic-concurrency 409, not an SSA ownership conflict.
 		base := fake.NewClientBuilder().WithScheme(newScheme(t)).
 			WithObjects(liveCM("cm-alpha"), liveCM("cm-beta")).Build()
-		cl := &patchFailClient{Client: base, err: apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "cm-alpha", errors.New("field manager conflict"))}
+		cl := &patchFailClient{Client: base, err: apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "cm-alpha", errors.New("resource version changed"))}
 
 		res, err := NewSimple(cl).Apply(context.Background(),
 			compileAndBuild(t, collectionCMGraph()), watchrouter.NoopWatcher{})
 
-		require.NoError(t, err,
-			"a tolerated update conflict on objects that exist must not hold the node not-ready")
-		// The per-item error is dropped by design (see recordUpdateRejected): a
-		// tolerated update-rejection is silent — the object is present, so the
-		// node converges and the underlying conflict is NOT surfaced as any
-		// returned error. (This pins the corrected comment: the rejection is not
-		// escalated to a hard error, and — the RGD path having no per-node
-		// condition message for a converged node — it is not surfaced at all.)
+		require.ErrorIs(t, err, ErrNotReady)
+		assert.NotErrorIs(t, err, ErrFieldManagerConflict)
+		assert.ErrorContains(t, err, "resource version changed")
+		assert.Contains(t, res.Unresolved, "cm")
 		names := make([]string, 0, len(res.Applied))
 		for _, a := range res.Applied {
 			names = append(names, a.Name)
@@ -238,10 +230,7 @@ func TestSimple_ApplyTemplate_CollectionApplyTolerance(t *testing.T) {
 
 	t.Run("a permanent update rejection on an existing object is tolerated", func(t *testing.T) {
 		t.Parallel()
-		// A permanent update rejection on an object that ALREADY exists (e.g. a
-		// Kubernetes immutable-field update: `Invalid`/`Forbidden`) is tolerated
-		// by design: the object is present in the cluster, so its identity is
-		// recorded and the collection continues rather than blocking the node forever.
+		// Invalid updates on existing objects remain tolerated, including immutable fields.
 		base := fake.NewClientBuilder().WithScheme(newScheme(t)).
 			WithObjects(liveCM("cm-alpha"), liveCM("cm-beta")).Build()
 		cl := &patchFailClient{Client: base, err: apierrors.NewInvalid(schema.GroupKind{Kind: "ConfigMap"}, "cm-alpha", nil)}
@@ -302,14 +291,7 @@ func TestSimple_ApplyTemplate_CollectionApplyTolerance(t *testing.T) {
 	})
 }
 
-// TestCollectionApplyState_UpdateRejectedIsSilent pins the corrected contract
-// behind the FINDING-1 comment fix: recordUpdateRejected records the live
-// identity (so the item lands in Applied) but records NO item failure and NO
-// hard error — the tolerated update-rejection is intentionally silent and is
-// NOT surfaced as any returned error. The old comment claimed the per-item
-// error was "surfaced in the node's condition message", which was false; this
-// test guards against that false claim creeping back in as behavior (e.g. a
-// well-meaning change that starts returning the dropped error).
+// A tolerated validation rejection publishes the live value without an error.
 func TestCollectionApplyState_UpdateRejectedIsSilent(t *testing.T) {
 	t.Parallel()
 
@@ -502,7 +484,7 @@ func TestSimple_ApplyTemplate_LargeCollectionTolerance(t *testing.T) {
 	t.Parallel()
 
 	const count = 60
-	// 00..09: pre-existing, fail on update (tolerated, live recorded)
+	// 00..09: pre-existing, fail on update (soft ErrNotReady, live recorded)
 	// 10..19: absent, fail on create (tolerated, recorded in itemFailures, soft ErrNotReady)
 	// 20..59: absent, succeed on create (applied)
 
@@ -517,7 +499,7 @@ func TestSimple_ApplyTemplate_LargeCollectionTolerance(t *testing.T) {
 		patchFunc: func(ctx context.Context, obj client.Object) error {
 			name := obj.GetName()
 			if strings.HasPrefix(name, "cm-item-0") {
-				return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, name, errors.New("field manager conflict"))
+				return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, name, errors.New("resource version changed"))
 			}
 			if strings.HasPrefix(name, "cm-item-1") {
 				return errors.New("quota exceeded")
@@ -531,9 +513,11 @@ func TestSimple_ApplyTemplate_LargeCollectionTolerance(t *testing.T) {
 		compileAndBuild(t, largeCollectionGraph(count)), watchrouter.NoopWatcher{})
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrNotReady), "failing creates must produce soft ErrNotReady")
-	assert.Contains(t, err.Error(), "10 item(s) failed to apply")
+	assert.True(t, errors.Is(err, ErrNotReady), "failing creates and transient updates must produce soft ErrNotReady")
+	assert.Contains(t, err.Error(), "20 item(s) failed to apply")
+	assert.Contains(t, err.Error(), "resource version changed")
 	assert.Contains(t, err.Error(), "quota exceeded")
+	assert.Contains(t, res.Unresolved, "cm")
 
 	// 10 existing + 40 newly created = 50 items tracked in Applied
 	assert.Len(t, res.Applied, 50)
@@ -615,7 +599,7 @@ func TestSimple_ApplyTemplate_CollectionHardErrors(t *testing.T) {
 		assert.False(t, errors.Is(err, ErrNotReady))
 	})
 
-	t.Run("permanent update rejections on existing collection items are tolerated as soft errors", func(t *testing.T) {
+	t.Run("Invalid updates are tolerated but Forbidden updates retry", func(t *testing.T) {
 		t.Parallel()
 		g := generator.NewGraph("g",
 			generator.WithNamespace("default"),
@@ -627,10 +611,8 @@ func TestSimple_ApplyTemplate_CollectionHardErrors(t *testing.T) {
 			}, generator.ForEachDim("n", "${src.names}")),
 		)
 
-		// All three items already exist; two of their updates are permanently
-		// rejected (Invalid / Forbidden immutable-field updates). By design these
-		// are tolerated on existing objects: the live identities are recorded and
-		// the collection converges rather than aborting the walk.
+		// All three items already exist. Invalid is tolerated, Forbidden holds
+		// the node not-ready, and the healthy sibling still applies.
 		base := fake.NewClientBuilder().WithScheme(newScheme(t)).
 			WithObjects(liveCM("cm-0"), liveCM("cm-1"), liveCM("cm-2")).Build()
 		cl := &concurrencyTrackingClient{
@@ -650,8 +632,11 @@ func TestSimple_ApplyTemplate_CollectionHardErrors(t *testing.T) {
 		res, err := NewSimple(cl).Apply(context.Background(),
 			compileAndBuild(t, g), watchrouter.NoopWatcher{})
 
-		require.NoError(t, err,
-			"permanent update rejections on existing items must be tolerated so the node converges")
+		require.ErrorIs(t, err, ErrNotReady)
+		assert.ErrorContains(t, err, "1 item(s) failed to apply")
+		assert.ErrorContains(t, err, "item default/cm-2")
+		assert.ErrorContains(t, err, "forbidden mutation")
+		assert.Contains(t, res.Unresolved, "cm")
 		names := make([]string, 0, len(res.Applied))
 		for _, a := range res.Applied {
 			names = append(names, a.Name)

--- a/pkg/graphengine/executor/executor.go
+++ b/pkg/graphengine/executor/executor.go
@@ -128,28 +128,18 @@ type Contribution struct {
 }
 
 // ToleratedRejection describes a collection item whose server-side-apply UPDATE
-// was rejected on an ALREADY-EXISTING object and tolerated: the live object is
-// kept and the node still converges (so an unfixable update — e.g. an immutable
-// field — does not wedge the instance forever). The desired change did NOT land,
-// so this is surfaced as an observational signal (log + optional Warning event
-// via Simple.OnToleratedRejection) WITHOUT affecting readiness gating or
-// requeue — flipping those would reintroduce the wedge.
+// was rejected as Invalid/BadRequest on an existing object and tolerated. The
+// live object is kept and the node still converges, so an immutable-field update
+// does not wedge the instance. This signal does not affect readiness or requeue;
+// other update failures hold the node not-ready instead.
 type ToleratedRejection struct {
 	NodeID     string // fully-qualified node path
 	APIVersion string // target apiVersion ("apps/v1", "v1", ...)
 	Kind       string // target kind
 	Namespace  string
 	Name       string
-	// Reason is a short operator-facing classification of WHY the update was
-	// rejected (e.g. "field immutable", "invalid request", or a transient cause
-	// that will be retried on a later reconcile). Derived from the typed API
-	// error, since a permanent immutable-field rejection and a transient one are
-	// not distinguishable by outcome here (both keep the live object).
+	// Reason classifies the validation rejection ("field immutable" or "invalid request").
 	Reason string
-	// Permanent is true when the rejection cannot succeed by retrying the same
-	// payload (Invalid/BadRequest); false for transient causes that a later
-	// reconcile may resolve.
-	Permanent bool
 	// Cause is the raw API error string, for the log/event detail.
 	Cause string
 }

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -111,13 +111,10 @@ type Simple struct {
 	// remains as a backstop.
 	identityClaims *identityClaimSet
 	// OnToleratedRejection, when non-nil, is invoked for each collection item
-	// whose UPDATE was rejected on an already-existing object and tolerated
-	// (the live object is kept and the node still converges). It is a purely
-	// OBSERVATIONAL hook — it must not influence readiness or requeue, or the
-	// anti-wedge tolerance would be lost. The instance controller wires it to an
-	// event recorder (Warning event); the Graph controller leaves it nil
-	// (log-only, it has no recorder). Called from parallel apply goroutines, so
-	// the implementation must be safe for concurrent use (an EventRecorder is).
+	// whose UPDATE was rejected as Invalid/BadRequest on an existing object and
+	// tolerated. It is observational: the live object is kept and the node still
+	// converges. Called from parallel apply goroutines, so the implementation
+	// must be safe for concurrent use (an EventRecorder is).
 	OnToleratedRejection func(ToleratedRejection)
 }
 
@@ -604,14 +601,11 @@ var errSchemaNotReady = errors.New("executor: target GVK not yet known to the cl
 // still terminating. External refs/collections are exempt (they are
 // read-only and handled by applyRef/applyRefCollection, not here).
 //
-// Collection nodes apply each item INDEPENDENTLY and tolerate per-item SSA
-// failures: a failure to
-// UPDATE an already-present item (e.g. an immutable field) does not abort
-// the node — the live object is recorded as applied so tracking/prune stay
-// correct and the node can still converge. A failure to CREATE an item that
-// is not yet present marks the node soft not-ready so downstream gates and
-// the reconcile requeues. A scalar node still returns an SSA error as a hard
-// error, unchanged.
+// Collection nodes apply each item independently. Invalid/BadRequest UPDATE
+// rejections keep the live object and let the node converge (e.g. an immutable
+// field). Other per-item SSA failures hold the node soft not-ready for retry,
+// retaining existing identities; Invalid/BadRequest CREATE failures are hard
+// errors. A scalar node still returns an ordinary SSA error as a hard error.
 func (s *Simple) applyTemplate(ctx context.Context, rt *runtime.Runtime, w watchrouter.Watcher, n *runtime.Node, desired []*unstructured.Unstructured) ([]expv1alpha1.ManagedResource, error) {
 	mappings, err := s.buildMappings(n, desired)
 	if err != nil {
@@ -785,16 +779,9 @@ func (st *collectionApplyState) recordApplied(i int, mr expv1alpha1.ManagedResou
 	st.mu.Unlock()
 }
 
-// classifyRejection turns a tolerated collection-update rejection into a short
-// operator-facing reason and a permanent/transient flag. A permanent rejection
-// (Invalid/BadRequest) cannot succeed by retrying the same payload; an Invalid
-// whose status causes name an immutable field is reported specifically so the
-// operator sees WHY the desired change never landed. Transient causes
-// (Conflict, timeouts, throttling, unavailability) are retried on a later
-// reconcile, so they are flagged non-permanent. This is best-effort: a webhook
-// Forbidden or a CEL-validation Invalid that depends on other mutable cluster
-// state cannot be perfectly classified by error code, which is exactly why the
-// node converges and merely SURFACES the rejection rather than gating on it.
+// classifyRejection returns an operator-facing reason and the existing
+// Invalid/BadRequest tolerance classification. "Permanent" is a policy boundary,
+// not a guarantee that an admission rejection cannot depend on mutable state.
 func classifyRejection(err error) (reason string, permanent bool) {
 	switch {
 	case apierrors.IsInvalid(err):
@@ -908,11 +895,11 @@ func (st *collectionApplyState) softError(nodeID string) error {
 
 // applyCollectionTemplate applies a collection Template with bounded
 // parallelism. It registers ONE selector watch for the whole node up front,
-// then applies each item independently, tolerating per-item failures: a
-// rejected UPDATE on an already-present item records the live identity and
-// converges; a failed CREATE holds the node soft not-ready; a terminating item
-// gates the node. Hard errors (bad GET, namespace, applyset conflict, permanent
-// validation rejection) abort and are deterministically joined by item index.
+// then applies each item independently. Invalid/BadRequest UPDATE rejections
+// keep the live object and converge; other SSA failures hold the node soft
+// not-ready, retaining existing identities. A terminating item gates the node.
+// Hard errors (bad GET, namespace, applyset conflict, Invalid/BadRequest CREATE)
+// are deterministically joined by item index.
 func (s *Simple) applyCollectionTemplate(ctx context.Context, w watchrouter.Watcher, rt *runtime.Runtime, n *runtime.Node, desired []*unstructured.Unstructured, mappings []applyMapping) ([]expv1alpha1.ManagedResource, error) {
 	if len(desired) == 0 {
 		return []expv1alpha1.ManagedResource{}, nil
@@ -982,8 +969,8 @@ func (s *Simple) applyCollectionTemplate(ctx context.Context, w watchrouter.Watc
 	if deletingErr := st.deletingError(); deletingErr != nil {
 		return st.appliedResources(), deletingErr
 	}
-	// Any create failure holds the collection soft not-ready so downstream
-	// gates and the reconcile requeues (never a hard abort).
+	// Retriable create or update failures hold the collection soft not-ready
+	// so downstream gates and the reconcile requeues.
 	if softErr := st.softError(n.ID()); softErr != nil {
 		return st.appliedResources(), softErr
 	}
@@ -1049,30 +1036,22 @@ func (s *Simple) applyCollectionItem(ctx context.Context, rt *runtime.Runtime, n
 			return nil
 		}
 		if current != nil {
-			// The object already exists; only the UPDATE was rejected. This is
-			// tolerated BY DESIGN, including permanent rejections such as a
-			// Kubernetes immutable-field update (`Forbidden: pod updates may not
-			// change fields ...`): the object is present in the cluster, so record
-			// the live identity and let the collection converge rather than block
-			// the node forever on an unfixable update. (Integration coverage:
-			// collection_test.go deep-chaining scale up/down relies on this.)
-			//
-			// The rejection is NOT escalated to a hard error or a soft not-ready
-			// (that would wedge the node on an unfixable update), but it must not
-			// be fully SILENT either: a desired change did not land while the node
-			// still converges. Emit a warning to the controller log AND, when the
-			// caller wired OnToleratedRejection, an observational signal (the
-			// instance controller records a Warning event) classifying WHY — so a
-			// stale live object is diagnosable in `kubectl describe`, not just in
-			// logs. The signal is observational ONLY: it never touches readiness
-			// gating or requeue, or the anti-wedge tolerance would be lost.
 			reason, permanent := classifyRejection(err)
+			if !permanent {
+				// Keep the live identity for tracking, but retry before publishing
+				// a converged collection value to dependents.
+				st.recordApplied(i, managedResourceFrom(n, current))
+				st.recordFailure(i, fmt.Errorf("item %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
+				return nil
+			}
+			// Tolerate validation rejections on existing objects so immutable
+			// updates do not wedge the node. Surface the unapplied change through
+			// the log and optional event hook while publishing the live value.
 			log.FromContext(ctx).Info("collection item update rejected; keeping live object and converging (desired change did not land)",
 				"node", s.qualifiedPath(n.ID()),
 				"object", obj.GetNamespace()+"/"+obj.GetName(),
 				"gvk", obj.GroupVersionKind().String(),
 				"reason", reason,
-				"permanent", permanent,
 				"cause", err.Error())
 			if s.OnToleratedRejection != nil {
 				gvk := obj.GroupVersionKind()
@@ -1083,7 +1062,6 @@ func (s *Simple) applyCollectionItem(ctx context.Context, rt *runtime.Runtime, n
 					Namespace:  obj.GetNamespace(),
 					Name:       obj.GetName(),
 					Reason:     reason,
-					Permanent:  permanent,
 					Cause:      err.Error(),
 				})
 			}

--- a/pkg/graphengine/executor/tolerated_rejection_test.go
+++ b/pkg/graphengine/executor/tolerated_rejection_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,15 +26,15 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	expv1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/testutil/generator"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/watchrouter"
 )
 
-// TestClassifyRejection covers the permanent-vs-transient classification that
-// enriches the tolerated-update-rejection signal (finding 886, Opt 2). The axis
-// is NOT "immutable vs still-reconciling" (a reconciling object is an accepted
-// write, never an error here) but "permanent vs transient rejection".
+// TestClassifyRejection covers the validation-tolerance boundary and its reasons.
 func TestClassifyRejection(t *testing.T) {
 	t.Parallel()
 
@@ -76,43 +77,129 @@ func TestClassifyRejection(t *testing.T) {
 func TestApply_OnToleratedRejectionHookFires(t *testing.T) {
 	t.Parallel()
 
-	// Both members already exist, so every SSA is an update; reject with an
-	// immutable-field Invalid so the tolerate path fires.
-	base := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(liveCM("cm-alpha"), liveCM("cm-beta")).Build()
-	immutable := apierrors.NewInvalid(
-		schema.GroupKind{Kind: "ConfigMap"}, "cm-alpha",
-		field.ErrorList{field.Invalid(field.NewPath("data"), "x", "field is immutable")},
-	)
-	cl := &patchFailClient{Client: base, err: immutable}
+	for _, tc := range []struct {
+		name   string
+		err    error
+		reason string
+	}{
+		{
+			name: "immutable Invalid",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "ConfigMap"}, "cm-alpha",
+				field.ErrorList{field.Invalid(field.NewPath("data"), "x", "field is immutable")}),
+			reason: "field immutable",
+		},
+		{name: "BadRequest", err: apierrors.NewBadRequest("invalid request body"), reason: "invalid request"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			base := fake.NewClientBuilder().WithScheme(newScheme(t)).
+				WithObjects(liveCM("cm-alpha"), liveCM("cm-beta")).Build()
+			cl := &concurrencyTrackingClient{Client: base, patchFunc: func(_ context.Context, obj client.Object) error {
+				if obj.GetName() != "dependent" {
+					return tc.err
+				}
+				return nil
+			}}
+			graph := collectionCMGraph()
+			generator.WithTemplate("dependent", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "dependent"},
+				"data":     map[string]any{"k": "${cm[0].data.k}"},
+			})(graph)
 
-	var mu sync.Mutex
-	var got []ToleratedRejection
+			var mu sync.Mutex
+			var got []ToleratedRejection
+			s := NewSimple(cl)
+			s.GateReadiness = true
+			s.OnToleratedRejection = func(r ToleratedRejection) {
+				mu.Lock()
+				got = append(got, r)
+				mu.Unlock()
+			}
+
+			res, err := s.Apply(context.Background(), compileAndBuild(t, graph), watchrouter.NoopWatcher{})
+			require.NoError(t, err, "a tolerated update rejection must still converge")
+			assert.Len(t, res.Applied, 3)
+			assert.Empty(t, res.Unresolved)
+			assert.Equal(t, map[string]any{"k": "old"}, getFakeCM(t, base, "dependent").Object["data"],
+				"dependents must see the live value, not the rejected desired value")
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.Len(t, got, 2, "the hook must fire once per tolerated item")
+			assert.ElementsMatch(t, []string{"cm-alpha", "cm-beta"}, []string{got[0].Name, got[1].Name})
+			for _, r := range got {
+				assert.Equal(t, "cm", r.NodeID)
+				assert.Equal(t, "v1", r.APIVersion)
+				assert.Equal(t, "ConfigMap", r.Kind)
+				assert.Equal(t, "default", r.Namespace)
+				assert.Equal(t, tc.reason, r.Reason)
+				assert.Equal(t, tc.err.Error(), r.Cause)
+			}
+		})
+	}
+}
+
+func TestApply_TransientUpdateRejectionHoldsNodeNotReady(t *testing.T) {
+	t.Parallel()
+	alpha, beta := liveCM("cm-alpha"), liveCM("cm-beta")
+	alpha.SetUID("uid-alpha")
+	beta.SetUID("uid-beta")
+	base := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(alpha, beta).Build()
+	rejection := apierrors.NewInternalError(errors.New("failed calling webhook: connection refused"))
+	rejectUpdate := true
+	cl := &concurrencyTrackingClient{Client: base, patchFunc: func(_ context.Context, obj client.Object) error {
+		if rejectUpdate && obj.GetName() == "cm-alpha" {
+			return rejection
+		}
+		return nil
+	}}
+	graph := collectionCMGraph()
+	generator.WithTemplate("dependent", map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "dependent"},
+		"data":     map[string]any{"k": "${cm[0].data.k}"},
+	})(graph)
 	s := NewSimple(cl)
-	s.OnToleratedRejection = func(r ToleratedRejection) {
-		mu.Lock()
-		got = append(got, r)
-		mu.Unlock()
+	s.GateReadiness = true
+	var hookCalls atomic.Int32
+	s.OnToleratedRejection = func(ToleratedRejection) { hookCalls.Add(1) }
+	rt := compileAndBuild(t, graph)
+
+	res, err := s.Apply(context.Background(), rt, watchrouter.NoopWatcher{})
+	assert.ErrorIs(t, err, ErrNotReady)
+	assert.ErrorIs(t, err, rejection, "the underlying API error must be preserved")
+	assert.ErrorContains(t, err, `collection "cm": 1 item(s) failed to apply`)
+	assert.ErrorContains(t, err, "item default/cm-alpha")
+	assert.ErrorContains(t, err, "failed calling webhook: connection refused")
+	assert.NotErrorIs(t, err, ErrFieldManagerConflict)
+	assert.Equal(t, []string{"cm", "dependent"}, res.Unresolved)
+	wantMembers := []expv1alpha1.ManagedResource{
+		{NodeID: "cm", APIVersion: "v1", Kind: "ConfigMap", Namespace: "default", Name: "cm-alpha", UID: "uid-alpha"},
+		{NodeID: "cm", APIVersion: "v1", Kind: "ConfigMap", Namespace: "default", Name: "cm-beta", UID: "uid-beta"},
 	}
+	assert.Equal(t, wantMembers, res.Applied, "both live identities and UIDs must remain tracked")
+	assert.Empty(t, rt.Node("cm").Observed(), "the failed collection must not publish a converged value")
+	assert.False(t, cmExists(t, base, "dependent"), "dependents must wait for the rejected update")
+	assert.Equal(t, map[string]any{"k": "old"}, getFakeCM(t, base, "cm-alpha").Object["data"])
+	assert.Equal(t, map[string]any{"k": "new"}, getFakeCM(t, base, "cm-beta").Object["data"], "the healthy sibling still updates")
+	assert.Zero(t, hookCalls.Load(), "retrying failures are not tolerated rejections")
 
-	res, err := s.Apply(context.Background(),
-		compileAndBuild(t, collectionCMGraph()), watchrouter.NoopWatcher{})
-
-	require.NoError(t, err, "a tolerated update-rejection must not fail Apply (the node converges)")
-	// Both items converge into Applied (live identities recorded).
-	assert.Len(t, res.Applied, 2)
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, got, 2, "the hook must fire once per tolerated item")
-	for _, r := range got {
-		assert.Equal(t, "v1", r.APIVersion)
-		assert.Equal(t, "ConfigMap", r.Kind)
-		assert.Equal(t, "default", r.Namespace)
-		assert.Equal(t, "field immutable", r.Reason)
-		assert.True(t, r.Permanent, "an immutable-field rejection is permanent")
-		assert.Contains(t, r.Cause, "immutable")
+	// Clear only the API failure; a later Apply uses the same, unedited graph.
+	rejectUpdate = false
+	res, err = s.Apply(context.Background(), compileAndBuild(t, graph), watchrouter.NoopWatcher{})
+	require.NoError(t, err)
+	assert.Empty(t, res.Unresolved)
+	require.Len(t, res.Applied, 3)
+	assert.Equal(t, wantMembers, res.Applied[:2], "recovery must retain the original member identities")
+	for _, member := range wantMembers {
+		live := getFakeCM(t, base, member.Name)
+		assert.Equal(t, member.UID, string(live.GetUID()))
+		assert.Equal(t, map[string]any{"k": "new"}, live.Object["data"])
 	}
+	assert.Equal(t, "dependent", res.Applied[2].Name)
+	assert.Equal(t, map[string]any{"k": "new"}, getFakeCM(t, base, "dependent").Object["data"])
+	assert.Zero(t, hookCalls.Load())
 }
 
 // TestApply_NoHookWhenNil confirms a nil hook is a safe no-op (the Graph

--- a/test/integration/suites/core/collection_transient_rejection_test.go
+++ b/test/integration/suites/core/collection_transient_rejection_test.go
@@ -1,0 +1,177 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("Collection transient update rejection", func() {
+	It("retries a rejected member without an instance edit and preserves its identity", func(ctx SpecContext) {
+		namespace := "collection-retry-" + rand.String(5)
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, ns)).To(Succeed())
+		})
+
+		rgd := generator.NewResourceGraphDefinition("test-transient-rejection",
+			generator.WithSchema("TransientRejectionCollection", "v1alpha1",
+				map[string]any{"slots": "[]string", "value": "string"}, nil),
+			generator.WithResourceCollection("configmaps", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{
+					"name":   "${schema.metadata.name}-${slot}",
+					"labels": map[string]any{"slot": "${slot}"},
+				},
+				"data": map[string]any{"value": "${schema.spec.value}"},
+			}, []krov1alpha1.ForEachDimension{{"slot": "${schema.spec.slots}"}}, nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1", "kind": "TransientRejectionCollection",
+			"metadata": map[string]any{"name": "coll", "namespace": namespace},
+			"spec":     map[string]any{"slots": []any{"a", "b"}, "value": "v1"},
+		}}
+		createInstanceWithCleanup(ctx, instance)
+		waitForInstanceActive(ctx, namespace, instance.GetName(), instance)
+		instanceKey := client.ObjectKeyFromObject(instance)
+		instanceUID := instance.GetUID()
+		initialGeneration := instance.GetGeneration()
+		memberUIDs := map[string]types.UID{}
+		for _, name := range []string{"coll-a", "coll-b"} {
+			cm := &corev1.ConfigMap{}
+			Expect(env.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)).To(Succeed())
+			Expect(cm.Data["value"]).To(Equal("v1"))
+			Expect(cm.UID).NotTo(BeEmpty())
+			memberUIDs[name] = cm.UID
+		}
+
+		By("rejecting only slot=a ConfigMap updates through an unreachable admission webhook")
+		webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "block-slot-a-" + namespace},
+			Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+				Name:                    "block-slot-a.kro-test.invalid",
+				AdmissionReviewVersions: []string{"v1"},
+				SideEffects:             new(admissionregistrationv1.SideEffectClassNone),
+				FailurePolicy:           new(admissionregistrationv1.Fail),
+				TimeoutSeconds:          new(int32(1)),
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Update},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"configmaps"},
+					},
+				}},
+				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": namespace}},
+				ObjectSelector:    &metav1.LabelSelector{MatchLabels: map[string]string{"slot": "a"}},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					URL: new("https://127.0.0.1:1/validate"),
+				},
+			}},
+		}
+		Expect(env.Client.Create(ctx, webhook)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(client.IgnoreNotFound(env.Client.Delete(ctx, webhook))).To(Succeed())
+		})
+
+		// Wait for admission configuration propagation using an unmanaged object;
+		// probing a managed sibling would also enqueue its instance.
+		probe := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "webhook-probe", Namespace: namespace, Labels: map[string]string{"slot": "a"}},
+			Data:       map[string]string{"value": "v1"},
+		}
+		Expect(env.Client.Create(ctx, probe)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(env.Client.Delete(ctx, probe)).To(Succeed())
+		})
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(probe), probe)).To(Succeed())
+			probe.Data["value"] = rand.String(5)
+			err := env.Client.Update(ctx, probe)
+			g.Expect(apierrors.IsInternalError(err)).To(BeTrue(), "expected webhook InternalError, got %v", err)
+			g.Expect(err).To(MatchError(ContainSubstring("failed calling webhook")))
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+
+		By("requesting v2 for both existing members")
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, instanceKey, instance)).To(Succeed())
+			g.Expect(unstructured.SetNestedField(instance.Object, "v2", "spec", "value")).To(Succeed())
+			g.Expect(env.Client.Update(ctx, instance)).To(Succeed())
+		}).WithContext(ctx).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+		generation := instance.GetGeneration()
+		Expect(generation).To(BeNumerically(">", initialGeneration))
+
+		By("reporting current-generation not-ready while retaining the stale member and updating its sibling")
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, instanceKey, instance)).To(Succeed())
+			cond := findInstanceConditionByType(instance, "ResourcesReady")
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond["observedGeneration"]).To(Equal(generation))
+			for name, value := range map[string]string{"coll-a": "v1", "coll-b": "v2"} {
+				cm := &corev1.ConfigMap{}
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)).To(Succeed())
+				g.Expect(cm.Data["value"]).To(Equal(value))
+				g.Expect(cm.UID).To(Equal(memberUIDs[name]))
+			}
+			state, _, _ := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(state).To(Equal("IN_PROGRESS"), "ResourcesReady: %v", cond)
+			g.Expect(cond["status"]).To(Equal("False"))
+			g.Expect(cond["reason"]).To(Equal("NotReady"))
+			g.Expect(cond["message"]).To(ContainSubstring("item " + namespace + "/coll-a"))
+			g.Expect(cond["message"]).To(ContainSubstring("failed calling webhook"))
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+
+		By("removing only the webhook and letting the existing retry recover the unchanged instance")
+		Expect(env.Client.Delete(ctx, webhook)).To(Succeed())
+		// Allow a full capped backoff interval (five minutes) plus propagation.
+		Eventually(func(g Gomega) {
+			for name, uid := range memberUIDs {
+				cm := &corev1.ConfigMap{}
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)).To(Succeed())
+				g.Expect(cm.Data["value"]).To(Equal("v2"))
+				g.Expect(cm.UID).To(Equal(uid))
+			}
+			g.Expect(env.Client.Get(ctx, instanceKey, instance)).To(Succeed())
+			g.Expect(instance.GetUID()).To(Equal(instanceUID))
+			g.Expect(instance.GetGeneration()).To(Equal(generation))
+			state, _, _ := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(state).To(Equal("ACTIVE"))
+			cond := findInstanceConditionByType(instance, "ResourcesReady")
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond["observedGeneration"]).To(Equal(generation))
+			g.Expect(cond["status"]).To(Equal("True"))
+			g.Expect(cond["reason"]).To(Equal("AllResourcesReady"))
+		}).WithContext(ctx).WithTimeout(6 * time.Minute).WithPolling(500 * time.Millisecond).Should(Succeed())
+	})
+})


### PR DESCRIPTION

An instance can report `ACTIVE` while an unavailable admission webhook prevents an existing `forEach` member from receiving an update. Healthy siblings advance, but the rejected member stays stale because the failed update is treated as success and no failure-driven retry is scheduled.

Use the existing rejection classification to retain the live member's identity and UID while returning not-ready for errors outside `Invalid`/`BadRequest`. Siblings continue applying, dependents wait, and the controller's existing backoff retries the update. This includes Forbidden and unclassified failures. Validation rejections keep their existing live-value tolerance for immutable updates; the tolerated-event payload loses its now-constant `Permanent` field. Existing field-manager-conflict guards retain their precedence.

The regression fails on the baseline's false success and passes with this change: removing only the failed webhook repairs the stale member under its original UID and returns the unchanged instance to `ACTIVE`. Targeted race tests also cover identity retention, dependent gating, and rejection boundaries. Real-API checks preserve ownership-conflict handling and immutable-Pod scale-up/down behavior.
