### PR TITLE
Reject schema-only RGD duplicate identities before adopting objects

### DIFF
--- a/pkg/controller/instance/controller_graph_engine.go
+++ b/pkg/controller/instance/controller_graph_engine.go
@@ -176,6 +176,10 @@ func (c *Controller) reconcileViaGraphEngine(
 	// but the parent has no inventory tracking them.
 	supersetMeta, applier, preErr := c.preApplyApplySetInventory(ctx, log, inst, rt)
 	if preErr != nil {
+		if errors.Is(preErr, applyset.ErrDuplicateResource) {
+			mark.ResourcesNotReady("duplicate resource in graph: %v", preErr)
+			return c.persistRejectedGraphEngineStatus(ctx, inst, wireStatus, rt, rgd, preErr)
+		}
 		return preErr
 	}
 
@@ -521,11 +525,16 @@ func (c *Controller) preApplyApplySetInventory(
 		ParentNamespace: inst.GetNamespace(),
 	}, inst)
 
-	candidateMeta := c.candidateMetadata(rt, inst)
+	candidateMeta, candidates := c.candidateMetadata(rt, inst)
 	supersetMeta, projErr := applier.Union(candidateMeta)
 	if projErr != nil {
 		log.Error(projErr, "graph-engine: pre-apply applyset union failed")
 		return supersetMeta, applier, c.delayedRequeue(fmt.Errorf("pre-apply applyset union failed: %w", projErr))
+	}
+	// Project validates the stable rendered identities. Keep the broader union
+	// above for inventory: unresolved nodes still contribute fallback scope.
+	if _, err := applier.Project(candidates); err != nil {
+		return supersetMeta, applier, c.delayedRequeue(fmt.Errorf("pre-apply applyset projection failed: %w", err))
 	}
 
 	if err := c.patchInstanceApplySetMetadata(ctx, inst, supersetMeta); err != nil {
@@ -537,14 +546,15 @@ func (c *Controller) preApplyApplySetInventory(
 
 // candidateMetadata collects candidate ApplySet metadata (GroupKinds and
 // AdditionalNamespaces) expected to be managed this cycle from the runtime's template
-// nodes, without constructing artificial Kubernetes objects.
-func (c *Controller) candidateMetadata(rt *geruntime.Runtime, inst *unstructured.Unstructured) applyset.Metadata {
+// nodes, plus resolved schema-only resources for pre-apply identity validation.
+func (c *Controller) candidateMetadata(rt *geruntime.Runtime, inst *unstructured.Unstructured) (applyset.Metadata, []applyset.Resource) {
 	meta := applyset.Metadata{
 		ID:                   applyset.ID(inst),
 		Tooling:              applyset.ToolingID(),
 		GroupKinds:           sets.New[schema.GroupKind](),
 		AdditionalNamespaces: sets.New[string](),
 	}
+	var candidates []applyset.Resource
 	parentNS := inst.GetNamespace()
 
 	// Seed Def nodes (such as the synthesized `schema` instance node) into the runtime
@@ -584,8 +594,20 @@ func (c *Controller) candidateMetadata(rt *geruntime.Runtime, inst *unstructured
 		// that re-enqueues the instance and fights the pre-apply writer forever.
 		// On an IsIgnored error we can't decide, so keep the node (holding the
 		// inventory steady is the safe direction).
-		if ignored, err := n.IsIgnored(); err == nil && ignored {
+		ignored, inclusionErr := n.IsIgnored()
+		if inclusionErr == nil && ignored {
 			continue
+		}
+
+		// Only the RGD's literal schema node is stable before the walk. Any
+		// resource dependency (including in the body or conditions) can still
+		// be a soft-dependency placeholder rather than its observed value.
+		stable := inclusionErr == nil && !n.DynamicGVK()
+		for _, dep := range n.Spec().HardDepIDs() {
+			if dep != rgdadapter.SchemaNodeID {
+				stable = false
+				break
+			}
 		}
 
 		// If the node resolves cleanly in memory, extract its rendered GroupKinds
@@ -603,6 +625,11 @@ func (c *Controller) candidateMetadata(rt *geruntime.Runtime, inst *unstructured
 				if ns != "" && ns != parentNS {
 					meta.AdditionalNamespaces.Insert(ns)
 				}
+				if stable && obj.GetName() != "" && (!n.Namespaced() || ns != "") {
+					// Project compares authored namespaces before defaulting them.
+					obj.SetNamespace(ns)
+					candidates = append(candidates, applyset.Resource{ID: n.ID(), Object: obj})
+				}
 			}
 			continue
 		}
@@ -616,7 +643,7 @@ func (c *Controller) candidateMetadata(rt *geruntime.Runtime, inst *unstructured
 			}
 		}
 	}
-	return meta
+	return meta, candidates
 }
 
 // applySetMetadataFromApplied builds ApplySet inventory metadata from only the
@@ -872,6 +899,22 @@ func inventoryUpToDate(inst *unstructured.Unstructured, wantLabels, wantAnnotati
 		}
 	}
 	return true
+}
+
+// persistRejectedGraphEngineStatus persists conditions and state without running
+// child or author-status patches, then returns the original rejection for requeue.
+func (c *Controller) persistRejectedGraphEngineStatus(
+	ctx context.Context,
+	inst *unstructured.Unstructured,
+	wireStatus map[string]any,
+	rt *geruntime.Runtime,
+	rgd *v1alpha1.ResourceGraphDefinition,
+	rejection error,
+) error {
+	if err := c.persistGraphEngineStatus(ctx, inst, wireStatus, rt, rgd, true); err != nil {
+		return err
+	}
+	return rejection
 }
 
 // persistGraphEngineStatus composes the controller-owned status surface for the

