### PR TITLE
Keep conditional RGD children while their inputs are unready

### DIFF
--- a/pkg/graphengine/executor/gating_test.go
+++ b/pkg/graphengine/executor/gating_test.go
@@ -162,6 +162,147 @@ func TestSimple_GateReadinessDoesNotReportWithheldAsApplied(t *testing.T) {
 	}
 }
 
+func TestSimple_GateReadinessBeforeIncludeWhen(t *testing.T) {
+	t.Parallel()
+	const resourcePredicate = `${db.data.phase == "Running"}`
+	const schemaPredicate = `${settings.enabled}`
+	cases := []struct {
+		name           string
+		gate           bool
+		phase          string
+		includeWhen    string
+		wantUnresolved bool
+		wantApp        bool
+	}{
+		{
+			name: "unready resource input is withheld", gate: true,
+			phase: "Starting", includeWhen: resourcePredicate, wantUnresolved: true,
+		},
+		{
+			name:  "Graph default decides false against the interim value",
+			phase: "Starting", includeWhen: resourcePredicate,
+		},
+		{
+			name: "schema-disabled node waits for its template dependency", gate: true,
+			phase: "Starting", includeWhen: schemaPredicate, wantUnresolved: true,
+		},
+		{
+			name: "schema-disabled node is ignored once its template dependency is ready", gate: true,
+			phase: "Running", includeWhen: schemaPredicate,
+		},
+		{
+			name: "ready resource input can decide false", gate: true,
+			phase: "Stopped", includeWhen: resourcePredicate,
+		},
+		{
+			name: "ready resource input can include the child", gate: true,
+			phase: "Running", includeWhen: resourcePredicate, wantApp: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := generator.NewGraph("g",
+				generator.WithNamespace("default"),
+				generator.WithDef("settings", map[string]any{"enabled": false}),
+				generator.WithTemplate("db", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "db"},
+					"data":     map[string]any{"phase": tc.phase},
+				}),
+				generator.WithReadyWhen(`${db.data.phase != "Starting"}`),
+				generator.WithTemplate("app", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "app"},
+					"data":     map[string]any{"from": "${db.data.phase}"},
+				}),
+				generator.WithIncludeWhen(tc.includeWhen),
+			)
+			cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+			ex := NewSimple(cl)
+			if tc.gate {
+				ex.GateReadiness = true
+			}
+			res, err := ex.Apply(context.Background(), compileAndBuild(t, g), watchrouter.NoopWatcher{})
+			if tc.phase == "Starting" {
+				require.ErrorIs(t, err, ErrNotReady)
+			} else {
+				require.NoError(t, err)
+			}
+			if tc.wantUnresolved {
+				assert.Equal(t, []string{"app"}, res.Unresolved,
+					"withhold instead of deciding false, so the caller retains the existing child")
+			} else {
+				assert.Empty(t, res.Unresolved)
+			}
+			wantApplied := []string{"db"}
+			if tc.wantApp {
+				wantApplied = append(wantApplied, "app")
+			}
+			var appliedIDs []string
+			for _, applied := range res.Applied {
+				appliedIDs = append(appliedIDs, applied.NodeID)
+			}
+			assert.ElementsMatch(t, wantApplied, appliedIDs)
+			assert.True(t, cmExists(t, cl, "db"))
+			assert.Equal(t, tc.wantApp, cmExists(t, cl, "app"))
+		})
+	}
+}
+
+func TestSimple_GateReadinessWithIgnoredDependency(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []string{"", "Running", "Starting"} {
+		t.Run("other dependency phase="+phase, func(t *testing.T) {
+			t.Parallel()
+			opts := []generator.GraphOption{
+				generator.WithNamespace("default"),
+				generator.WithTemplate("disabled", map[string]any{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": map[string]any{"name": "disabled"},
+					"data":     map[string]any{"k": "v"},
+				}),
+				generator.WithIncludeWhen("${false}"),
+			}
+			data := map[string]any{"from": "${disabled.data.k}"}
+			if phase != "" {
+				opts = append(opts,
+					generator.WithTemplate("other", map[string]any{
+						"apiVersion": "v1", "kind": "ConfigMap",
+						"metadata": map[string]any{"name": "other"},
+						"data":     map[string]any{"phase": phase},
+					}),
+					generator.WithReadyWhen(`${other.data.phase == "Running"}`),
+				)
+				data["other"] = "${other.data.phase}"
+			}
+			opts = append(opts, generator.WithTemplate("app", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "app"},
+				"data":     data,
+			}))
+			cl := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+			ex := NewSimple(cl)
+			ex.GateReadiness = true
+			res, err := ex.Apply(context.Background(),
+				compileAndBuild(t, generator.NewGraph("g", opts...)), watchrouter.NoopWatcher{})
+			if phase == "Starting" {
+				require.ErrorIs(t, err, ErrNotReady)
+				assert.Equal(t, []string{"app"}, res.Unresolved,
+					"an unready template dependency withholds even a contagiously ignored node")
+			} else {
+				require.NoError(t, err)
+				assert.Empty(t, res.Unresolved, "an ignored dependency is terminal-ready")
+			}
+			for _, applied := range res.Applied {
+				assert.Equal(t, "other", applied.NodeID)
+			}
+			assert.False(t, cmExists(t, cl, "disabled"))
+			assert.False(t, cmExists(t, cl, "app"))
+		})
+	}
+}
+
 // ApplyWithLabeler is the only path the instance controller calls
 // (controller_graph_engine.go). It composes a per-call labeler over the
 // struct-level one and runs the walk on a copy of the executor so concurrent

