### PR TITLE
Preserve CEL timestamp typing when publishing RGD schema values

### DIFF
--- a/pkg/graphengine/rgdadapter/runtime_cache_test.go
+++ b/pkg/graphengine/rgdadapter/runtime_cache_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,11 +27,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	memory "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/compiler"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/executor"
 	"github.com/kubernetes-sigs/kro/pkg/graphengine/registry"
 	graphruntime "github.com/kubernetes-sigs/kro/pkg/graphengine/runtime"
+	"github.com/kubernetes-sigs/kro/pkg/graphengine/watchrouter"
 	testk8s "github.com/kubernetes-sigs/kro/pkg/testutil/k8s"
 )
 
@@ -134,6 +138,35 @@ func TestBuildRuntimeForInstanceCached_ReusesProgram(t *testing.T) {
 	// No cross-instance data leakage: each runtime resolves its OWN value.
 	assert.Equal(t, "value-A", resolveCMValue(t, rtA))
 	assert.Equal(t, "value-B", resolveCMValue(t, rtB))
+}
+
+func TestBuildRuntimeForInstanceCached_SchemaKeepsDeclaredTypingAfterPublish(t *testing.T) {
+	rgd := schemaValueRGD("webapp")
+	rgd.Spec.Resources[0].Template = rawResource(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "cm", "namespace": "default"},
+		"data":       map[string]any{"year": "${string(schema.metadata.creationTimestamp.getFullYear())}"},
+	})
+	instance := webInstance("app", "default", "value")
+	instance.SetCreationTimestamp(metav1.Date(2024, time.May, 6, 7, 8, 9, 0, time.UTC))
+	rt, _, err := BuildRuntimeForInstanceCached(rgd, instance, newTestCompiler(t), registry.New())
+	require.NoError(t, err)
+
+	// The seeded schema already supports timestamp methods before publication.
+	objects, err := rt.Node("cm").Resolve()
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+	require.Equal(t, "2024", nestedString(t, objects[0].Object, "data", "year"))
+
+	// The executor publishes the schema Def before resolving and applying cm.
+	ex := executor.NewSimple(fake.NewClientBuilder().Build())
+	result, err := ex.Apply(t.Context(), rt, watchrouter.NoopWatcher{})
+	require.NoError(t, err, "schema publication must preserve its declared CEL type")
+	require.Len(t, result.Applied, 1)
+	objects = rt.Node("cm").Observed()
+	require.Len(t, objects, 1)
+	assert.Equal(t, "2024", nestedString(t, objects[0].Object, "data", "year"))
 }
 
 // TestBuildRuntimeForInstanceCached_NoLeakUnderConcurrency runs many instances

--- a/pkg/graphengine/runtime/node_test.go
+++ b/pkg/graphengine/runtime/node_test.go
@@ -325,6 +325,34 @@ func TestNode_Resolve(t *testing.T) {
 			},
 		},
 		{
+			name: "published computed def fields keep their dynamic values",
+			graph: generator.NewGraph("g",
+				generator.WithDef("input", map[string]any{"name": "alpha"}),
+				generator.WithDef("values", map[string]any{
+					"enabled": "${input.name == 'alpha'}",
+					"mapping": "${{'name': input.name}}",
+					"names":   "${[input.name, 'beta']}",
+				}),
+				generator.WithDef("consumer", map[string]any{
+					"enabled": "${values.enabled}",
+					"mapping": "${values.mapping}",
+					"names":   "${values.names}",
+				}),
+			),
+			populate: func(rt *Runtime) {
+				setFirst(rt, "input")
+				setFirst(rt, "values")
+			},
+			assertID: "consumer",
+			want: []func(t *testing.T, out map[string]any){
+				func(t *testing.T, out map[string]any) {
+					assert.Equal(t, true, out["enabled"])
+					assert.Equal(t, map[string]any{"name": "alpha"}, out["mapping"])
+					assert.Equal(t, []any{"alpha", "beta"}, out["names"])
+				},
+			},
+		},
+		{
 			name: "template substitution at metadata.name",
 			graph: generator.NewGraph("g",
 				generator.WithDef("naming", map[string]any{"prefix": "team-", "app": "billing"}),

--- a/pkg/graphengine/runtime/runtime.go
+++ b/pkg/graphengine/runtime/runtime.go
@@ -280,23 +280,26 @@ func (r *Runtime) Node(id string) *Node { return r.byID[id] }
 func (r *Runtime) Scope() map[string]any { return r.scope }
 
 // Set publishes value under id in the scope so downstream nodes can read
-// it via CEL expressions like ${id.field}. Values with known OpenAPI schemas
-// on Template and Ref nodes are wrapped via UnstructuredToVal so CEL format
-// annotations (such as format: "byte") are respected at runtime.
+// it via CEL expressions like ${id.field}. Template, Ref, and overridden Def
+// nodes with known OpenAPI schemas are wrapped via UnstructuredToVal so CEL
+// format annotations (such as format: "byte") are respected at runtime.
 func (r *Runtime) Set(id string, value any) {
 	var sc *spec.Schema
-	isTemplateOrRef := false
+	useSchema := false
 	if r.program != nil {
 		sc = r.program.NodeSchemas[id]
 	}
 	if node, ok := r.byID[id]; ok {
-		isTemplateOrRef = node.Kind() == compiler.NodeKindTemplate || node.Kind() == compiler.NodeKindRef
+		// Ordinary Defs can contain computed values whose inferred schemas
+		// use int-or-string as a dyn marker, so they must stay unwrapped.
+		useSchema = node.Kind() == compiler.NodeKindTemplate || node.Kind() == compiler.NodeKindRef ||
+			(node.Kind() == compiler.NodeKindDef && node.objectOverride != nil)
 	}
-	r.scope[id] = wrapValueForScope(value, sc, isTemplateOrRef)
+	r.scope[id] = wrapValueForScope(value, sc, useSchema)
 }
 
-func wrapValueForScope(val any, sc *spec.Schema, isTemplateOrRef bool) any {
-	if !isTemplateOrRef || sc == nil || val == nil {
+func wrapValueForScope(val any, sc *spec.Schema, useSchema bool) any {
+	if !useSchema || sc == nil || val == nil {
 		return val
 	}
 	switch v := val.(type) {


### PR DESCRIPTION

An RGD using `${string(schema.metadata.creationTimestamp.getFullYear())}` in a resource template can compile successfully yet fail during instance reconciliation with `no such overload: getFullYear(string)`. The expression should return the instance's creation year.

The cached runtime seeds a typed schema value, but publishing its overridden Def replaces that value with a raw map. Extend `Runtime.Set` to use the existing schema-aware wrapper for overridden Def nodes with a schema.

The regression runs the real executor with an in-memory Kubernetes client and asserts year `"2024"` before and after schema publication. It fails on the base and passes with this fix. A computed bool/map/list case protects ordinary Defs; temporarily wrapping every Def makes that guard fail. Runtime and adapter package tests, plus focused executor tests, pass with the race detector.