--- a/pkg/controller/instance/controller_graph_engine.go
+++ b/pkg/controller/instance/controller_graph_engine.go
@@ -225,7 +225,7 @@ func (c *Controller) reconcileViaGraphEngine(
 		} else {
 			mark.ResourcesDeleting("%v", applyErr)
 		}
-	case errors.Is(applyErr, executor.ErrNotReady) && errors.Is(applyErr, executor.ErrFieldManagerConflict):
+	case isSoftFieldManagerConflict(applyErr):
 		// Soft like any not-ready node, but the message must say the field is
 		// owned by another manager (the instance markers have no dedicated reason).
 		mark.ResourcesNotReady("field manager conflict: %v", applyErr)
@@ -968,6 +968,12 @@ func (c *Controller) persistGraphEngineStatus(
 	}
 
 	return c.persistConditionsAndState(ctx, inst, wireStatus, status, previousState)
+}
+
+// isSoftFieldManagerConflict reports whether err signals both not-ready and a
+// field-manager conflict.
+func isSoftFieldManagerConflict(err error) bool {
+	return errors.Is(err, executor.ErrNotReady) && errors.Is(err, executor.ErrFieldManagerConflict)
 }
 
 // isResourceDeleting reports whether err (an executor apply error) signals a

--- a/pkg/controller/instance/controller_graph_engine_test.go
+++ b/pkg/controller/instance/controller_graph_engine_test.go
@@ -1329,7 +1329,7 @@ func TestCandidateMetadata(t *testing.T) {
 	raw := newControllerTestDynamicClient(t, inst.DeepCopy())
 	c, _ := newGraphEngineControllerUnderTest(t, raw, testEmptyRGDSpec(), revisions.RevisionStateActive, comp, nil)
 
-	meta := c.candidateMetadata(rt, inst)
+	meta, _ := c.candidateMetadata(rt, inst)
 	assert.True(t, meta.GroupKinds.Has(schema.GroupKind{Group: "", Kind: "ConfigMap"}))
 	assert.True(t, meta.AdditionalNamespaces.Has("custom-ns"))
 }