--- a/pkg/graphengine/executor/simple.go
+++ b/pkg/graphengine/executor/simple.go
@@ -63,8 +63,8 @@ type Simple struct {
 	// immediately before SSA apply so kro's per-instance labels are
 	// stamped by the graph-engine path. Safe to leave nil — no-op.
 	LabelInjector func(*unstructured.Unstructured)
-	// GateReadiness makes the executor withhold a node until every one of
-	// its dependencies has reached a terminal ready state this cycle. When
+	// GateReadiness withholds inclusion evaluation and apply until every hard
+	// dependency has reached a terminal ready state this cycle. When
 	// false (the default), every reachable node is applied regardless of
 	// upstream readiness so drift watches register across a not-ready node.
 	GateReadiness bool
@@ -204,11 +204,11 @@ func (s *Simple) ApplyWithLabeler(
 
 var _ Interface = (*Simple)(nil)
 
-// Apply walks rt in topological order. For each node it checks ignore
-// status (contagious), resolves the desired state, registers a watch on
-// the resulting GVR/Name/Namespace via w, applies to cluster (or just
-// renders for Def), records observed state on the node, and finally
-// checks readyWhen — surfacing an unsatisfied result as ErrNotReady so
+// Apply walks rt in topological order. For each node it gates on dependency
+// readiness when enabled, checks ignore status (contagious), resolves the desired
+// state, registers a watch on the resulting GVR/Name/Namespace via w, applies to
+// cluster (or just renders for Def), records observed state on the node, and
+// finally checks readyWhen — surfacing an unsatisfied result as ErrNotReady so
 // the reconciler requeues without backoff.
 //
 // Per-template watches are registered BEFORE SSA apply. Doing it before
@@ -228,14 +228,14 @@ var _ Interface = (*Simple)(nil)
 // node that is merely still converging. Hard errors (apply failure, type
 // errors, etc.) still abort immediately.
 //
-// Dependency-readiness gating: a node is applied only once every node it
-// depends on is ready this cycle (readyWhen satisfied). A dependency that
-// was applied-but-not-ready, blocked, or unresolved leaves the dependent
-// blocked too — it is recorded Unresolved and skipped (never applied) so a
-// dependent resource is not created before its dependencies converge, and
-// its own dependents cascade-block via the readiness map. Gating is opt-in
-// via GateReadiness; when it is off every reachable node is applied
-// regardless of upstream readiness.
+// Dependency-readiness gating runs before inclusion: an applied-but-not-ready,
+// blocked, or unresolved hard dependency leaves the dependent Unresolved (never
+// Applied), so callers preserve its existing resources. This prevents a false
+// includeWhen against an interim observed value from making a child prunable.
+// It also withholds a schema-disabled node while a template-only dependency is
+// unready. Intentionally ignored dependencies count as terminal-ready. Gating is
+// opt-in via GateReadiness; when off, inclusion and apply proceed regardless of
+// upstream readiness.
 func (s *Simple) Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.Watcher) (ApplyResult, error) {
 	// Establish the per-Apply identity-claim set at the top-level walk. A
 	// subgraph child walk (applySubgraph copies the executor by value) inherits
@@ -268,6 +268,14 @@ func (s *Simple) Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.W
 	ready := make(map[string]bool, len(rt.Nodes()))
 
 	for _, n := range rt.Nodes() {
+		if s.GateReadiness {
+			if dep, blocked := firstUnreadyDep(n, ready); blocked {
+				result.Unresolved = append(result.Unresolved, n.ID())
+				recordSoft(fmt.Errorf("apply %q: waiting for dependency %q: %w", n.ID(), dep, ErrNotReady))
+				continue
+			}
+		}
+
 		ignored, err := n.IsIgnored()
 		if err != nil {
 			if isSoftRuntimeErr(err) {
@@ -289,17 +297,6 @@ func (s *Simple) Apply(ctx context.Context, rt *runtime.Runtime, w watchrouter.W
 			// dependents (their dependents are contagiously ignored too).
 			ready[n.ID()] = true
 			continue
-		}
-
-		// Gate on dependency readiness: do not apply until every dependency is
-		// ready this cycle. Opt-in — when off, dependents apply across a
-		// not-ready upstream (drift watches still register).
-		if s.GateReadiness {
-			if dep, blocked := firstUnreadyDep(n, ready); blocked {
-				result.Unresolved = append(result.Unresolved, n.ID())
-				recordSoft(fmt.Errorf("apply %q: waiting for dependency %q: %w", n.ID(), dep, ErrNotReady))
-				continue
-			}
 		}
 
 		// A subgraph node has no payload of its own — it runs a child

--- a/test/integration/suites/core/include_when_readiness_test.go
+++ b/test/integration/suites/core/include_when_readiness_test.go
@@ -1,0 +1,156 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = DescribeTable("IncludeWhen readiness",
+	func(ctx SpecContext, kind, predicate string, disableWhileUnready bool) {
+		namespace := "test-inclusion-readiness-" + rand.String(5)
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(env.Client.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(client.IgnoreNotFound(env.Client.Delete(ctx, ns))).To(Succeed())
+		})
+
+		rgd := generator.NewResourceGraphDefinition(namespace,
+			generator.WithSchema(kind, "v1alpha1", map[string]any{
+				"name": "string", "enabled": "boolean", "extra": "boolean",
+			}, nil), // No author status: inclusion must not depend on placeholder projection.
+			generator.WithResource("db", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${schema.spec.name}-db"},
+				// The test populates phase externally; kro owns only owner.
+				"data": map[string]any{"owner": "${schema.spec.name}"},
+			}, []string{`${db.data.phase == "Running"}`}, nil),
+			generator.WithResource("app", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${schema.spec.name}-app"},
+				"data":     map[string]any{"dbOwner": "${db.data.owner}"},
+			}, nil, []string{predicate}),
+			generator.WithResource("extra", map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${schema.spec.name}-extra"},
+			}, nil, []string{"${schema.spec.extra}"}),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(client.IgnoreNotFound(env.Client.Delete(ctx, rgd))).To(Succeed())
+		})
+		waitForRGDActive(ctx, rgd.Name)
+
+		const name = "inclusion"
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": krov1alpha1.KRODomainName + "/v1alpha1",
+			"kind":       kind,
+			"metadata":   map[string]any{"name": name, "namespace": namespace},
+			"spec":       map[string]any{"name": name, "enabled": true, "extra": true},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(client.IgnoreNotFound(env.Client.Delete(ctx, instance))).To(Succeed())
+			waitForResourceDeleted(ctx, namespace, name, instance)
+		})
+
+		instanceKey := client.ObjectKeyFromObject(instance)
+		dbKey := types.NamespacedName{Namespace: namespace, Name: name + "-db"}
+		appKey := types.NamespacedName{Namespace: namespace, Name: name + "-app"}
+		extraKey := types.NamespacedName{Namespace: namespace, Name: name + "-extra"}
+		patchPhase := func(phase string) {
+			db := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: dbKey.Name, Namespace: namespace}}
+			patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"data":{"phase":%q}}`, phase)))
+			Expect(env.Client.Patch(ctx, db, patch)).To(Succeed())
+		}
+		waitForState := func(state, ready string) {
+			Eventually(func(g Gomega) {
+				g.Expect(env.Client.Get(ctx, instanceKey, instance)).To(Succeed())
+				got, _, err := unstructured.NestedString(instance.Object, "status", "state")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(got).To(Equal(state))
+				condition := findInstanceConditionByType(instance, "ResourcesReady")
+				g.Expect(condition).To(HaveKeyWithValue("status", ready))
+				g.Expect(condition).To(HaveKeyWithValue("observedGeneration", instance.GetGeneration()))
+			}, 30*time.Second, 250*time.Millisecond).Should(Succeed())
+		}
+
+		By("establishing the child with db ready")
+		Eventually(func() error {
+			return env.Client.Get(ctx, dbKey, &corev1.ConfigMap{})
+		}, 30*time.Second, 250*time.Millisecond).Should(Succeed())
+		patchPhase("Running")
+		waitForState("ACTIVE", "True")
+		original := &corev1.ConfigMap{}
+		Expect(env.Client.Get(ctx, appKey, original)).To(Succeed())
+		Expect(original.UID).NotTo(BeEmpty())
+		Expect(original.Data).To(Equal(map[string]string{"dbOwner": name}))
+		extra := &corev1.ConfigMap{}
+		Expect(env.Client.Get(ctx, extraKey, extra)).To(Succeed())
+
+		By("observing the dependency's interim false value before checking retention")
+		patchPhase("Starting")
+		waitForState("IN_PROGRESS", "False")
+		if disableWhileUnready {
+			By("disabling app and an unrelated resource while the template dependency is unready")
+			patch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"enabled":false,"extra":false}}`))
+			Expect(env.Client.Patch(ctx, instance, patch)).To(Succeed())
+			waitForState("IN_PROGRESS", "False")
+		}
+		Consistently(func(g Gomega) {
+			app := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, appKey, app)).To(Succeed(),
+				"app must survive an applied-but-not-ready dependency")
+			g.Expect(app.UID).To(Equal(original.UID))
+			g.Expect(app.Data).To(Equal(original.Data))
+			if disableWhileUnready {
+				retired := &corev1.ConfigMap{}
+				g.Expect(env.Client.Get(ctx, extraKey, retired)).To(Succeed(),
+					"a withheld owning node closes the existing instance-wide prune gate")
+				g.Expect(retired.UID).To(Equal(extra.UID))
+			}
+		}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
+
+		By("evaluating inclusion once the dependency is ready again")
+		patchPhase("Running")
+		waitForState("ACTIVE", "True")
+		if disableWhileUnready {
+			waitForResourceDeleted(ctx, namespace, appKey.Name, &corev1.ConfigMap{})
+			waitForResourceDeleted(ctx, namespace, extraKey.Name, &corev1.ConfigMap{})
+		} else {
+			app := &corev1.ConfigMap{}
+			Expect(env.Client.Get(ctx, appKey, app)).To(Succeed())
+			Expect(app.UID).To(Equal(original.UID))
+			Expect(app.Data).To(Equal(original.Data))
+		}
+	},
+	Entry("retains an existing child through a false interim resource value",
+		"InclusionReadyInputs", `${schema.spec.name != "" && db.data.phase == "Running"}`, false, SpecTimeout(120*time.Second)),
+	Entry("withholds schema-disabled children and unrelated pruning until template inputs are ready",
+		"InclusionSchemaDisabled", `${schema.spec.enabled}`, true, SpecTimeout(120*time.Second)),
+)