@@ -1381,7 +1381,7 @@ func TestCandidateMetadata_SkipsIgnoredNodes(t *testing.T) {
 	raw := newControllerTestDynamicClient(t, inst.DeepCopy())
 	c, _ := newGraphEngineControllerUnderTest(t, raw, testEmptyRGDSpec(), revisions.RevisionStateActive, comp, nil)
 
-	meta := c.candidateMetadata(rt, inst)
+	meta, _ := c.candidateMetadata(rt, inst)
 	assert.True(t, meta.GroupKinds.Has(schema.GroupKind{Group: "", Kind: "ConfigMap"}),
 		"included node's GroupKind must be in the candidate inventory")
 	assert.False(t, meta.GroupKinds.Has(schema.GroupKind{Group: "", Kind: "ResourceQuota"}),
@@ -1855,7 +1855,7 @@ func TestReconcileViaGraphEngine_PatchContributions(t *testing.T) {
 		assert.Len(t, storedContribs, 1, "unreleased patch contribution must be retained in ledger")
 	})
 
-	t.Run("Duplicate rendered identities are rejected pre-write with hardErr, ResourcesNotReady, degraded Error state", func(t *testing.T) {
+	t.Run("Duplicate rendered identities prevent child writes and persist failure status", func(t *testing.T) {
 		inst := newInstanceObject("demo", "default")
 		raw := newControllerTestDynamicClient(t, inst.DeepCopy())
 
@@ -1888,18 +1888,20 @@ func TestReconcileViaGraphEngine_PatchContributions(t *testing.T) {
 		watcher := &fakeInstanceWatcher{}
 		err := c.reconcileViaGraphEngine(context.Background(), inst, watcher)
 		require.Error(t, err)
-		// The collision is now caught PRE-WRITE by the executor's identity-claim
-		// guard (before cm2's SSA write clobbers cm1), so the error is
-		// ErrDuplicateIdentity rather than the post-apply validateAppliedIdentities
-		// message. (Like any hard apply error it is still delayed-requeued so the
-		// instance retries; the state below reflects the degraded outcome.)
-		assert.Contains(t, err.Error(), "duplicate resource identity across nodes")
+		assert.Contains(t, err.Error(), "cm1")
+		assert.Contains(t, err.Error(), "cm2")
+		assert.True(t, requeue.IsRequeueError(err))
+
+		cm := newConfigMapObject("shared-cm", "default")
+		assert.True(t, apierrors.IsNotFound(fakeRuntimeCl.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)),
+			"the duplicate must be rejected before either child is created")
 
 		stored := getStoredParentObject(t, raw)
 		cond := conditionByType(t, stored, ResourcesReady)
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)
 		require.NotNil(t, cond.Message)
-		assert.Contains(t, *cond.Message, "resource reconciliation failed")
+		assert.Contains(t, *cond.Message, "cm1")
+		assert.Contains(t, *cond.Message, "cm2")
 
 		status, _, _ := unstructured.NestedMap(stored.Object, "status")
 		require.NotNil(t, status)
@@ -1968,4 +1970,115 @@ func TestReconcileViaGraphEngine_PatchContributions(t *testing.T) {
 		cond := conditionByType(t, stored, ResourcesReady)
 		assert.Equal(t, metav1.ConditionTrue, cond.Status)
 	})
+}
+
+func TestReconcileViaGraphEngine_DuplicateIdentityCollections(t *testing.T) {
+	for _, overlap := range []bool{false, true} {
+		t.Run(fmt.Sprintf("scalarOverlap=%t", overlap), func(t *testing.T) {
+			inst := newInstanceObject("demo", "default")
+			spec := testRGDSpecWithConfigMap("shared-cm", "")
+			spec.Resources[0].ForEach = []v1alpha1.ForEachDimension{{"ns": `${['', schema.metadata.namespace]}`}}
+			spec.Resources[0].Template.Raw = []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"shared-cm","namespace":"${ns}"}}`)
+			if overlap {
+				// A resolved collection row must also be checked against scalar nodes.
+				spec.Resources[0].ForEach = []v1alpha1.ForEachDimension{{"ns": `${[schema.metadata.namespace]}`}}
+				spec.Resources = append(spec.Resources, &v1alpha1.Resource{
+					ID:       "scalar",
+					Template: apimachineryruntime.RawExtension{Raw: []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"shared-cm"}}`)},
+				})
+			}
+			raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+			cl := newFakeRuntimeClient(t)
+			c, _ := newGraphEngineControllerUnderTest(t, raw, spec, revisions.RevisionStateActive, newTestRealCompiler(t), cl)
+			err := c.reconcileViaGraphEngine(t.Context(), inst, &fakeInstanceWatcher{})
+			require.Error(t, err)
+			cm := newConfigMapObject("shared-cm", "default")
+			assert.True(t, apierrors.IsNotFound(cl.Get(t.Context(), client.ObjectKeyFromObject(cm), cm)),
+				"no row may write before namespace-defaulted duplicates are rejected")
+			assert.Equal(t, metav1.ConditionFalse, conditionByType(t, getStoredParentObject(t, raw), ResourcesReady).Status)
+		})
+	}
+}
+
+func TestReconcileViaGraphEngine_DuplicateIdentityStatusAndInventory(t *testing.T) {
+	for _, authorConditions := range []bool{false, true} {
+		t.Run(fmt.Sprintf("authorConditions=%t", authorConditions), func(t *testing.T) {
+			inst := newInstanceObject("demo", "default")
+			inst.SetGeneration(1)
+			mark := NewConditionsMarkerFor(inst)
+			mark.InstanceManaged()
+			mark.GraphResolved()
+			mark.ResourcesReady()
+			inst.Object["status"].(map[string]any)["state"] = string(v1alpha1.InstanceStateActive)
+			inst.Object["status"].(map[string]any)["endpoint"] = "previous"
+			inst.SetGeneration(2)
+			metadata.SetInstanceFinalizer(inst)
+
+			orphan := newManagedObject(newDeploymentObject("retired", "other-ns"), inst, "retired", 1)
+			contribs := []executor.Contribution{{APIVersion: "v1", Kind: "ConfigMap", Namespace: "default", Name: "prior-target", FieldManager: "prior-manager"}}
+			ledger, err := controllergraph.MarshalContributions(contribs)
+			require.NoError(t, err)
+			priorAnnotations := inst.GetAnnotations()
+			priorAnnotations[metadata.PatchContributionsAnnotation] = ledger
+			inst.SetAnnotations(priorAnnotations)
+
+			spec := testRGDSpecWithConfigMap("shared-cm", "")
+			other := spec.Resources[0].DeepCopy()
+			other.ID = "other"
+			spec.Resources = append(spec.Resources, other)
+			condType := ResourcesReady
+			if authorConditions {
+				condType = "AuthorReady"
+				spec.Schema.Status.Raw = []byte(`{"conditions":["${runtime.newCondition({type: 'AuthorReady', status: runtime.condition(schema, 'ResourcesReady').status, reason: 'Projected'})}"]}`)
+				inst.Object["status"].(map[string]any)["conditions"] = []any{map[string]any{
+					"type": condType, "status": "True", "reason": "Previous", "observedGeneration": int64(1),
+					"lastTransitionTime": "2026-01-01T00:00:00Z",
+				}}
+			}
+			raw := newControllerTestDynamicClient(t, inst.DeepCopy(), orphan.DeepCopy())
+			cl := newFakeRuntimeClient(t)
+			c, _ := newGraphEngineControllerUnderTest(t, raw, spec, revisions.RevisionStateActive, newTestRealCompiler(t), cl)
+			c.reconcileConfig.HasAuthorConditions = authorConditions
+
+			require.Error(t, c.reconcileViaGraphEngine(t.Context(), inst, &fakeInstanceWatcher{}))
+			stored := getStoredParentObject(t, raw)
+			status := stored.Object["status"].(map[string]any)
+			assert.Equal(t, string(v1alpha1.InstanceStateError), status["state"])
+			assert.Equal(t, "previous", status["endpoint"])
+			cond := conditionByType(t, stored, condType)
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			for _, entry := range status["conditions"].([]any) {
+				condition := entry.(map[string]any)
+				assert.Equal(t, int64(2), condition["observedGeneration"])
+			}
+			for key, value := range priorAnnotations {
+				assert.Equal(t, value, stored.GetAnnotations()[key], "prior inventory %s", key)
+			}
+			live, err := raw.Tracker().Get(controllerTestDeployGVR, "other-ns", "retired")
+			require.NoError(t, err)
+			assert.Equal(t, orphan, live, "rejection must not prune prior managed resources")
+		})
+	}
+}
+
+func TestReconcileViaGraphEngine_DuplicateIdentityExcludesIgnored(t *testing.T) {
+	for _, includeWhen := range []string{`${false}`, `${schema.spec.enabled}`} {
+		t.Run(includeWhen, func(t *testing.T) {
+			inst := newInstanceObject("demo", "default")
+			inst.Object["spec"] = map[string]any{"enabled": false}
+			spec := testRGDSpecWithConfigMap("shared-cm", "")
+			spec.Schema.Spec.Raw = []byte(`{"enabled":"boolean"}`)
+			skipped := spec.Resources[0].DeepCopy()
+			skipped.ID = "skipped"
+			skipped.IncludeWhen = []string{includeWhen}
+			spec.Resources = append(spec.Resources, skipped)
+			raw := newControllerTestDynamicClient(t, inst.DeepCopy())
+			cl := newFakeRuntimeClient(t)
+			c, _ := newGraphEngineControllerUnderTest(t, raw, spec, revisions.RevisionStateActive, newTestRealCompiler(t), cl)
+			require.NoError(t, c.reconcileViaGraphEngine(t.Context(), inst, &fakeInstanceWatcher{}))
+			cm := newConfigMapObject("shared-cm", "default")
+			require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(cm), cm))
+			assert.Equal(t, "cm", cm.GetLabels()[metadata.NodeIDLabel])
+		})
+	}
 }

--- a/test/integration/suites/core/duplicate_identity_test.go
+++ b/test/integration/suites/core/duplicate_identity_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	krov1alpha1 "github.com/kubernetes-sigs/kro/api/v1alpha1"
+	"github.com/kubernetes-sigs/kro/pkg/testutil/generator"
+)
+
+var _ = Describe("RGD duplicate identities before adoption", func() {
+	It("preserves a foreign object through rejection and instance deletion", func(ctx SpecContext) {
+		namespace := env.CreateNamespace(GinkgoT())
+		const sharedName = "dup-shared"
+		key := types.NamespacedName{Name: sharedName, Namespace: namespace}
+		userCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: sharedName, Namespace: namespace,
+				Labels:      map[string]string{"user-label": "keep"},
+				Annotations: map[string]string{"user-annotation": "keep"},
+			},
+			Data: map[string]string{"from": "previous"},
+		}
+		Expect(env.Client.Create(ctx, userCM)).To(Succeed())
+		pristine := &corev1.ConfigMap{}
+		Expect(env.Client.Get(ctx, key, pristine)).To(Succeed())
+
+		sharedConfigMap := func(from string) map[string]any {
+			return map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "${schema.spec.name}"},
+				"data":     map[string]any{"from": from},
+			}
+		}
+		rgd := generator.NewResourceGraphDefinition("test-dup-identity",
+			generator.WithSchema("TestDupIdentity", "v1alpha1",
+				map[string]any{"name": "string"}, map[string]any{"rendered": "${schema.spec.name}"}),
+			generator.WithResource("cma", sharedConfigMap("cma"), nil, nil),
+			generator.WithResource("cmb", sharedConfigMap("cmb"), nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) { Expect(env.Client.Delete(ctx, rgd)).To(Succeed()) })
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1", "kind": "TestDupIdentity",
+			"metadata": map[string]any{"name": "dup-instance", "namespace": namespace},
+			"spec":     map[string]any{"name": sharedName},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		instanceKey := types.NamespacedName{Name: instance.GetName(), Namespace: namespace}
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, instanceKey, instance)).To(Succeed())
+			state, _, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(state).To(Equal("ERROR"))
+			conditions, _, err := unstructured.NestedSlice(instance.Object, "status", "conditions")
+			g.Expect(err).NotTo(HaveOccurred())
+			var ready map[string]any
+			for _, entry := range conditions {
+				condition := entry.(map[string]any)
+				if condition["type"] == "ResourcesReady" {
+					ready = condition
+				}
+			}
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready["status"]).To(Equal("False"))
+			g.Expect(ready["observedGeneration"]).To(Equal(instance.GetGeneration()))
+			g.Expect(ready["message"]).To(And(ContainSubstring("cma"), ContainSubstring("cmb")))
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+
+		assertUntouched := func(g Gomega) {
+			live := &corev1.ConfigMap{}
+			g.Expect(env.Client.Get(ctx, key, live)).To(Succeed())
+			g.Expect(live.Data).To(Equal(pristine.Data))
+			g.Expect(live.ObjectMeta).To(Equal(pristine.ObjectMeta), "including UID, resourceVersion, labels, annotations, ownerReferences and managedFields")
+		}
+		Consistently(assertUntouched, time.Second, 100*time.Millisecond).Should(Succeed())
+		_, found, err := unstructured.NestedString(instance.Object, "status", "rendered")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeFalse(), "author-status execution is withheld on the rejected cycle")
+
+		Expect(env.Client.Delete(ctx, instance)).To(Succeed())
+		Eventually(func() bool {
+			return apierrors.IsNotFound(env.Client.Get(ctx, instanceKey, instance))
+		}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
+		Consistently(assertUntouched, time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+
+	It("does not mistake a resource-backed placeholder name for a duplicate", func(ctx SpecContext) {
+		namespace := env.CreateNamespace(GinkgoT())
+		configMap := func(name, value string) map[string]any {
+			return map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": name}, "data": map[string]any{"k": value},
+			}
+		}
+		rgd := generator.NewResourceGraphDefinition("test-dup-softseed",
+			generator.WithSchema("TestDupSoftseed", "v1alpha1", nil, map[string]any{"value": "${a.data.k}"}),
+			generator.WithResource("a", configMap("upstream", "real"), nil, nil),
+			generator.WithResource("b", configMap("${a.?data.k.orValue('fallback')}", "b"), nil, nil),
+			generator.WithResource("c", configMap("fallback", "c"), nil, nil),
+		)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) { Expect(env.Client.Delete(ctx, rgd)).To(Succeed()) })
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: rgd.Name}, rgd)).To(Succeed())
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+		instance := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kro.run/v1alpha1", "kind": "TestDupSoftseed",
+			"metadata": map[string]any{"name": "softseed", "namespace": namespace},
+		}}
+		Expect(env.Client.Create(ctx, instance)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) { Expect(env.Client.Delete(ctx, instance)).To(Succeed()) })
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: instance.GetName(), Namespace: namespace}, instance)).To(Succeed())
+			state, _, err := unstructured.NestedString(instance.Object, "status", "state")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(state).To(Equal("ACTIVE"))
+			for name, value := range map[string]string{"upstream": "real", "real": "b", "fallback": "c"} {
+				cm := &corev1.ConfigMap{}
+				g.Expect(env.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cm)).To(Succeed())
+				g.Expect(cm.Data["k"]).To(Equal(value), fmt.Sprintf("ConfigMap %s", name))
+			}
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+})


### PR DESCRIPTION

When two RGD resources render the same object identity, the first can overwrite and label a pre-existing user object before the second reports a duplicate. Deleting the failed instance can then delete the adopted object.

Reuse the existing ApplySet projection to check included, fully resolved, static-GVK templates whose whole-node dependencies are empty or only `schema`. Include collection rows and default empty namespaced namespaces before checking. A collision stops child application and pruning, preserves prior inventories, and persists failure conditions and `ERROR` state at the current generation. Author conditions are still projected; author-status fields retain their previous values or remain absent for that rejected cycle.

The accompanying API regression fails on the baseline because the user's ConfigMap is overwritten. With the fix, its data and complete metadata, including UID and resourceVersion, remain unchanged through completed instance deletion. The same result holds with the alpha feature gates disabled. Targeted controls cover namespace aliases, collection/scalar overlap, ignored writers, placeholder names, and status/inventory retention.

Resource-dependent templates and standalone Graphs retain the existing per-walk duplicate guard and its first-write limitation.