--- a/test/integration/suites/core/include_when_readiness_test.go
+++ b/test/integration/suites/core/include_when_readiness_test.go
@@ -131,7 +131,7 @@ var _ = DescribeTable("IncludeWhen readiness",
 			if disableWhileUnready {
 				retired := &corev1.ConfigMap{}
 				g.Expect(env.Client.Get(ctx, extraKey, retired)).To(Succeed(),
-					"a withheld owning node closes the existing instance-wide prune gate")
+					"the skipped extra must remain while app is withheld")
 				g.Expect(retired.UID).To(Equal(extra.UID))
 			}
 		}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
@@ -151,6 +151,6 @@ var _ = DescribeTable("IncludeWhen readiness",
 	},
 	Entry("retains an existing child through a false interim resource value",
 		"InclusionReadyInputs", `${schema.spec.name != "" && db.data.phase == "Running"}`, false, SpecTimeout(120*time.Second)),
-	Entry("withholds schema-disabled children and unrelated pruning until template inputs are ready",
+	Entry("retains schema-disabled children and a skipped extra until template inputs are ready",
 		"InclusionSchemaDisabled", `${schema.spec.enabled}`, true, SpecTimeout(120*time.Second)),
 )


### PR DESCRIPTION

An RGD can create a child whose `includeWhen` reads a dependency's phase, then delete that child when the dependency briefly changes from `Running` to `Starting`. The instance reports not-ready, but the child has already been classified as excluded and pruned.

Move the existing opt-in readiness gate before inclusion evaluation. A dependent with unready hard inputs is recorded as `Unresolved`, preserving its existing child until inclusion can be evaluated against ready inputs. Standalone Graph keeps its ungated behavior.

The all-hard-dependency tradeoff is intentional: even a schema-disabled child waits, potentially indefinitely, when a template-only dependency is unready. With this fix on the pinned base, the instance-wide prune gate also retains unrelated retired resources. With completed-template pruning, withheld/skipped owners remain protected while unrelated completed templates can prune retired members.

Focused race tests and two envtest cases pass. The same tests on the baseline reproduce missing `Unresolved` entries and actual child deletion. The primary example uses no author status or optional access, preserves child UID/data through the readiness dip, and converges afterward. The second verifies the schema-disabled tradeoff and pruning when readiness returns.
